### PR TITLE
fix: hide drop joystick when drag ends

### DIFF
--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
@@ -1726,6 +1726,7 @@ export class MintDockManagerElement extends HTMLElement {
     const state = this.dragState;
     this.dragState = null;
     this.hideDropIndicator();
+    this.dropJoystick.hidden = true;
     this.stopDragPointerTracking();
     this.lastDragPointerPosition = null;
     if (state && state.floatingIndex !== null && !state.dropHandled) {
@@ -2361,6 +2362,8 @@ export class MintDockManagerElement extends HTMLElement {
     const hostRect = this.getBoundingClientRect();
     const indicator = this.dropIndicator;
     const joystick = this.dropJoystick;
+
+    joystick.hidden = false;
 
     const path = this.parsePath(stack.dataset['path']);
     let overlayZ = 100;


### PR DESCRIPTION
## Summary
- ensure the drop joystick is hidden when global dragend fires without an active pane drag
- also hide the joystick if the deferred drag end timeout triggers after the drag state is cleared

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff82b07c04832387b28604afdb67b4