### PR TITLE
Hide drop joysticks when panel drag ends

### DIFF
--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
@@ -1924,6 +1924,8 @@ export class MintDockManagerElement extends HTMLElement {
   }
 
   private onDragMouseUp(): void {
+    this.hideAllDropJoysticks();
+
     if (!this.dragState) {
       this.stopDragPointerTracking();
       return;
@@ -1933,6 +1935,8 @@ export class MintDockManagerElement extends HTMLElement {
   }
 
   private onDragTouchEnd(): void {
+    this.hideAllDropJoysticks();
+
     if (!this.dragState) {
       this.stopDragPointerTracking();
       return;
@@ -2423,6 +2427,19 @@ export class MintDockManagerElement extends HTMLElement {
     delete this.dropJoystick.dataset['path'];
     this.dropJoystickTarget = null;
     this.updateDropJoystickActiveZone(null);
+    this.hideAllDropJoysticks();
+  }
+
+  private hideAllDropJoysticks(): void {
+    const shadowRoot = this.shadowRoot;
+    if (!shadowRoot) {
+      return;
+    }
+
+    const joysticks = shadowRoot.querySelectorAll<HTMLElement>('.dock-drop-joystick');
+    joysticks.forEach((joystick) => {
+      joystick.dataset['visible'] = 'false';
+    });
   }
 
   private findStackAtPoint(clientX: number, clientY: number): HTMLElement | null {


### PR DESCRIPTION
## Summary
- hide every drop joystick in the dock manager when a drag ends so they do not remain visible
- ensure clearing the drop indicator also clears any visible joysticks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff94a3c3188323966a19dc4fd15b5e