### PR TITLE
Ensure modal overlay change detection

### DIFF
--- a/libs/mintplayer-ng-bootstrap/modal/src/components/modal-host/modal-host.component.ts
+++ b/libs/mintplayer-ng-bootstrap/modal/src/components/modal-host/modal-host.component.ts
@@ -28,6 +28,7 @@ export class BsModalHostComponent implements AfterViewInit, OnDestroy {
     this._isOpen = value;
     if (this.componentInstance) {
       this.componentInstance.instance.isOpen = value;
+      this.componentInstance.changeDetectorRef.detectChanges();
     }
     this.isOpenChange.emit(value);
   }
@@ -53,6 +54,7 @@ export class BsModalHostComponent implements AfterViewInit, OnDestroy {
     });
     this.componentInstance = this.overlayRef.attach<BsModalComponent>(portal);
     this.componentInstance.instance.isOpen = this._isOpen;
+    this.componentInstance.changeDetectorRef.detectChanges();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## Summary
- trigger change detection on the dynamically created modal component whenever the open state changes
- ensure the initial attachment of the modal overlay also updates the component view immediately

## Testing
- npx jest libs/mintplayer-ng-bootstrap/modal/src/components/modal-host/modal-host.component.spec.ts --runInBand *(fails: Need to call TestBed.initTestEnvironment() first)*

------
https://chatgpt.com/codex/tasks/task_e_690102f8d6dc8323a21cee29de1d9770