### PR TITLE
feat: Make shell component noscript-compatible

### DIFF
--- a/libs/mintplayer-ng-bootstrap/shell/src/shell/shell.component.html
+++ b/libs/mintplayer-ng-bootstrap/shell/src/shell/shell.component.html
@@ -1,10 +1,16 @@
+<input type="checkbox" class="d-none shell-toggle" bsNoNoscript
+    [id]="shellToggleId()"
+    [checked]="state() === 'show'"
+    [indeterminate]="state() === 'auto'">
 <div class="sidebar-root" [class]="[stateClass(), breakpointClass()]" #root>
     <div class="sidebar position-fixed pe-none">
         <div class="sidebar-body d-flex flex-column pe-all">
+            <label class="sidebar-close" [for]="shellToggleId()" bsNoNoscript>&times;</label>
             <ng-container *ngTemplateOutlet="sidebarTemplate()"></ng-container>
         </div>
     </div>
     <div class="content">
+        <label class="sidebar-open" [for]="shellToggleId()" bsNoNoscript>&#9776;</label>
         <ng-content></ng-content>
     </div>
 </div>

--- a/libs/mintplayer-ng-bootstrap/shell/src/shell/shell.component.scss
+++ b/libs/mintplayer-ng-bootstrap/shell/src/shell/shell.component.scss
@@ -99,3 +99,44 @@
     //     }
     // }
 }
+
+// Noscript toggle labels (hidden by default)
+.sidebar-open, .sidebar-close {
+    display: none;
+}
+
+@each $name, $value in $grid-breakpoints {
+    .sidebar-root.shell-#{$name} .sidebar-open.noscript,
+    .sidebar-root.shell-#{$name} .sidebar-close.noscript {
+        @include media-breakpoint-down($name, $grid-breakpoints) {
+            display: block;
+            cursor: pointer;
+        }
+    }
+}
+
+.sidebar-open.noscript {
+    padding: .25rem .75rem;
+    font-size: 1.25rem;
+    line-height: 1;
+}
+
+.sidebar-close.noscript {
+    padding: .25rem .75rem;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: rgba(255, 255, 255, 0.75);
+    align-self: flex-end;
+}
+
+// Noscript: checkbox checked → show sidebar
+@each $name, $value in $grid-breakpoints {
+    input.noscript.shell-toggle:checked ~ .sidebar-root.shell-#{$name} {
+        @include media-breakpoint-down($name, $grid-breakpoints) {
+            @include sidebar-show-narrow();
+        }
+        @include media-breakpoint-up($name, $grid-breakpoints) {
+            @include sidebar-show-wide();
+        }
+    }
+}

--- a/libs/mintplayer-ng-bootstrap/shell/src/shell/shell.component.ts
+++ b/libs/mintplayer-ng-bootstrap/shell/src/shell/shell.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, ElementRef, input, signal, TemplateRef, viewChild } from '@angular/core';
+import { BsNoNoscriptDirective } from '@mintplayer/ng-bootstrap/no-noscript';
 import { BsShellState } from '../shell-state';
 import { Breakpoint } from '@mintplayer/ng-bootstrap';
 
@@ -7,7 +8,7 @@ import { Breakpoint } from '@mintplayer/ng-bootstrap';
   selector: 'bs-shell',
   templateUrl: './shell.component.html',
   styleUrl: './shell.component.scss',
-  imports: [NgTemplateOutlet],
+  imports: [NgTemplateOutlet, BsNoNoscriptDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BsShellComponent {
@@ -25,6 +26,10 @@ export class BsShellComponent {
   });
 
   breakpointClass = computed(() => `shell-${this.breakpoint()}`);
+
+  static shellCounter = 0;
+  shellId = signal(++BsShellComponent.shellCounter);
+  shellToggleId = computed(() => `bs-shell-toggle-${this.shellId()}`);
 
   public setSize(size: string) {
     this.rootElement().nativeElement.style.setProperty('--size', size);


### PR DESCRIPTION
## Summary

- Add a hidden checkbox with `bsNoNoscript` for sidebar toggle state (indeterminate=auto, checked=show, unchecked=hide)
- Add noscript-only hamburger (☰) and close (×) labels visible only on narrow screens when JS is disabled
- CSS `:checked` sibling selectors override sidebar visibility when checkbox is toggled
- Expose `shellToggleId` so consumers can add their own toggle labels elsewhere

## How it works

| Checkbox state | Shell state | Set by |
|---------------|-------------|--------|
| Indeterminate | auto | JS property binding (`[indeterminate]`) |
| Checked | show | HTML attribute or noscript label click |
| Unchecked | hide | Noscript label click |

**With JS:** Angular manages the `state` input and CSS classes (`.show`/`.hide`). The checkbox `[checked]` and `[indeterminate]` bindings keep it in sync.

**Without JS:** The built-in hamburger/close labels toggle the checkbox. CSS `input.noscript.shell-toggle:checked ~ .sidebar-root` shows the sidebar on narrow screens.

## Test plan

- [ ] Verify sidebar auto behavior works with JavaScript enabled (no regression)
- [ ] Verify sidebar show/hide states work with JavaScript
- [ ] Verify hamburger label appears on narrow screens without JavaScript
- [ ] Verify clicking hamburger opens sidebar without JavaScript
- [ ] Verify clicking close button hides sidebar without JavaScript
- [ ] Verify hamburger/close labels are hidden when JavaScript is enabled
- [ ] Verify hamburger/close labels are hidden on wide screens
- [ ] Verify `setSize()` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)