### PR TITLE
fix: Prevent column width bloat and misalignment in virtual datatable

### DIFF
--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.12.6",
+  "version": "21.12.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-bootstrap/virtual-datatable/src/virtual-datatable/virtual-datatable.component.scss
+++ b/libs/mintplayer-ng-bootstrap/virtual-datatable/src/virtual-datatable/virtual-datatable.component.scss
@@ -17,9 +17,13 @@
 
 // Use auto layout so columns size to content and the table can overflow
 // horizontally when content is wider than the container.
+// Override Bootstrap's width:100% to prevent table-layout:auto from
+// redistributing extra space across columns — keeps header and body
+// column widths aligned and stable across scroll events.
 bs-table ::ng-deep table,
 .virtual-scroll-viewport table {
   table-layout: auto;
+  width: max-content;
 }
 
 // When responsive, prevent text wrapping so cells grow to fit content.

--- a/libs/mintplayer-ng-bootstrap/virtual-datatable/src/virtual-datatable/virtual-datatable.component.ts
+++ b/libs/mintplayer-ng-bootstrap/virtual-datatable/src/virtual-datatable/virtual-datatable.component.ts
@@ -74,6 +74,10 @@ export class BsVirtualDatatableComponent<TData> extends DatatableSortBase implem
 
     if (!bodyTableBody) return;
 
+    // Track the max width seen for each column so columns only grow, never
+    // shrink (prevents layout jumps as rows scroll in/out of view).
+    const maxWidths: number[] = [];
+
     const syncWidths = () => {
       const headerCells = el.querySelectorAll<HTMLElement>('bs-table thead th');
       const allBodyRows = Array.from(bodyTableBody.querySelectorAll<HTMLTableRowElement>('tr'));
@@ -106,24 +110,48 @@ export class BsVirtualDatatableComponent<TData> extends DatatableSortBase implem
         headerCells[i].style.minWidth = '';
       }
 
-      // Measure natural widths across all visible rows
-      const widths: number[] = [];
+      // Temporarily force both tables to size to content only, overriding
+      // Bootstrap's width:100% which causes table-layout:auto to redistribute
+      // extra space across columns. Without this, measured widths include
+      // redistributed space that varies with each data slice.
+      const headerTable = el.querySelector<HTMLElement>('bs-table table');
+      const bodyTable = el.querySelector<HTMLElement>('cdk-virtual-scroll-viewport table');
+      headerTable?.style.setProperty('width', 'max-content', 'important');
+      bodyTable?.style.setProperty('width', 'max-content', 'important');
+
+      // Measure natural content widths across all visible rows
       for (let i = 0; i < columnCount; i++) {
-        widths[i] = headerCells[i].offsetWidth;
-      }
-      for (const row of allBodyRows) {
-        const tds = row.cells;
-        for (let i = 0; i < Math.min(tds.length, columnCount); i++) {
-          const w = tds[i].offsetWidth;
-          if (w > widths[i]) widths[i] = w;
+        let colWidth = headerCells[i].offsetWidth;
+        for (const row of allBodyRows) {
+          const tds = row.cells;
+          if (i < tds.length) {
+            const w = tds[i].offsetWidth;
+            if (w > colWidth) colWidth = w;
+          }
+        }
+        // Update tracked maximum so columns only grow, never shrink
+        if (!maxWidths[i] || colWidth > maxWidths[i]) {
+          maxWidths[i] = colWidth;
         }
       }
 
-      // Apply measured widths to header and first body row to keep them in sync
+      // Remove temporary width override so tables render normally
+      headerTable?.style.removeProperty('width');
+      bodyTable?.style.removeProperty('width');
+
+      // Apply max widths to header and ALL body rows to keep them in sync.
+      // Setting min-width on every row prevents table-layout:auto from
+      // redistributing extra space differently across the two tables when
+      // some rows contain placeholder content.
       for (let i = 0; i < columnCount; i++) {
-        const w = `${widths[i]}px`;
+        const w = `${maxWidths[i]}px`;
         headerCells[i].style.minWidth = w;
-        bodyCells[i].style.minWidth = w;
+        for (const row of allBodyRows) {
+          const tds = row.cells;
+          if (i < tds.length) {
+            tds[i].style.minWidth = w;
+          }
+        }
       }
 
       // Restore scroll positions after min-widths are re-applied


### PR DESCRIPTION
## Summary
Follow-up to #277. Fixes remaining column width issues in `bs-virtual-datatable`:

- **SCSS**: Add `width: max-content` to override Bootstrap's `width: 100%`, preventing `table-layout: auto` from redistributing extra space across columns
- **Measurement**: Temporarily set `width: max-content !important` as inline style during measurement to ensure accurate content-only widths regardless of external CSS
- **Apply to all rows**: Set `min-width` on ALL visible body rows (not just the first) so placeholder rows from unloaded pages don't cause header/body misalignment
- **Grow-only columns**: Retain `maxWidths` accumulator so columns only grow when genuinely wider content appears — no shrinking, no layout jumps
- **Version bump**: 21.12.6 → 21.12.7

## Root Cause
PR #277 fixed stale `min-width` on CDK-recycled rows. However, Bootstrap's `.table { width: 100% }` still caused `table-layout: auto` to redistribute extra space proportionally across columns. Since different data slices have different content distributions, column widths fluctuated on every scroll event. Additionally, setting `min-width` on only the first body row left placeholder rows unconstrained, causing the body table to redistribute differently than the header.

## Test plan
- [ ] Navigate to a virtual scrolling query page (e.g., `/query/cars`)
- [ ] Scroll down and back up multiple times
- [ ] Verify column widths remain stable and only grow (never shrink)
- [ ] Verify header and body columns stay perfectly aligned at all scroll positions
- [ ] Verify horizontal scroll sync still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)