### PR TITLE
feat(multiselect): Add bsItemTemplate directive

### DIFF
--- a/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
@@ -1,6 +1,6 @@
 <h1 class="text-center">Multiselect dropdown</h1>
 <bs-form>
-    <bs-multiselect [selectedItems]="selectedItems">
+    <bs-multiselect [(selectedItems)]="selectedItems">
         <div *bsHeaderTemplate>
             <input type="text" autofocus>
         </div>
@@ -10,12 +10,12 @@
         <ng-container *bsButtonTemplate="let count">
             {{ count }} geselecteerd
         </ng-container>
-        <ng-container *bsItemTemplate="let item of availableItems">
+        <ng-container *bsItemTemplate="let item of availableItems()">
             Color: {{ item }}
         </ng-container>
     </bs-multiselect>
     Selected items:
-    @for (item of selectedItems; track item) {
+    @for (item of selectedItems(); track item) {
         <span>{{ item }}, </span>
     }
 </bs-form>

--- a/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
@@ -1,6 +1,6 @@
 <h1 class="text-center">Multiselect dropdown</h1>
 <bs-form>
-    <bs-multiselect [items]="availableItems" [selectedItems]="selectedItems">
+    <bs-multiselect [selectedItems]="selectedItems">
         <div *bsHeaderTemplate>
             <input type="text" autofocus>
         </div>

--- a/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
@@ -10,6 +10,9 @@
         <ng-container *bsButtonTemplate="let count">
             {{ count }} geselecteerd
         </ng-container>
+        <ng-template bsItemTemplate let-item>
+            Color: {{ item }}
+        </ng-template>
     </bs-multiselect>
     Selected items:
     @for (item of selectedItems; track item) {

--- a/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.html
@@ -10,9 +10,9 @@
         <ng-container *bsButtonTemplate="let count">
             {{ count }} geselecteerd
         </ng-container>
-        <ng-template bsItemTemplate let-item>
+        <ng-container *bsItemTemplate="let item of availableItems">
             Color: {{ item }}
-        </ng-template>
+        </ng-container>
     </bs-multiselect>
     Selected items:
     @for (item of selectedItems; track item) {

--- a/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy} from '@angular/core';
+import { Component, signal, ChangeDetectionStrategy } from '@angular/core';
 import { BsFormComponent, BsFormControlDirective } from '@mintplayer/ng-bootstrap/form';
 import { BsMultiselectComponent, BsHeaderTemplateDirective, BsFooterTemplateDirective, BsButtonTemplateDirective, BsItemTemplateDirective } from '@mintplayer/ng-bootstrap/multiselect';
 import { FocusOnLoadDirective } from '@mintplayer/ng-focus-on-load';
@@ -12,7 +12,7 @@ import { FocusOnLoadDirective } from '@mintplayer/ng-focus-on-load';
 })
 export class MultiselectDropdownComponent {
 
-  availableItems = ['Blue', 'Red', 'Green', 'Yellow', 'Orange', 'Purple', 'Pink'];
-  selectedItems: string[] = [];
+  readonly availableItems = signal(['Blue', 'Red', 'Green', 'Yellow', 'Orange', 'Purple', 'Pink']);
+  readonly selectedItems = signal<string[]>([]);
 
 }

--- a/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/overlay/multiselect-dropdown/multiselect-dropdown.component.ts
@@ -1,13 +1,13 @@
 import { Component, ChangeDetectionStrategy} from '@angular/core';
 import { BsFormComponent, BsFormControlDirective } from '@mintplayer/ng-bootstrap/form';
-import { BsMultiselectComponent, BsHeaderTemplateDirective, BsFooterTemplateDirective, BsButtonTemplateDirective } from '@mintplayer/ng-bootstrap/multiselect';
+import { BsMultiselectComponent, BsHeaderTemplateDirective, BsFooterTemplateDirective, BsButtonTemplateDirective, BsItemTemplateDirective } from '@mintplayer/ng-bootstrap/multiselect';
 import { FocusOnLoadDirective } from '@mintplayer/ng-focus-on-load';
 
 @Component({
   selector: 'demo-multiselect-dropdown',
   templateUrl: './multiselect-dropdown.component.html',
   styleUrls: ['./multiselect-dropdown.component.scss'],
-  imports: [BsFormComponent, BsFormControlDirective, BsMultiselectComponent, BsHeaderTemplateDirective, BsFooterTemplateDirective, BsButtonTemplateDirective, FocusOnLoadDirective],
+  imports: [BsFormComponent, BsFormControlDirective, BsMultiselectComponent, BsHeaderTemplateDirective, BsFooterTemplateDirective, BsButtonTemplateDirective, BsItemTemplateDirective, FocusOnLoadDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MultiselectDropdownComponent {

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
@@ -4,17 +4,17 @@
         <ng-container *ngTemplateOutlet="resolvedButtonTemplate(); context: { $implicit: selectedItems().length }"></ng-container>
     </button>
     <div *bsDropdownMenu class="bg-white mw-250px p-3 border rounded shadow">
-        <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
-        @if (headerTemplate) {
+        <ng-container *ngTemplateOutlet="headerTemplate()"></ng-container>
+        @if (headerTemplate()) {
             <hr class="my-2">
         }
         @for (item of items(); track item) {
             <bs-toggle-button [ngModel]="selectedItems().indexOf(item) > -1" (ngModelChange)="itemChange(item, $event)" class="d-block"><ng-container *ngTemplateOutlet="resolvedItemTemplate(); context: { $implicit: item }"></ng-container></bs-toggle-button>
         }
-        @if (footerTemplate) {
+        @if (footerTemplate()) {
             <hr class="my-2">
         }
-        <ng-container *ngTemplateOutlet="footerTemplate"></ng-container>
+        <ng-container *ngTemplateOutlet="footerTemplate()"></ng-container>
     </div>
 </div>
 <ng-template #defaultButtonTemplate let-count>

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
@@ -9,7 +9,7 @@
             <hr class="my-2">
         }
         @for (item of items(); track item) {
-            <bs-toggle-button [ngModel]="selectedItems().indexOf(item) > -1" (ngModelChange)="itemChange(item, $event)" class="d-block">{{ item }}</bs-toggle-button>
+            <bs-toggle-button [ngModel]="selectedItems().indexOf(item) > -1" (ngModelChange)="itemChange(item, $event)" class="d-block"><ng-container *ngTemplateOutlet="itemTemplate ?? defaultItemTemplate; context: { $implicit: item }"></ng-container></bs-toggle-button>
         }
         @if (footerTemplate) {
             <hr class="my-2">
@@ -20,3 +20,4 @@
 <ng-template #defaultButtonTemplate let-count>
     {{ count }} selected
 </ng-template>
+<ng-template #defaultItemTemplate let-item>{{ item }}</ng-template>

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
@@ -1,7 +1,7 @@
 <bs-has-overlay></bs-has-overlay>
 <div bsDropdown [hasBackdrop]="true" [closeOnClickOutside]="true">
     <button bsDropdownToggle [color]="colors.primary">
-        <ng-container *ngTemplateOutlet="buttonTemplate ?? defaultButtonTemplate; context: { $implicit: selectedItems().length }"></ng-container>
+        <ng-container *ngTemplateOutlet="resolvedButtonTemplate(); context: { $implicit: selectedItems().length }"></ng-container>
     </button>
     <div *bsDropdownMenu class="bg-white mw-250px p-3 border rounded shadow">
         <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
@@ -9,7 +9,7 @@
             <hr class="my-2">
         }
         @for (item of items(); track item) {
-            <bs-toggle-button [ngModel]="selectedItems().indexOf(item) > -1" (ngModelChange)="itemChange(item, $event)" class="d-block"><ng-container *ngTemplateOutlet="itemTemplate ?? defaultItemTemplate; context: { $implicit: item }"></ng-container></bs-toggle-button>
+            <bs-toggle-button [ngModel]="selectedItems().indexOf(item) > -1" (ngModelChange)="itemChange(item, $event)" class="d-block"><ng-container *ngTemplateOutlet="resolvedItemTemplate(); context: { $implicit: item }"></ng-container></bs-toggle-button>
         }
         @if (footerTemplate) {
             <hr class="my-2">

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, model, TemplateRef, TrackByFunction, viewChild, ChangeDetectionStrategy} from '@angular/core';
+import { Component, computed, model, signal, TemplateRef, viewChild, ChangeDetectionStrategy } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BsHasOverlayComponent } from '@mintplayer/ng-bootstrap/has-overlay';
@@ -16,24 +16,21 @@ import { Color } from '@mintplayer/ng-bootstrap';
 })
 export class BsMultiselectComponent<T> {
 
-  headerTemplate?: TemplateRef<any>;
-  footerTemplate?: TemplateRef<any>;
-  buttonTemplate?: TemplateRef<any>;
-  itemTemplate?: TemplateRef<any>;
-  colors = Color;
-
+  readonly headerTemplate = signal<TemplateRef<any> | undefined>(undefined);
+  readonly footerTemplate = signal<TemplateRef<any> | undefined>(undefined);
+  readonly buttonTemplate = signal<TemplateRef<any> | undefined>(undefined);
+  readonly itemTemplate = signal<TemplateRef<any> | undefined>(undefined);
+  readonly colors = Color;
 
   readonly items = model<T[]>([]);
   readonly selectedItems = model<T[]>([]);
   readonly defaultButtonTemplate = viewChild.required<TemplateRef<any>>('defaultButtonTemplate');
   readonly defaultItemTemplate = viewChild.required<TemplateRef<any>>('defaultItemTemplate');
 
-  readonly resolvedButtonTemplate = computed(() => this.buttonTemplate ?? this.defaultButtonTemplate());
-  readonly resolvedItemTemplate = computed(() => this.itemTemplate ?? this.defaultItemTemplate());
+  readonly resolvedButtonTemplate = computed(() => this.buttonTemplate() ?? this.defaultButtonTemplate());
+  readonly resolvedItemTemplate = computed(() => this.itemTemplate() ?? this.defaultItemTemplate());
 
-  // itemChange(item: any, ev: Event) {
   itemChange(item: T, value: boolean | null) {
-    // const value = (<any>ev.target).checked;
     if (value) {
       this.selectedItems.update(v => [...v, item]);
     } else {

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, model, TemplateRef, TrackByFunction, viewChild, ChangeDetectionStrategy} from '@angular/core';
+import { Component, computed, input, model, TemplateRef, TrackByFunction, viewChild, ChangeDetectionStrategy} from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BsHasOverlayComponent } from '@mintplayer/ng-bootstrap/has-overlay';
@@ -27,6 +27,9 @@ export class BsMultiselectComponent<T> {
   readonly selectedItems = model<T[]>([]);
   readonly defaultButtonTemplate = viewChild.required<TemplateRef<any>>('defaultButtonTemplate');
   readonly defaultItemTemplate = viewChild.required<TemplateRef<any>>('defaultItemTemplate');
+
+  readonly resolvedButtonTemplate = computed(() => this.buttonTemplate ?? this.defaultButtonTemplate());
+  readonly resolvedItemTemplate = computed(() => this.itemTemplate ?? this.defaultItemTemplate());
 
   // itemChange(item: any, ev: Event) {
   itemChange(item: T, value: boolean | null) {

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
@@ -19,12 +19,14 @@ export class BsMultiselectComponent<T> {
   headerTemplate?: TemplateRef<any>;
   footerTemplate?: TemplateRef<any>;
   buttonTemplate?: TemplateRef<any>;
+  itemTemplate?: TemplateRef<any>;
   colors = Color;
 
 
   readonly items = input<T[]>([]);
   readonly selectedItems = model<T[]>([]);
   readonly defaultButtonTemplate = viewChild.required<TemplateRef<any>>('defaultButtonTemplate');
+  readonly defaultItemTemplate = viewChild.required<TemplateRef<any>>('defaultItemTemplate');
 
   // itemChange(item: any, ev: Event) {
   itemChange(item: T, value: boolean | null) {

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.ts
@@ -23,7 +23,7 @@ export class BsMultiselectComponent<T> {
   colors = Color;
 
 
-  readonly items = input<T[]>([]);
+  readonly items = model<T[]>([]);
   readonly selectedItems = model<T[]>([]);
   readonly defaultButtonTemplate = viewChild.required<TemplateRef<any>>('defaultButtonTemplate');
   readonly defaultItemTemplate = viewChild.required<TemplateRef<any>>('defaultItemTemplate');

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/button-template/button-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/button-template/button-template.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { Component, signal, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BsMultiselectComponent } from '../../component/multiselect.component';
 import { BsButtonTemplateDirective } from './button-template.directive';
@@ -7,14 +7,14 @@ import { BsButtonTemplateDirective } from './button-template.directive';
   selector: 'bs-multiselect',
   template: `
     <button>
-      <ng-container *ngTemplateOutlet="buttonTemplate ?? defaultButtonTemplate; context: { $implicit: 0 }"></ng-container>
+      <ng-container *ngTemplateOutlet="buttonTemplate(); context: { $implicit: 0 }"></ng-container>
     </button>`,
   providers: [
     { provide: BsMultiselectComponent, useExisting: BsMultiselectMockComponent }
   ]
 })
 class BsMultiselectMockComponent {
-  buttonTemplate!: TemplateRef<any>;
+  readonly buttonTemplate = signal<TemplateRef<any> | undefined>(undefined);
 }
 
 @Component({
@@ -28,7 +28,6 @@ class BsMultiselectMockComponent {
     </bs-multiselect>`
 })
 class BsButtonTemplateTestComponent {
-  @ViewChild('modalTemplate') modalTemplate!: TemplateRef<any>;
   @ViewChild('multiselect') multiselect!: BsMultiselectMockComponent;
 }
 
@@ -62,6 +61,6 @@ describe('BsButtonTemplateDirective', () => {
   });
 
   it('should contain a button template', () => {
-    expect(component.multiselect.buttonTemplate).toBeTruthy();
+    expect(component.multiselect.buttonTemplate()).toBeTruthy();
   });
 });

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/button-template/button-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/button-template/button-template.directive.ts
@@ -9,9 +9,9 @@ export class BsButtonTemplateDirective<T> {
   constructor() {
     const template = inject(TemplateRef);
     const multiselect = inject<BsMultiselectComponent<T>>(BsMultiselectComponent);
-    multiselect.buttonTemplate = template;
+    multiselect.buttonTemplate.set(template);
   }
-  
+
   public static ngTemplateContextGuard<TData>(
     dir: BsButtonTemplateDirective<TData>,
     ctx: any

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/footer-template/footer-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/footer-template/footer-template.directive.spec.ts
@@ -1,20 +1,32 @@
-import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { Component, signal, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BsMultiselectComponent } from '../../component/multiselect.component';
 import { BsFooterTemplateDirective } from './footer-template.directive';
-import { MockComponent } from 'ng-mocks';
+
+@Component({
+  selector: 'bs-multiselect',
+  template: `
+    <button>
+      <ng-container *ngTemplateOutlet="footerTemplate(); context: { $implicit: 0 }"></ng-container>
+    </button>`,
+  providers: [
+    { provide: BsMultiselectComponent, useExisting: BsMultiselectMockComponent }
+  ]
+})
+class BsMultiselectMockComponent {
+  readonly footerTemplate = signal<TemplateRef<any> | undefined>(undefined);
+}
 
 @Component({
   selector: 'bs-footer-template-test',
-  imports: [MockComponent(BsMultiselectComponent), BsFooterTemplateDirective],
+  imports: [BsMultiselectMockComponent, BsFooterTemplateDirective],
   template: `
     <bs-multiselect #multiselect>
       <ng-container *bsFooterTemplate="let count">{{ count }} geselecteerd</ng-container>
     </bs-multiselect>`
 })
 class BsFooterTemplateTestComponent {
-  @ViewChild('modalTemplate') modalTemplate!: TemplateRef<any>;
-  @ViewChild('multiselect') multiselect!: BsMultiselectComponent<any>;
+  @ViewChild('multiselect') multiselect!: BsMultiselectMockComponent;
 }
 
 describe('BsFooterTemplateDirective', () => {
@@ -28,8 +40,8 @@ describe('BsFooterTemplateDirective', () => {
         BsFooterTemplateDirective,
 
         // Mock dependencies
-        MockComponent(BsMultiselectComponent),
-        
+        BsMultiselectMockComponent,
+
         // Testbench
         BsFooterTemplateTestComponent,
       ],
@@ -47,6 +59,6 @@ describe('BsFooterTemplateDirective', () => {
   });
 
   it('should contain a footer template', () => {
-    expect(component.multiselect.footerTemplate).toBeTruthy();
+    expect(component.multiselect.footerTemplate()).toBeTruthy();
   });
 });

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/footer-template/footer-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/footer-template/footer-template.directive.ts
@@ -9,7 +9,7 @@ export class BsFooterTemplateDirective<T> {
   constructor() {
     const template = inject(TemplateRef);
     const multiselect = inject<BsMultiselectComponent<T>>(BsMultiselectComponent);
-    multiselect.footerTemplate = template;
+    multiselect.footerTemplate.set(template);
   }
 
 }

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/header-template/header-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/header-template/header-template.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { Component, signal, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BsMultiselectComponent } from '../../component/multiselect.component';
 import { BsHeaderTemplateDirective } from './header-template.directive';
@@ -7,14 +7,14 @@ import { BsHeaderTemplateDirective } from './header-template.directive';
   selector: 'bs-multiselect',
   template: `
     <button>
-      <ng-container *ngTemplateOutlet="headerTemplate ?? defaultHeaderTemplate; context: { $implicit: 0 }"></ng-container>
+      <ng-container *ngTemplateOutlet="headerTemplate(); context: { $implicit: 0 }"></ng-container>
     </button>`,
   providers: [
     { provide: BsMultiselectComponent, useExisting: BsMultiselectMockComponent }
   ]
 })
 class BsMultiselectMockComponent {
-  headerTemplate!: TemplateRef<any>;
+  readonly headerTemplate = signal<TemplateRef<any> | undefined>(undefined);
 }
 
 @Component({
@@ -28,7 +28,6 @@ class BsMultiselectMockComponent {
     </bs-multiselect>`
 })
 class BsHeaderTemplateTestComponent {
-  @ViewChild('modalTemplate') modalTemplate!: TemplateRef<any>;
   @ViewChild('multiselect') multiselect!: BsMultiselectMockComponent;
 }
 
@@ -62,6 +61,6 @@ describe('BsHeaderTemplateDirective', () => {
   });
 
   it('should contain a header template', () => {
-    expect(component.multiselect.headerTemplate).toBeTruthy();
+    expect(component.multiselect.headerTemplate()).toBeTruthy();
   });
 });

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/header-template/header-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/header-template/header-template.directive.ts
@@ -9,7 +9,7 @@ export class BsHeaderTemplateDirective<T> {
   constructor() {
     const template = inject(TemplateRef);
     const multiselect = inject<BsMultiselectComponent<T>>(BsMultiselectComponent);
-    multiselect.headerTemplate = template;
+    multiselect.headerTemplate.set(template);
   }
 
 }

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/index.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/index.ts
@@ -1,3 +1,4 @@
 export * from './header-template/header-template.directive';
 export * from './footer-template/footer-template.directive';
 export * from './button-template/button-template.directive';
+export * from './item-template/item-template.directive';

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.spec.ts
@@ -28,7 +28,6 @@ class BsMultiselectMockComponent {
     </bs-multiselect>`
 })
 class BsItemTemplateTestComponent {
-  @ViewChild('modalTemplate') modalTemplate!: TemplateRef<any>;
   @ViewChild('multiselect') multiselect!: BsMultiselectMockComponent;
 }
 

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.spec.ts
@@ -1,0 +1,67 @@
+import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BsMultiselectComponent } from '../../component/multiselect.component';
+import { BsItemTemplateDirective } from './item-template.directive';
+
+@Component({
+  selector: 'bs-multiselect',
+  template: `
+    <button>
+      <ng-container *ngTemplateOutlet="itemTemplate ?? defaultItemTemplate; context: { $implicit: 'test' }"></ng-container>
+    </button>`,
+  providers: [
+    { provide: BsMultiselectComponent, useExisting: BsMultiselectMockComponent }
+  ]
+})
+class BsMultiselectMockComponent {
+  itemTemplate!: TemplateRef<any>;
+}
+
+@Component({
+  selector: 'bs-item-template-test',
+  imports: [BsMultiselectMockComponent, BsItemTemplateDirective],
+  template: `
+    <bs-multiselect #multiselect>
+      <ng-template bsItemTemplate let-item>
+          {{ item }}
+      </ng-template>
+    </bs-multiselect>`
+})
+class BsItemTemplateTestComponent {
+  @ViewChild('modalTemplate') modalTemplate!: TemplateRef<any>;
+  @ViewChild('multiselect') multiselect!: BsMultiselectMockComponent;
+}
+
+describe('BsItemTemplateDirective', () => {
+  let component: BsItemTemplateTestComponent;
+  let fixture: ComponentFixture<BsItemTemplateTestComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        // Directive to test
+        BsItemTemplateDirective,
+
+        // Mock dependencies
+        BsMultiselectMockComponent,
+
+        // Testbench
+        BsItemTemplateTestComponent
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BsItemTemplateTestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create an instance', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain an item template', () => {
+    expect(component.multiselect.itemTemplate).toBeTruthy();
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { Component, signal, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BsMultiselectComponent } from '../../component/multiselect.component';
 import { BsItemTemplateDirective } from './item-template.directive';
@@ -7,14 +7,15 @@ import { BsItemTemplateDirective } from './item-template.directive';
   selector: 'bs-multiselect',
   template: `
     <button>
-      <ng-container *ngTemplateOutlet="itemTemplate ?? defaultItemTemplate; context: { $implicit: 'test' }"></ng-container>
+      <ng-container *ngTemplateOutlet="itemTemplate(); context: { $implicit: 'test' }"></ng-container>
     </button>`,
   providers: [
     { provide: BsMultiselectComponent, useExisting: BsMultiselectMockComponent }
   ]
 })
 class BsMultiselectMockComponent {
-  itemTemplate!: TemplateRef<any>;
+  readonly itemTemplate = signal<TemplateRef<any> | undefined>(undefined);
+  readonly items = signal<any[]>([]);
 }
 
 @Component({
@@ -61,6 +62,6 @@ describe('BsItemTemplateDirective', () => {
   });
 
   it('should contain an item template', () => {
-    expect(component.multiselect.itemTemplate).toBeTruthy();
+    expect(component.multiselect.itemTemplate()).toBeTruthy();
   });
 });

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
@@ -9,7 +9,7 @@ export class BsItemTemplateDirective<T> {
 
   constructor() {
     const template = inject(TemplateRef);
-    this.multiselect.itemTemplate = template;
+    this.multiselect.itemTemplate.set(template);
 
     effect(() => {
       const value = this.bsItemTemplateOf();

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, inject, TemplateRef } from '@angular/core';
+import { BsMultiselectComponent } from '../../component/multiselect.component';
+
+@Directive({
+  selector: '[bsItemTemplate]',
+})
+export class BsItemTemplateDirective<T> {
+
+  constructor() {
+    const template = inject(TemplateRef);
+    const multiselect = inject<BsMultiselectComponent<T>>(BsMultiselectComponent);
+    multiselect.itemTemplate = template;
+  }
+
+  public static ngTemplateContextGuard<TData>(
+    dir: BsItemTemplateDirective<TData>,
+    ctx: any
+  ): ctx is BsItemTemplateContext<TData> {
+    return true;
+  }
+
+}
+
+export class BsItemTemplateContext<T> {
+  public $implicit: T = null!;
+}

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
@@ -1,15 +1,22 @@
-import { Directive, inject, input, TemplateRef } from '@angular/core';
+import { Directive, effect, inject, input, TemplateRef } from '@angular/core';
 import { BsMultiselectComponent } from '../../component/multiselect.component';
 
 @Directive({
   selector: '[bsItemTemplate]',
 })
 export class BsItemTemplateDirective<T> {
+  private multiselect = inject<BsMultiselectComponent<T>>(BsMultiselectComponent);
 
   constructor() {
     const template = inject(TemplateRef);
-    const multiselect = inject<BsMultiselectComponent<T>>(BsMultiselectComponent);
-    multiselect.itemTemplate = template;
+    this.multiselect.itemTemplate = template;
+
+    effect(() => {
+      const value = this.bsItemTemplateOf();
+      if (value) {
+        this.multiselect.items.set(value);
+      }
+    });
   }
 
   public static ngTemplateContextGuard<TData>(
@@ -19,7 +26,7 @@ export class BsItemTemplateDirective<T> {
     return true;
   }
 
-  /** Used for type inference — pass the same array as [items] on bs-multiselect */
+  /** Pass the items array — forwards to BsMultiselectComponent.items */
   readonly bsItemTemplateOf = input<T[] | undefined>(undefined);
 }
 

--- a/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/directives/item-template/item-template.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, inject, TemplateRef } from '@angular/core';
+import { Directive, inject, input, TemplateRef } from '@angular/core';
 import { BsMultiselectComponent } from '../../component/multiselect.component';
 
 @Directive({
@@ -15,10 +15,12 @@ export class BsItemTemplateDirective<T> {
   public static ngTemplateContextGuard<TData>(
     dir: BsItemTemplateDirective<TData>,
     ctx: any
-  ): ctx is BsItemTemplateContext<TData> {
+  ): ctx is BsItemTemplateContext<Exclude<TData, false | 0 | '' | null | undefined>> {
     return true;
   }
 
+  /** Used for type inference — pass the same array as [items] on bs-multiselect */
+  readonly bsItemTemplateOf = input<T[] | undefined>(undefined);
 }
 
 export class BsItemTemplateContext<T> {

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.12.9",
+  "version": "21.12.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
## Summary
- Add `BsItemTemplateDirective` (`[bsItemTemplate]`) to customize how each item is rendered inside the multiselect dropdown, following the same pattern as the existing `bsHeaderTemplate`, `bsFooterTemplate`, and `bsButtonTemplate` directives
- Add `BsItemTemplateContext<T>` context guard class with typed `$implicit` for the item
- Add `defaultItemTemplate` fallback in the component (signal-based `viewChild.required`) so the component renders `{{ item }}` when no custom template is provided
- Update the demo app multiselect page to demonstrate the new directive
- Bump package version from 21.12.9 to 21.12.10

## Test plan
- [ ] Verify the multiselect dropdown renders items as before when no `bsItemTemplate` is provided (default fallback)
- [ ] Verify that providing `<ng-template bsItemTemplate let-item>` customizes item rendering
- [ ] Verify the demo app shows `Color: Blue`, `Color: Red`, etc. in the dropdown
- [ ] Run unit tests for the new `BsItemTemplateDirective`

🤖 Generated with [Claude Code](https://claude.com/claude-code)