### PR TITLE
fix(multiselect): Add type="button" to prevent form submission

### DIFF
--- a/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
+++ b/libs/mintplayer-ng-bootstrap/multiselect/src/component/multiselect.component.html
@@ -1,6 +1,6 @@
 <bs-has-overlay></bs-has-overlay>
 <div bsDropdown [hasBackdrop]="true" [closeOnClickOutside]="true">
-    <button bsDropdownToggle [color]="colors.primary">
+    <button type="button" bsDropdownToggle [color]="colors.primary">
         <ng-container *ngTemplateOutlet="resolvedButtonTemplate(); context: { $implicit: selectedItems().length }"></ng-container>
     </button>
     <div *bsDropdownMenu class="bg-white mw-250px p-3 border rounded shadow">

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.12.10",
+  "version": "21.12.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
## Summary
- Added `type="button"` to the multiselect dropdown toggle `<button>` to prevent it from submitting the parent form
- Bumped version to 21.12.11

## Details
A `<button>` without an explicit `type` attribute defaults to `type="submit"`, which causes unintended form submissions when the multiselect is used inside a `<form>`. Adding `type="button"` prevents this behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)