### PR TITLE
feat(pagination): Add ellipsis support for large page counts

### DIFF
--- a/apps/ng-bootstrap-demo/src/app/pages/basic/pagination/pagination.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/basic/pagination/pagination.component.html
@@ -20,8 +20,8 @@ Selected value: {{ example3SelectedPageNumber() }}
 <br>
 Selected value: {{ example4SelectedPageNumber() }}
 
-<!-- <h2>Show ellipsis</h2>
-<p>Restrict the number of boxes shown on the paginator. Show the ellipsis (overflow) box.</p>
-<bs-pagination [pageNumbers]="example4PageNumbers" [(selectedPageNumber)]="example4SelectedPageNumber" [numberOfBoxes]="9" []></bs-pagination>
+<h2>Show ellipsis</h2>
+<p>Restrict the number of boxes shown on the paginator. Ellipsis indicators show where pages are omitted.</p>
+<bs-pagination [pageNumbers]="example5PageNumbers()" [(selectedPageNumber)]="example5SelectedPageNumber" [numberOfBoxes]="11"></bs-pagination>
 <br>
-Selected value: {{ example4SelectedPageNumber }} -->
+Selected value: {{ example5SelectedPageNumber() }}

--- a/apps/ng-bootstrap-demo/src/app/pages/basic/pagination/pagination.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/basic/pagination/pagination.component.ts
@@ -21,4 +21,7 @@ export class PaginationComponent {
   example4PageNumbers = signal<number[]>([...Array(30).keys()].map((p) => p + 1));
   example4SelectedPageNumber = model(15);
 
+  example5PageNumbers = signal<number[]>([...Array(1000).keys()].map((p) => p + 1));
+  example5SelectedPageNumber = model(500);
+
 }

--- a/docs/prd-pagination-ellipsis.md
+++ b/docs/prd-pagination-ellipsis.md
@@ -1,0 +1,170 @@
+# PRD: Pagination Ellipsis Support
+
+## Problem
+
+When `<bs-datatable>` has many pages (e.g. 1000), the `<bs-pagination>` component renders all page numbers, making the table extremely wide. The existing `numberOfBoxes` input truncates the visible window but does **not** show ellipsis indicators or anchor pages (first/last), so users lose orientation within the page range.
+
+## Current State — Half-Built Feature
+
+The ellipsis feature was clearly started but left incomplete. All the scaffolding is in place:
+
+| Asset | Location | Status |
+|-------|----------|--------|
+| `numberOfBoxes` input | `pagination.component.ts:17` | **Working** — limits visible boxes; `0` = show all |
+| `PageNumberType` | `page-number.type.ts:1` | **Ready** — already a union: `number \| '...'` |
+| `PageWithSelection` | `page-with-selection.ts:3` | **Ready** — uses `PageNumberType` for `page` field |
+| Template ellipsis guard | `pagination.component.html:12` | **Broken** — checks `pageNumber.page != '...'` but renders an empty `<li>` instead of a visible ellipsis box |
+| `isLeftOverflow` / `isRightOverflow` | `pagination.component.ts:40-57` | **Unused** — computed signals that detect overflow but are never referenced |
+| Commented-out demo | demo `pagination.component.html:23-27` | **Incomplete** — has `[numberOfBoxes]="9"` and a dangling `[]` attribute |
+
+### What needs to be finished
+
+1. The `shownPageNumbers()` computed signal does simple windowing — it never inserts `'...'` entries or pins first/last anchors.
+2. The template renders an empty `<li>` for `'...'` entries (no visible ellipsis text, no `disabled` class).
+3. The datatable does not pass `numberOfBoxes` to its page-navigation pagination instance.
+
+## Two Usage Modes
+
+The `<bs-pagination>` component is mode-agnostic — it renders whatever `pageNumbers` array it receives. In practice there are two distinct usage patterns:
+
+### Mode A — Sequential page numbers (page navigation)
+
+```
+pageNumbers = [1, 2, 3, 4, ..., 99, 100]
+showArrows = true
+```
+
+Used in `<bs-datatable>` footer (right side) and standalone pagination demos. This is the mode that benefits from ellipsis and anchoring.
+
+### Mode B — Arbitrary page-size values (per-page selector)
+
+```
+pageNumbers = [10, 20, 50, 100, 200, 500, 1000]
+showArrows = false
+```
+
+Used in `<bs-datatable>` footer (left side) as an items-per-page picker. Typically has fewer than 10 values, so ellipsis is rarely needed. The algorithm must still work correctly — it operates on array indices, not on the semantic meaning of the numbers.
+
+## Requirements
+
+### No new inputs needed
+
+The existing `numberOfBoxes` input is sufficient. When `numberOfBoxes > 0`, the component will now show ellipsis and pin first/last anchors automatically. When `numberOfBoxes` is `0` (the default), all pages are shown — no change in behavior.
+
+### Box allocation algorithm
+
+When `numberOfBoxes > 0`, the component must decide which page numbers to show within the budget. The budget is `numberOfBoxes` (or `numberOfBoxes - 2` when `showArrows` is `true`, matching the existing `visibleNumberOfNumberBoxes` logic).
+
+Let `B` = effective budget of number boxes (after deducting arrows).
+
+**Allocation priority** (the order in which slots are filled as `B` increases):
+
+| Priority | Action | Rationale |
+|----------|--------|-----------|
+| 1 | Always show the **selected page** | User must see where they are |
+| 2 | Add pages **immediately left** of selected | Context around current position |
+| 3 | Add pages **immediately right** of selected | Context around current position |
+| 4 | Pin the **first page** (index 0) + left ellipsis | Orientation anchor — user can jump to start |
+| 5 | Pin the **last page** (last index) + right ellipsis | Orientation anchor — user can jump to end |
+| 6 | Continue expanding left/right neighbors alternately | Fill remaining budget |
+
+Ellipsis entries (`'...'`) consume one slot each in the budget. They appear between the anchor and the neighbor window when there is a gap of **2 or more** omitted pages. If the gap is exactly 1 page, show that page instead of an ellipsis (showing `1 2 3` is better than `1 ... 3`).
+
+### Rendering examples (sequential pages 1–100, selected = 50, effective budget shown)
+
+| Budget | Rendered boxes |
+|--------|---------------|
+| `0` | `1 2 3 ... 100` (all) |
+| `5` | `1 ... 50 ... 100` |
+| `7` | `1 ... 49 50 51 ... 100` |
+| `9` | `1 ... 48 49 50 51 52 ... 100` |
+| `11` | `1 ... 47 48 49 50 51 52 53 ... 100` |
+| `13` | `1 ... 46 47 48 49 50 51 52 53 54 ... 100` |
+
+Note: extra budget goes to expanding the inner neighbor window, not to expanding anchor segments. This maximizes context around the selected page.
+
+#### Edge cases — selected near boundaries (pages 1–100, budget = 9)
+
+| Selected | Rendered |
+|----------|----------|
+| `1` | `1 2 3 4 5 6 7 ... 100` |
+| `2` | `1 2 3 4 5 6 7 ... 100` |
+| `5` | `1 2 3 4 5 6 7 ... 100` |
+| `6` | `1 ... 4 5 6 7 8 ... 100` |
+| `95` | `1 ... 93 94 95 96 97 ... 100` |
+| `99` | `1 ... 94 95 96 97 98 99 100` |
+| `100` | `1 ... 94 95 96 97 98 99 100` |
+
+#### Edge case — small page count (pages 1–5, numberOfBoxes = 9)
+
+| Selected | Rendered |
+|----------|----------|
+| `3` | `1 2 3 4 5` |
+
+Budget exceeds page count — show all, no ellipsis.
+
+#### Edge case — page-size mode ([10, 20, 50, 100, 200, 500, 1000], numberOfBoxes = 5, selected = 100)
+
+| Rendered |
+|----------|
+| `10 ... 100 ... 1000` |
+
+The algorithm treats these as indices, same as sequential pages.
+
+### Template changes
+
+Update the existing broken ellipsis rendering to show a **disabled, non-clickable** ellipsis box:
+
+```html
+@if (pageNumber.page === '...') {
+    <a class="page-link disabled" aria-disabled="true">
+        <span aria-hidden="true">&hellip;</span>
+        <span class="visually-hidden">More pages</span>
+    </a>
+} @else {
+    <a class="page-link" href="" (click)="onSelectPage($event, pageNumber.page)" [class.active]="pageNumber.selected">
+        {{ pageNumber.page }}
+        @if (pageNumber.selected) {
+            <span class="visually-hidden">(current)</span>
+        }
+    </a>
+}
+```
+
+### Datatable integration
+
+Add `pageNumberOfBoxes` to `DatatableSettings` so consumers can configure it. Default to `11`. Pass it to the page-navigation pagination instance (right side) in `datatable.component.html`. The per-page selector (left side) remains unchanged.
+
+## Implementation Plan
+
+### Step 1 — Rewrite `shownPageNumbers()` computed signal
+
+Replace the current windowing logic with the ellipsis-aware allocation algorithm.
+
+### Step 2 — Update the template
+
+Fix the broken `'...'` rendering to show a visible, disabled ellipsis box with proper accessibility.
+
+### Step 3 — Clean up unused overflow signals
+
+Remove `isLeftOverflow()` and `isRightOverflow()` — the new `shownPageNumbers()` handles everything internally.
+
+### Step 4 — Integrate with datatable
+
+Add `pageNumberOfBoxes` to `DatatableSettings` (default `11`). Pass it to the page-navigation pagination.
+
+### Step 5 — Update demos
+
+Uncomment and fix the "Show ellipsis" demo section. Add a large page range demo (e.g. 1000 pages).
+
+## Out of Scope
+
+- Keyboard navigation within the pagination
+- "Jump to page" input field
+- Responsive breakpoint-based `numberOfBoxes`
+- Custom ellipsis templates
+
+## Backward Compatibility
+
+- `numberOfBoxes` defaults to `0` (show all) — **existing consumers see zero change**
+- Consumers already using `numberOfBoxes` will now get ellipsis + anchors instead of plain windowing — this is strictly an improvement

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable-settings.ts
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable-settings.ts
@@ -28,6 +28,7 @@ export class DatatableSettings {
     public sortColumns: SortColumn[] = [];
     public perPage: { values: number[], selected: number };
     public page: { values: number[], selected: number };
+    public pageNumberOfBoxes: number = 11;
 
     public toPagination() {
         const res = <PaginationRequest>{

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.html
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.html
@@ -34,7 +34,7 @@
                                 [showArrows]="false"></bs-pagination>
                             <bs-pagination class="float-end" [pageNumbers]="settings().page.values"
                                 [selectedPageNumber]="settings().page.selected" (selectedPageNumberChange)="onPageChange($event)"
-                                [showArrows]="true"></bs-pagination>
+                                [showArrows]="true" [numberOfBoxes]="settings().pageNumberOfBoxes"></bs-pagination>
                         </div>
                     </div>
                 </bs-grid>

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.12.11",
+  "version": "21.12.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-bootstrap/pagination/src/component/pagination/pagination.component.html
+++ b/libs/mintplayer-ng-bootstrap/pagination/src/component/pagination/pagination.component.html
@@ -7,9 +7,14 @@
             </a>
         </li>
     }
-    @for (pageNumber of shownPageNumbers(); track pageNumber.page) {
+    @for (pageNumber of shownPageNumbers(); track $index) {
         <li class="page-item">
-            @if (pageNumber.page != '...') {
+            @if (pageNumber.page === '...') {
+                <a class="page-link disabled" aria-disabled="true">
+                    <span aria-hidden="true">&hellip;</span>
+                    <span class="visually-hidden">More pages</span>
+                </a>
+            } @else {
                 <a class="page-link" href="" (click)="onSelectPage($event, pageNumber.page)" [class.active]="pageNumber.selected">
                     {{ pageNumber.page }}
                     @if (pageNumber.selected) {

--- a/libs/mintplayer-ng-bootstrap/pagination/src/component/pagination/pagination.component.ts
+++ b/libs/mintplayer-ng-bootstrap/pagination/src/component/pagination/pagination.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
 import { Size } from '@mintplayer/ng-bootstrap';
 import { PageWithSelection } from '../../interfaces/page-with-selection';
+import { PageNumberType } from '../../types/page-number.type';
 
 @Component({
   selector: 'bs-pagination',
@@ -148,8 +149,10 @@ export class BsPaginationComponent {
     return pageNumbers.indexOf(selectedPageNumber) === pageNumbers.length - 1;
   });
 
-  onSelectPage(event: MouseEvent, page: number) {
-    this.selectedPageNumber.set(page);
+  onSelectPage(event: MouseEvent, page: PageNumberType) {
+    if (typeof page === 'number') {
+      this.selectedPageNumber.set(page);
+    }
     return false;
   }
 

--- a/libs/mintplayer-ng-bootstrap/pagination/src/component/pagination/pagination.component.ts
+++ b/libs/mintplayer-ng-bootstrap/pagination/src/component/pagination/pagination.component.ts
@@ -36,51 +36,102 @@ export class BsPaginationComponent {
     }
   });
 
-  /** Indicates whether there are too many numbers to the left-hand side of the current page. */
-  isLeftOverflow = computed(() => {
-    const pageNumbers = this.pageNumbers();
-    const selectedPageNumber = this.selectedPageNumber();
-    const visibleNumberOfNumberBoxes = this.visibleNumberOfNumberBoxes();
-    const index = pageNumbers.indexOf(selectedPageNumber);
-    const middle = Math.floor(visibleNumberOfNumberBoxes / 2);
-    return index > middle;
-  });
-
-  /** Indicates whether there are too many numbers to the right-hand side of the current page. */
-  isRightOverflow = computed(() => {
-    const pageNumbers = this.pageNumbers();
-    const selectedPageNumber = this.selectedPageNumber();
-    const visibleNumberOfNumberBoxes = this.visibleNumberOfNumberBoxes();
-    const index = pageNumbers.indexOf(selectedPageNumber);
-    const middle = Math.floor(visibleNumberOfNumberBoxes / 2);
-    return (pageNumbers.length - index) < middle;
-  });
-
-  /** Page numbers to be displayed to the user. */
+  /** Page numbers to be displayed to the user, with ellipsis entries where pages are omitted. */
   shownPageNumbers = computed<PageWithSelection[]>(() => {
     const pageNumbers = this.pageNumbers();
     const selectedPageNumber = this.selectedPageNumber();
-    const visibleNumberOfNumberBoxes = this.visibleNumberOfNumberBoxes();
+    const budget = this.visibleNumberOfNumberBoxes();
 
-    let startIndex = 0;
-    const half = Math.round((visibleNumberOfNumberBoxes - 1) / 2);
-    if (pageNumbers.indexOf(selectedPageNumber) < half) {
-      startIndex = 0;
-    } else if (
-      pageNumbers.indexOf(selectedPageNumber) >=
-      pageNumbers.length - half
-    ) {
-      startIndex = pageNumbers.length - visibleNumberOfNumberBoxes;
-    } else {
-      startIndex = pageNumbers.indexOf(selectedPageNumber) - half;
+    // No truncation needed
+    if (budget <= 0 || budget >= pageNumbers.length) {
+      return pageNumbers.map((p) => <PageWithSelection>{
+        page: p,
+        selected: p === selectedPageNumber,
+      });
     }
 
-    return [...Array(visibleNumberOfNumberBoxes).keys()]
-      .map((p) => p + startIndex)
-      .map((p) => <PageWithSelection>{
-        page: pageNumbers[p],
-        selected: pageNumbers[p] === selectedPageNumber,
+    const selectedIndex = Math.max(0, Math.min(
+      pageNumbers.indexOf(selectedPageNumber),
+      pageNumbers.length - 1
+    ));
+    const lastIndex = pageNumbers.length - 1;
+
+    // Centers a window of the given size on selectedIndex, clamped to valid range
+    const calcWindow = (size: number): [number, number] => {
+      const half = Math.floor((size - 1) / 2);
+      let ws = selectedIndex - half;
+      let we = ws + size - 1;
+      if (ws < 0) { we = Math.min(lastIndex, we - ws); ws = 0; }
+      if (we > lastIndex) { ws = Math.max(0, ws - (we - lastIndex)); we = lastIndex; }
+      return [ws, we];
+    };
+
+    // For small budgets (< 5), just show a centered window — not enough room for anchors + ellipsis
+    if (budget < 5) {
+      const [ws, we] = calcWindow(budget);
+      return Array.from({ length: we - ws + 1 }, (_, i) => <PageWithSelection>{
+        page: pageNumbers[ws + i],
+        selected: pageNumbers[ws + i] === selectedPageNumber,
       });
+    }
+
+    // For budget >= 5: reserve slots for first/last anchors and ellipsis, then fill the inner window.
+    // Overhead per side: 0 (window reaches edge), 1 (window is 1 away from edge), or 2 (anchor + ellipsis/bridge).
+    // Iterate until stable — converges in 2–4 iterations.
+    let leftOverhead = 2;
+    let rightOverhead = 2;
+    let windowStart = 0;
+    let windowEnd = 0;
+
+    for (let iteration = 0; iteration < 4; iteration++) {
+      const innerBudget = Math.max(1, budget - leftOverhead - rightOverhead);
+      [windowStart, windowEnd] = calcWindow(innerBudget);
+
+      const newLeftOverhead = windowStart === 0 ? 0 : windowStart === 1 ? 1 : 2;
+      const newRightOverhead = windowEnd === lastIndex ? 0 : windowEnd === lastIndex - 1 ? 1 : 2;
+
+      if (newLeftOverhead === leftOverhead && newRightOverhead === rightOverhead) break;
+      leftOverhead = newLeftOverhead;
+      rightOverhead = newRightOverhead;
+    }
+
+    // Build result
+    const result: PageWithSelection[] = [];
+    const pushPage = (index: number) => {
+      result.push(<PageWithSelection>{
+        page: pageNumbers[index],
+        selected: pageNumbers[index] === selectedPageNumber,
+      });
+    };
+
+    // Left anchor or bridge
+    if (windowStart >= 3) {
+      pushPage(0);
+      result.push({ page: '...', selected: false });
+    } else if (windowStart === 2) {
+      pushPage(0);
+      pushPage(1);
+    } else if (windowStart === 1) {
+      pushPage(0);
+    }
+
+    // Inner window
+    for (let i = windowStart; i <= windowEnd; i++) {
+      pushPage(i);
+    }
+
+    // Right bridge or anchor
+    if (windowEnd <= lastIndex - 3) {
+      result.push({ page: '...', selected: false });
+      pushPage(lastIndex);
+    } else if (windowEnd === lastIndex - 2) {
+      pushPage(lastIndex - 1);
+      pushPage(lastIndex);
+    } else if (windowEnd === lastIndex - 1) {
+      pushPage(lastIndex);
+    }
+
+    return result;
   });
 
   /** Indicates if first value is selected. */


### PR DESCRIPTION
## Summary
- Completes the half-built ellipsis feature in `<bs-pagination>`. When `numberOfBoxes > 0`, the component now pins first/last page anchors, centers the selected page in an inner window, and inserts disabled `…` indicators where pages are omitted.
- Bridges single-page gaps with the actual page number instead of ellipsis (e.g. `1 2 3` not `1 … 3`).
- Integrates `numberOfBoxes` into `<bs-datatable>` via a new `pageNumberOfBoxes` setting (default `11`) so large datasets no longer blow out the table width.
- Adds a 1000-page demo to the pagination page.
- Bumps `@mintplayer/ng-bootstrap` to `21.12.12`.

## Test plan
- [ ] Verify the pagination demo page renders correctly with ellipsis for the 1000-page example
- [ ] Click through pages near the start, middle, and end — confirm the selected page stays centered and anchors/ellipsis update correctly
- [ ] Verify existing pagination examples (basic, no arrows, range, max box count) still work unchanged
- [ ] Verify the datatable page shows ellipsis on the page-navigation pagination when there are many pages
- [ ] Verify the per-page selector (left pagination in datatable) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)