### PR TITLE
feat(priority-nav): Add priority navigation component

### DIFF
--- a/apps/ng-bootstrap-demo/src/app/app.component.html
+++ b/apps/ng-bootstrap-demo/src/app/app.component.html
@@ -230,6 +230,9 @@
           <a [routerLink]='["/advanced", "parallax"]'>Parallax</a>
         </bs-navbar-item>
         <bs-navbar-item>
+          <a [routerLink]='["/advanced", "priority-nav"]'>Priority navigation</a>
+        </bs-navbar-item>
+        <bs-navbar-item>
           <a [routerLink]='["/advanced", "scrollspy"]'>Scrollspy</a>
         </bs-navbar-item>
         <bs-navbar-item>

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/advanced.routes.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/advanced.routes.ts
@@ -10,6 +10,7 @@ export const ROUTES: Routes = [
   { path: 'autofocus', loadComponent: () => import('./autofocus/autofocus.component').then(m => m.AutofocusComponent) },
   { path: 'scrollspy', loadComponent: () => import('./scrollspy/scrollspy.component').then(m => m.ScrollspyComponent) },
   { path: 'parallax', loadComponent: () => import('./parallax/parallax.component').then(m => m.ParallaxComponent) },
+  { path: 'priority-nav', loadComponent: () => import('./priority-nav/priority-nav.component').then(m => m.PriorityNavComponent) },
   { path: 'code-snippet', loadComponent: () => import('./code-snippet/code-snippet.component').then(m => m.CodeSnippetComponent) },
   { path: 'scheduler', loadComponent: () => import('./scheduler/scheduler.component').then(m => m.SchedulerComponent) },
   { path: 'user-agent', loadComponent: () => import('./user-agent/user-agent.component').then(m => m.UserAgentComponent) },

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.html
@@ -1,0 +1,45 @@
+<h1 class="text-center">Priority navigation</h1>
+
+<p class="lead">
+    A horizontal navigation that keeps as many items visible as fit. Lower-priority items
+    move into a "More" overlay when there isn't enough room. Works without JavaScript via
+    a checkbox + media-query fallback.
+</p>
+
+<h2>Resize me</h2>
+<p>Drag the handle on the right to shrink the container and watch items move into the More menu.</p>
+<bs-resizable>
+    <div class="p-2 demo-box">
+        <bs-priority-nav>
+            @for (link of links; track link.label) {
+                <a *bsPriorityNavItem="link.priority; hideBelow: link.hideBelow"
+                   class="demo-link"
+                   href="#">
+                    {{ link.label }}
+                </a>
+            }
+        </bs-priority-nav>
+    </div>
+</bs-resizable>
+
+<h2 class="mt-4">collapseAt='sm'</h2>
+<p>At sm-and-below the entire strip collapses into the More menu.</p>
+<div class="p-2 demo-box">
+    <bs-priority-nav [collapseAt]="'sm'">
+        @for (link of links; track link.label) {
+            <a *bsPriorityNavItem="link.priority"
+               class="demo-link"
+               href="#">{{ link.label }}</a>
+        }
+    </bs-priority-nav>
+</div>
+
+<h2 class="mt-4">Noscript fallback</h2>
+<p>
+    Open DevTools, disable JavaScript, and reload the page. The strip continues to work:
+</p>
+<ul>
+    <li>Items hide via CSS media queries based on each item's <code>hideBelow</code> input.</li>
+    <li>The "More" toggle is a <code>&lt;label&gt;</code> tied to a hidden <code>&lt;input type="checkbox"&gt;</code>.</li>
+    <li>The overflow menu shows via the <code>:checked</code> sibling selector — purely CSS.</li>
+</ul>

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.html
@@ -8,7 +8,7 @@
 
 <h2>Resize me</h2>
 <p>Drag the handle on the right to shrink the container and watch items move into the More menu.</p>
-<bs-resizable>
+<bs-resizable [vertical]="false" [corners]="false">
     <div class="p-2 demo-box">
         <bs-priority-nav>
             @for (link of links; track link.label) {

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.scss
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.scss
@@ -1,0 +1,18 @@
+.demo-box {
+    border: 1px solid var(--bs-border-color, #ccc);
+    border-radius: 0.375rem;
+    background: var(--bs-body-bg, #fff);
+}
+
+.demo-link {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    color: var(--bs-link-color, #0d6efd);
+    text-decoration: none;
+    white-space: nowrap;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.spec.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { PriorityNavComponent } from './priority-nav.component';
+
+describe('PriorityNavComponent (demo)', () => {
+  let fixture: ComponentFixture<PriorityNavComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PriorityNavComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PriorityNavComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.ts
@@ -1,0 +1,27 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { BsPriorityNavComponent, BsPriorityNavItemDirective } from '@mintplayer/ng-bootstrap/priority-nav';
+import { BsResizableComponent } from '@mintplayer/ng-bootstrap/resizable';
+
+@Component({
+  selector: 'demo-priority-nav',
+  templateUrl: './priority-nav.component.html',
+  styleUrls: ['./priority-nav.component.scss'],
+  imports: [
+    BsPriorityNavComponent,
+    BsPriorityNavItemDirective,
+    BsResizableComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PriorityNavComponent {
+  links = [
+    { label: 'Home',     priority: 1, hideBelow: 'sm' as const },
+    { label: 'Products', priority: 2, hideBelow: 'md' as const },
+    { label: 'Services', priority: 3, hideBelow: 'md' as const },
+    { label: 'Pricing',  priority: 4, hideBelow: 'lg' as const },
+    { label: 'Blog',     priority: 5, hideBelow: 'lg' as const },
+    { label: 'Careers',  priority: 6, hideBelow: 'xl' as const },
+    { label: 'Support',  priority: 7, hideBelow: 'xl' as const },
+    { label: 'Contact',  priority: 8, hideBelow: 'xl' as const },
+  ];
+}

--- a/docs/prd/priority-navigation.md
+++ b/docs/prd/priority-navigation.md
@@ -1,0 +1,338 @@
+# PRD: Priority Navigation
+
+Tracking issue: [#196 — Priority Navigation](https://github.com/MintPlayer/mintplayer-ng-bootstrap/issues/196)
+
+## Problem
+
+Horizontal navigation bars and toolbars often contain more items than fit in the available width on small or narrow viewports. The two common workarounds are both poor UX:
+
+- **Hide everything behind a hamburger.** Wastes horizontal space when most items would have fit. Hides the most-used links unnecessarily.
+- **Wrap to a second row.** Disrupts layout, doubles the navbar height, and hurts vertical density on dense pages.
+
+The **priority navigation** pattern (a.k.a. *greedy nav*, *progressively-collapsing menu*) solves this: as many items as possible stay visible inline; the rest move into a "More ▾" overflow menu. As the container shrinks, lower-priority items move into the overflow first; as it grows, they move back out.
+
+The library already ships a JS-driven `bs-navbar` with a single small-mode breakpoint, but it has no concept of *individual item priority* and no pattern for "fit as many as possible". It is also strictly all-or-nothing — there is no progressive collapse.
+
+## Goal
+
+Ship a **generic, content-projection-based** `bs-priority-nav` component that:
+
+1. Works as a container for arbitrary items — links, buttons, labels, even nested dropdowns.
+2. Hides lower-priority items into a "More" overlay as soon as they would overflow, and restores them when there is room again.
+3. **Stays functional with JavaScript disabled** (noscript / SSR-only browsers / hardened environments) using the same `<input>` + `<label>` + CSS-only pattern already proven by `bs-carousel`, `bs-tab-control`, and `bs-accordion`.
+4. Adds an "Advanced → Priority navigation" demo page in `apps/ng-bootstrap-demo` that exercises the JS path *and* the noscript fallback side-by-side.
+
+Non-goal: replace `bs-navbar`. Priority nav is a smaller, more focused primitive that *can* be used inside a navbar but is also useful for toolbars, breadcrumb trails, tab strips, action bars, etc.
+
+## Reference Patterns Already in the Repo
+
+| Pattern | Location | What we reuse |
+|---|---|---|
+| Dual-branch SSR template (`@if (isServerSide)`) | `libs/mintplayer-ng-bootstrap/carousel/src/carousel/carousel.component.html:1` | Same shape for the noscript fallback branch |
+| `bsNoNoscript` directive (sets `.noscript` class on server only) | `libs/mintplayer-ng-bootstrap/no-noscript/src/no-noscript/no-noscript.directive.ts:1` | Marks inputs whose CSS-only behavior is gated on `.noscript` |
+| `<input type="radio/checkbox">` + `<label [for]>` + `:checked` siblings | `carousel.component.html:7-32`, `tab-control.component.html` (per `docs/prd/tab-control-noscript.md`) | "More" toggle without JS |
+| `isPlatformServer(PLATFORM_ID)` for SSR detection | `carousel.component.ts:30,34` | Same |
+| `contentChildren()` + signal `forwardRef` for child registration | `carousel.component.ts:36` | Item registration |
+| `BsObserveSizeDirective` (`bsObserveSize`, exports as `bsObserveSize`) | `libs/mintplayer-ng-swiper/observe-size/src/observe-size.directive.ts:1` | Container width measurement in JS mode — exposes `size`, `width`, `height` signals; SSR-safe; cleans up its own observer |
+
+## Public API
+
+### Container — `<bs-priority-nav>`
+
+```html
+<bs-priority-nav
+    [moreLabel]="'More'"
+    [moreLabelTemplate]="moreTpl"
+    [collapseAt]="null"
+    [overflowFrom]="'end'"
+    [hideEmptyMore]="true"
+    (overflowChange)="onOverflowChange($event)">
+    ...items...
+</bs-priority-nav>
+```
+
+| Input | Type | Default | Purpose |
+|---|---|---|---|
+| `moreLabel` | `string` | `'More'` | Text on the overflow toggle. Ignored when `moreLabelTemplate` is set. |
+| `moreLabelTemplate` | `TemplateRef<{ $implicit: boolean }> \| null` | `null` | Template for the overflow toggle. Implicit context is the open/closed state. |
+| `collapseAt` | `Breakpoint \| null` | `null` | When set (e.g. `'sm'`), at this breakpoint and below **all** items collapse to the More menu regardless of measured width. Mirrors `bs-navbar.breakpoint`. |
+| `overflowFrom` | `'end' \| 'start'` | `'end'` | Which side gives way first when space runs out. `'end'` = last item moves to More first. |
+| `hideEmptyMore` | `boolean` | `true` | Hide the "More" toggle when no items overflow. |
+
+| Output | Type | Fires when |
+|---|---|---|
+| `overflowChange` | `EventEmitter<BsPriorityNavItemDirective[]>` | The set of overflowing items changes. Useful for analytics or syncing external UI. |
+
+### Item — `<bs-priority-nav-item>` (component, content-projecting)
+
+```html
+<bs-priority-nav-item [priority]="1" [hideBelow]="'md'">
+    <a [routerLink]="['/home']">Home</a>
+</bs-priority-nav-item>
+```
+
+| Input | Type | Default | Purpose |
+|---|---|---|---|
+| `priority` | `number` | declaration order (last-declared = first to overflow) | Order in which items move into the More menu. **Lower number = more important, stays visible longer.** Items without a priority are treated as least important and overflow before any prioritized item. Items with equal priority follow declaration order. |
+| `hideBelow` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'xxl' \| null` | `null` | **Noscript-only hint.** At this breakpoint and below, the item is hidden from the inline strip and shown only via the More menu. Ignored when JS is active (measured width wins). |
+
+The item exposes a single `<ng-content>` slot. Whatever the consumer puts inside is what is rendered — anchors, buttons, dropdowns, even arbitrary HTML. This is the "as generic as possible" requirement.
+
+## Behavior — JS Mode (the happy path)
+
+1. The inline strip's wrapper element carries `bsObserveSize` (`#sizeObserver="bsObserveSize"`). Its `width` signal feeds a `computed` that recalculates the overflow set whenever the container resizes — no manual `ResizeObserver` wiring, no `throttleDelay` plumbing inside the component (the directive already handles SSR-safety and cleanup).
+2. The recalc walks items in priority order from highest to lowest, summing widths plus a running reservation for the More toggle. The first item whose accumulated width would exceed the container becomes the **overflow boundary**. That item and every lower-priority item are marked overflowing.
+3. Per-item width changes (lazy text, async data, font swap) — give each `bs-priority-nav-item` its own `bsObserveSize` and read `width()` from the parent's `computed`. Same primitive, same signal API.
+4. Items are not actually relocated in the DOM. The component renders **two copies** of each item:
+   - One in the inline strip with `[class.priority-nav-hidden]` toggled.
+   - One inside the More overlay with `[class.priority-nav-overflow-hidden]` toggled.
+   The hidden copy is `display: none`. This avoids breaking content-projection inputs/outputs that would die under DOM moves, and makes the noscript path almost identical to the JS path (see below).
+3. The More toggle is a `<button bsDropdownToggle>` opening a `bs-dropdown-menu` rendering the overflow copies. Reuses the existing `dropdown` library rather than rolling a custom overlay.
+4. `(overflowChange)` fires whenever the visibility set changes.
+
+### Edge cases
+
+- **Container is zero-width during SSR** → `bsObserveSize` already noops on the server (`isPlatformServer` guard at `observe-size.directive.ts:16`). The `computed` overflow signal sees `width() === undefined` and falls back to "show all items inline"; the recalc fires naturally on hydration when the directive's `ngAfterViewInit` sets the initial `size`.
+- **Nested dropdowns inside an item** → not measured separately; the item's natural width includes its toggle but not its open menu (which is portaled).
+- **`collapseAt` matches** → skip measurement entirely, set every item to overflow.
+- **Overflow toggle itself overflows on tiny viewports** → it has `flex-shrink: 0` and is allowed to truncate its label via CSS, but is never moved into itself.
+
+## Behavior — Noscript Mode (the fallback)
+
+The fundamental constraint: without JS we cannot measure the container or the items. The fallback therefore replaces *measured* overflow with *declared* overflow via the `hideBelow` input plus media queries.
+
+### Rendering shape (SSR + noscript)
+
+```html
+<div class="priority-nav noscript" bsNoNoscript>
+    <input type="checkbox" id="pn-{{uid}}-more" class="d-none" bsNoNoscript>
+
+    <ul class="priority-nav-inline">
+        <li class="priority-nav-item priority-nav-item-hide-below-md">
+            <a [routerLink]="['/home']">Home</a>
+        </li>
+        <li class="priority-nav-item priority-nav-item-hide-below-lg">
+            <a [routerLink]="['/products']">Products</a>
+        </li>
+        ...
+    </ul>
+
+    <label [for]="'pn-' + uid + '-more'" class="priority-nav-more-toggle" role="button" tabindex="0">
+        More <span class="caret"></span>
+    </label>
+
+    <div class="priority-nav-overflow">
+        <ul>
+            <li class="priority-nav-item priority-nav-item-show-below-md">
+                <a [routerLink]="['/home']">Home</a>
+            </li>
+            ...
+        </ul>
+    </div>
+</div>
+```
+
+### CSS rules (in `priority-nav.component.scss`)
+
+```scss
+:host ::ng-deep {
+    .priority-nav.noscript {
+        // Inline strip: hide items at-or-below their breakpoint
+        .priority-nav-item-hide-below-sm  { @media (max-width: 575.98px)  { display: none !important; } }
+        .priority-nav-item-hide-below-md  { @media (max-width: 767.98px)  { display: none !important; } }
+        .priority-nav-item-hide-below-lg  { @media (max-width: 991.98px)  { display: none !important; } }
+        .priority-nav-item-hide-below-xl  { @media (max-width: 1199.98px) { display: none !important; } }
+        .priority-nav-item-hide-below-xxl { @media (max-width: 1399.98px) { display: none !important; } }
+
+        // Overflow menu: only show items that ARE hidden inline at the current width
+        .priority-nav-overflow .priority-nav-item-show-below-sm  { display: none; @media (max-width: 575.98px)  { display: block; } }
+        .priority-nav-overflow .priority-nav-item-show-below-md  { display: none; @media (max-width: 767.98px)  { display: block; } }
+        // ...etc
+
+        // CSS-only "More" toggle
+        .priority-nav-overflow { display: none; }
+        input.noscript:checked ~ .priority-nav-overflow { display: block; }
+    }
+}
+```
+
+The `:host-context` plus `.noscript` class gates these rules so they don't fight the JS path (which uses `[class.priority-nav-hidden]` instead).
+
+### Noscript flow
+
+1. Page loads. SSR HTML is the dual-render shape above. `bsNoNoscript` puts `.noscript` on both the host and the checkbox.
+2. The browser applies media queries → low-priority items hidden inline; their twins in `.priority-nav-overflow` are display-block-eligible.
+3. User clicks the **`<label for="pn-…-more">`** — browser natively toggles the hidden checkbox.
+4. Sibling selector `input.noscript:checked ~ .priority-nav-overflow { display: block; }` reveals the overflow menu.
+5. User clicks an item → native link navigation works, no JS needed.
+
+### Hydration handoff
+
+When the JS bundle takes over:
+
+1. The `BsPriorityNavComponent` constructor checks `isPlatformServer` → on the client it removes the `.noscript` class on the host.
+2. CSS rules under `.priority-nav.noscript` stop applying.
+3. The component starts measuring and toggling `[class.priority-nav-hidden]` instead.
+4. The hidden checkbox is repurposed: clicking the More label now goes through Angular's `(click)` handler (with `event.preventDefault()`) and toggles a signal-driven dropdown, just like `bs-tab-control` does in its noscript handoff.
+
+## Demo Page — `Advanced → Priority navigation`
+
+### Files
+
+- `apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.ts`
+- `apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.html`
+- `apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.scss`
+- `apps/ng-bootstrap-demo/src/app/pages/advanced/priority-nav/priority-nav.component.spec.ts`
+
+### Routing & menu registration
+
+- Add to `apps/ng-bootstrap-demo/src/app/pages/advanced/advanced.routes.ts:32` (alphabetical position between `parallax` and `resizable` works):
+
+  ```ts
+  { path: 'priority-nav', loadComponent: () => import('./priority-nav/priority-nav.component').then(m => m.PriorityNavComponent) },
+  ```
+
+- Add a navbar entry to `apps/ng-bootstrap-demo/src/app/app.component.html:230` (next to `Parallax`):
+
+  ```html
+  <bs-navbar-item>
+      <a [routerLink]='["/advanced", "priority-nav"]'>Priority navigation</a>
+  </bs-navbar-item>
+  ```
+
+### Demo page content
+
+Three sections, following the `bs-parallax` / `bs-dock` precedent (h1 + freeform sections):
+
+1. **Default** — 8–10 items with mixed priorities, wrapped in a resizable container so the user can drag it narrower and watch items move into "More" in real time. Use `bs-resizable` from `apps/ng-bootstrap-demo/src/app/pages/advanced/resizable/`.
+2. **With `collapseAt='sm'`** — same items, but at sm-and-below the whole strip becomes a hamburger-style More menu.
+3. **Noscript demo** — embed an `<iframe srcdoc="...">` rendering the same nav with `<base href>` and `<noscript>` instructions, OR (simpler) include a paragraph with: *"Disable JS in DevTools and reload this page — the strip continues to work via media-query-driven hiding and a checkbox-based More toggle."* Plus a side-by-side static screenshot pair.
+
+The demo component itself uses `BsPriorityNavComponent`, `BsPriorityNavItemComponent`, and a `BsResizableDirective` — no other imports needed.
+
+## Library Files
+
+```
+libs/mintplayer-ng-bootstrap/priority-nav/
+├── index.ts
+├── ng-package.json
+├── package.json
+├── project.json
+├── README.md
+├── tsconfig.lib.json
+├── tsconfig.lib.prod.json
+├── tsconfig.spec.json
+└── src/
+    ├── index.ts
+    ├── priority-nav/
+    │   ├── priority-nav.component.ts
+    │   ├── priority-nav.component.html
+    │   ├── priority-nav.component.scss
+    │   └── priority-nav.component.spec.ts
+    └── priority-nav-item/
+        ├── priority-nav-item.component.ts
+        ├── priority-nav-item.component.html   (just `<ng-content></ng-content>`)
+        ├── priority-nav-item.component.scss   (empty or minimal)
+        └── priority-nav-item.component.spec.ts
+```
+
+Use the `libs/mintplayer-ng-bootstrap/carousel/` package as the structural template. Both `BsPriorityNavComponent` and `BsPriorityNavItemComponent` are standalone, OnPush, signal-based.
+
+## Implementation Plan
+
+### Step 1 — Scaffold the library package
+
+Mirror the `carousel` package layout. Wire it into `tsconfig.base.json` paths and the workspace `nx.json` if needed.
+
+### Step 2 — Implement `BsPriorityNavItemComponent`
+
+Trivial: a standalone component with `@ng-content`, `priority` input (default `Infinity` so unset items are last to overflow), `hideBelow` input. Exposes its `ElementRef` for parent measurement.
+
+### Step 3 — Implement `BsPriorityNavComponent` — noscript branch first
+
+Build the SSR template. Verify that with JS disabled in the browser:
+- Items above their `hideBelow` show inline.
+- Items below their `hideBelow` show only inside the More overlay.
+- The label/checkbox toggle reveals/hides the overlay.
+- Clicking a link navigates.
+
+### Step 4 — Implement the JS branch
+
+- Inject `PLATFORM_ID`, set `isServerSide`.
+- Apply `bsObserveSize` to the inline strip wrapper (`#stripSize="bsObserveSize"`) and to each `bs-priority-nav-item` host. Pull both into the parent component via `viewChild` / `contentChildren`.
+- `computed` signal `overflowingItems` that reads `stripSize.width()` and each item's `width()`, walks items by priority, and returns the overflow set. No manual subscriptions; signal graph drives recompute.
+- Bind `[class.priority-nav-hidden]` on inline copies and `[class.priority-nav-overflow-hidden]` on overflow copies.
+- More toggle: button + click handler that flips an `isMoreOpen` signal; `(document:click)` to close on outside click.
+- Emit `(overflowChange)` from an `effect` on `overflowingItems`.
+
+### Step 5 — Demo page
+
+Build the three sections described above. Verify in the dev server with throttling and viewport resizing.
+
+### Step 6 — Tests
+
+Per existing convention (`*.component.spec.ts` per component) — at minimum:
+- Renders with no items.
+- Renders with N items, all visible when container is wide.
+- Items hide in priority order when container shrinks. Stub `BsObserveSizeDirective` the same way `sticky-footer.component.spec.ts:8-19` does — replace with a directive whose `width`/`height` signals can be set imperatively.
+- `collapseAt='sm'` hides everything inline and shows everything in More.
+- `bsNoNoscript` adds `.noscript` class during SSR.
+
+## Out of Scope
+
+- **Animated transitions** when items move between inline and More. Phase 2.
+- **Drag-to-reorder priorities at runtime.** Not relevant to the use case.
+- **Auto-priority based on item visit frequency** (the original "Greedy Nav" extension). Phase 2.
+- **RTL-specific overflow direction.** `overflowFrom='start'` covers it conceptually but no special CSS.
+- **Migrating `bs-navbar` to use priority nav internally.** Possible follow-up; tracked separately.
+- **Keyboard shortcut** to open the More menu. Standard Tab navigation is enough for v1.
+
+## Backward Compatibility
+
+New library package. Zero risk to existing components. The new demo page is additive.
+
+## Issues Uncovered During Browser Verification
+
+Two layout bugs surfaced when exercising the demo at narrow viewports (≤500px). Both are fixed; documenting them here so the constraints behind the fixes don't get reintroduced.
+
+### 1. Off-screen measure strip extended `document.scrollWidth`
+
+**Symptom:** A horizontal scrollbar appeared at narrow viewports even though no visible content overflowed. Probing the DOM showed `.priority-nav-measure` (the off-screen strip used to read each item's natural width) sitting at `left: 0; top: -9999px` with content widening to ~688px on a 485px viewport, dragging `document.scrollWidth` past `clientWidth`.
+
+**Root cause:** `top: -9999px` removes the element from the visible viewport but **does not** remove it from the document's scrollable bounds. The measure strip's full intrinsic width (sum of all items + their padding/gaps) was contributing to the page's horizontal scroll area.
+
+**Fix:** Wrap the measure strip in a zero-size `overflow: hidden` clip box. The wrapper occupies no layout space and clips everything inside it from both visual rendering and `scrollWidth`/`scrollHeight` calculations. Items inside the strip still render at natural width — so `bsObserveSize` keeps reporting accurate widths — but they are now invisible to the document's scroll bounds.
+
+```scss
+.priority-nav-measure-wrapper {
+    position: absolute;
+    top: 0; left: 0;
+    width: 0; height: 0;
+    overflow: hidden;
+    pointer-events: none;
+}
+.priority-nav-measure {
+    visibility: hidden;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+}
+```
+
+**Constraint to preserve:** any future change to the measure strip must keep it inside the zero-size clip wrapper. Switching back to a bare `position: absolute; top: -9999px` will reintroduce the scrollbar.
+
+### 2. `.demo-box { height: 100% }` made the second demo absurdly tall
+
+**Symptom:** The `.demo-box` under `collapseAt='sm'` rendered at 790px tall while its inner `<bs-priority-nav>` was 40px. The first demo (wrapped in `<bs-resizable>`) looked fine.
+
+**Root cause:** The demo SCSS had `.demo-box { height: 100% }`. The first demo's `.demo-box` is inside `<bs-resizable>` (which has `min-height: 2rem` and otherwise sizes to content), so 100% resolved to a small content-driven height. The second demo's `.demo-box` is a direct child of the page's flex layout, so 100% resolved to 100% of the available column height — ~790px.
+
+**Fix:** Remove `height: 100%` from `.demo-box`. Both demos now size to their content. `<bs-resizable>` in inline mode (the default used by the first demo) only enforces `min-height: 2rem` — it does **not** require its child to fill it.
+
+**Constraint to preserve:** the demo-box should not assume any specific height. If a future demo needs a fixed-height container (e.g. to demonstrate vertical resizing), it should set the height explicitly on that demo's wrapper, not on `.demo-box`.
+
+## Open Questions
+
+1. ~~Should `priority` default to declaration order (later items overflow first) or to `0` (all-equal, declaration order tiebreak)?~~ **Resolved:** unset priority means "least important, overflows first." Explicit numeric priorities use lower=more-important so `priority: 1` reads as "highest priority, stays visible." Tiebreaker by declaration order.
+2. Should the noscript More overlay duplicate items (two DOM nodes per item) or use CSS `:has()` to retarget the same node? **Recommendation:** duplicate. `:has()` browser support is fine in 2026 but the markup gets harder to reason about, and JS mode benefits from the duplication too.
+3. Should the More toggle support a custom-styled button via `[moreLabelTemplate]` even in noscript mode? **Yes** — the template projects into both the JS button and the noscript label; the directive doesn't care which element renders it.

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.12.12",
+  "version": "21.12.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.12.13",
+  "version": "21.13.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-bootstrap/priority-nav/index.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/libs/mintplayer-ng-bootstrap/priority-nav/ng-package.json
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+        "entryFile": "index.ts"
+    }
+}

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/index.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/index.ts
@@ -1,0 +1,2 @@
+export * from './priority-nav/priority-nav.component';
+export * from './priority-nav-item/priority-nav-item.directive';

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.spec.ts
@@ -21,10 +21,10 @@ describe('BsPriorityNavItemDirective', () => {
 
     const items = fixture.componentInstance.items.toArray();
     expect(items.length).toBe(2);
-    expect(items[0].priority).toBe(5);
-    expect(items[0].hideBelow).toBe('md');
-    expect(items[1].priority).toBeNull();
-    expect(items[1].hideBelow).toBeNull();
+    expect(items[0].priority()).toBe(5);
+    expect(items[0].hideBelow()).toBe('md');
+    expect(items[1].priority()).toBeNull();
+    expect(items[1].hideBelow()).toBeNull();
   });
 
   it('assigns unique ids', () => {

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.spec.ts
@@ -1,0 +1,37 @@
+import { Component, ViewChildren, QueryList } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { BsPriorityNavItemDirective } from './priority-nav-item.directive';
+
+@Component({
+  selector: 'priority-nav-item-test',
+  imports: [BsPriorityNavItemDirective],
+  template: `
+    <a *bsPriorityNavItem="5; hideBelow: 'md'" href="#x">X</a>
+    <a *bsPriorityNavItem href="#y">Y</a>
+  `,
+})
+class TestHostComponent {
+  @ViewChildren(BsPriorityNavItemDirective) items!: QueryList<BsPriorityNavItemDirective>;
+}
+
+describe('BsPriorityNavItemDirective', () => {
+  it('captures priority and hideBelow inputs', () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.items.toArray();
+    expect(items.length).toBe(2);
+    expect(items[0].priority).toBe(5);
+    expect(items[0].hideBelow).toBe('md');
+    expect(items[1].priority).toBeNull();
+    expect(items[1].hideBelow).toBeNull();
+  });
+
+  it('assigns unique ids', () => {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    const items = fixture.componentInstance.items.toArray();
+    expect(items[0].id).not.toBe(items[1].id);
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, inject, Input, TemplateRef } from '@angular/core';
+import { Directive, inject, input, TemplateRef } from '@angular/core';
 import { Breakpoint } from '@mintplayer/ng-bootstrap';
 
 @Directive({
@@ -7,8 +7,8 @@ import { Breakpoint } from '@mintplayer/ng-bootstrap';
 export class BsPriorityNavItemDirective {
   templateRef = inject(TemplateRef);
 
-  @Input('bsPriorityNavItem') priority: number | null = null;
-  @Input('bsPriorityNavItemHideBelow') hideBelow: Breakpoint | null = null;
+  priority = input<number | null>(null, { alias: 'bsPriorityNavItem' });
+  hideBelow = input<Breakpoint | null>(null, { alias: 'bsPriorityNavItemHideBelow' });
 
   readonly id: number = ++BsPriorityNavItemDirective.idCounter;
   private static idCounter = 0;

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav-item/priority-nav-item.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, inject, Input, TemplateRef } from '@angular/core';
+import { Breakpoint } from '@mintplayer/ng-bootstrap';
+
+@Directive({
+  selector: '[bsPriorityNavItem]',
+})
+export class BsPriorityNavItemDirective {
+  templateRef = inject(TemplateRef);
+
+  @Input('bsPriorityNavItem') priority: number | null = null;
+  @Input('bsPriorityNavItemHideBelow') hideBelow: Breakpoint | null = null;
+
+  readonly id: number = ++BsPriorityNavItemDirective.idCounter;
+  private static idCounter = 0;
+}

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
@@ -1,0 +1,58 @@
+<div class="priority-nav" [class.noscript]="isServerSide" bsNoNoscript>
+    @if (isServerSide) {
+        <input type="checkbox" [id]="uid + '-more'" class="priority-nav-more-checkbox d-none" bsNoNoscript>
+    }
+
+    @if (!isServerSide) {
+        <div class="priority-nav-measure-wrapper" aria-hidden="true">
+            <div class="priority-nav-measure">
+                @for (item of itemList(); track item.id) {
+                    <span #measureItem="bsObserveSize" bsObserveSize class="priority-nav-measure-item">
+                        <ng-container *ngTemplateOutlet="item.templateRef"></ng-container>
+                    </span>
+                }
+            </div>
+        </div>
+    }
+
+    <div bsObserveSize #stripSize="bsObserveSize" class="priority-nav-strip">
+        @for (item of itemList(); track item.id) {
+            <span class="priority-nav-item"
+                  [class.priority-nav-hidden]="!isServerSide && isOverflowing(item)"
+                  [ngClass]="hideBelowClass(item)">
+                <ng-container *ngTemplateOutlet="item.templateRef"></ng-container>
+            </span>
+        }
+
+        @if (isServerSide) {
+            <label [for]="uid + '-more'" class="priority-nav-more-toggle priority-nav-more-toggle-noscript"
+                   role="button" tabindex="0">
+                <ng-container *ngTemplateOutlet="moreLabelTemplate() ?? defaultMoreLabel; context: { $implicit: false }"></ng-container>
+            </label>
+        } @else {
+            <button bsObserveSize #moreSize="bsObserveSize" type="button"
+                    class="priority-nav-more-toggle"
+                    [class.priority-nav-hidden]="!showMoreButton()"
+                    (click)="toggleMore()"
+                    [attr.aria-expanded]="isMoreOpen()">
+                <ng-container *ngTemplateOutlet="moreLabelTemplate() ?? defaultMoreLabel; context: { $implicit: isMoreOpen() }"></ng-container>
+            </button>
+        }
+    </div>
+
+    <div class="priority-nav-overflow"
+         [class.priority-nav-overflow-open]="!isServerSide && isMoreOpen()">
+        @for (item of itemList(); track item.id) {
+            <span class="priority-nav-overflow-item"
+                  [class.priority-nav-overflow-hidden]="!isServerSide && !isOverflowing(item)"
+                  [ngClass]="hideBelowClass(item)">
+                <ng-container *ngTemplateOutlet="item.templateRef"></ng-container>
+            </span>
+        }
+    </div>
+</div>
+
+<ng-template #defaultMoreLabel let-isOpen>
+    <span class="priority-nav-more-label">{{ moreLabel() }}</span>
+    <span class="priority-nav-caret" aria-hidden="true">&#9662;</span>
+</ng-template>

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
@@ -41,7 +41,8 @@
     </div>
 
     <div class="priority-nav-overflow"
-         [class.priority-nav-overflow-open]="!isServerSide && isMoreOpen()">
+         [class.priority-nav-overflow-open]="!isServerSide && isMoreOpen()"
+         [class.priority-nav-overflow-align-start]="!isServerSide && fullyCollapsed()">
         @for (item of itemList(); track item.id) {
             <span class="priority-nav-overflow-item"
                   [class.priority-nav-overflow-hidden]="!isServerSide && !isOverflowing(item)"

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
@@ -6,9 +6,9 @@
     @if (!isServerSide) {
         <div class="priority-nav-measure-wrapper" aria-hidden="true">
             <div class="priority-nav-measure">
-                @for (item of items(); track item.id) {
+                @for (entry of itemsWithMeta(); track entry.item.id) {
                     <span #measureItem="bsObserveSize" bsObserveSize class="priority-nav-measure-item">
-                        <ng-container *ngTemplateOutlet="item.templateRef"></ng-container>
+                        <ng-container *ngTemplateOutlet="entry.item.templateRef"></ng-container>
                     </span>
                 }
             </div>
@@ -16,11 +16,11 @@
     }
 
     <div bsObserveSize #stripSize="bsObserveSize" class="priority-nav-strip">
-        @for (item of items(); track item.id) {
+        @for (entry of itemsWithMeta(); track entry.item.id) {
             <span class="priority-nav-item"
-                  [class.priority-nav-hidden]="!isServerSide && isOverflowing(item)"
-                  [ngClass]="hideBelowClass(item)">
-                <ng-container *ngTemplateOutlet="item.templateRef"></ng-container>
+                  [class.priority-nav-hidden]="entry.hideInline"
+                  [ngClass]="entry.hideBelowClass">
+                <ng-container *ngTemplateOutlet="entry.item.templateRef"></ng-container>
             </span>
         }
 
@@ -43,11 +43,11 @@
     <div class="priority-nav-overflow"
          [class.priority-nav-overflow-open]="!isServerSide && isMoreOpen()"
          [class.priority-nav-overflow-align-start]="!isServerSide && fullyCollapsed()">
-        @for (item of items(); track item.id) {
+        @for (entry of itemsWithMeta(); track entry.item.id) {
             <span class="priority-nav-overflow-item"
-                  [class.priority-nav-overflow-hidden]="!isServerSide && !isOverflowing(item)"
-                  [ngClass]="hideBelowClass(item)">
-                <ng-container *ngTemplateOutlet="item.templateRef"></ng-container>
+                  [class.priority-nav-overflow-hidden]="entry.hideInOverflow"
+                  [ngClass]="entry.hideBelowClass">
+                <ng-container *ngTemplateOutlet="entry.item.templateRef"></ng-container>
             </span>
         }
     </div>

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
@@ -6,7 +6,7 @@
     @if (!isServerSide) {
         <div class="priority-nav-measure-wrapper" aria-hidden="true">
             <div class="priority-nav-measure">
-                @for (item of itemList(); track item.id) {
+                @for (item of items(); track item.id) {
                     <span #measureItem="bsObserveSize" bsObserveSize class="priority-nav-measure-item">
                         <ng-container *ngTemplateOutlet="item.templateRef"></ng-container>
                     </span>
@@ -16,7 +16,7 @@
     }
 
     <div bsObserveSize #stripSize="bsObserveSize" class="priority-nav-strip">
-        @for (item of itemList(); track item.id) {
+        @for (item of items(); track item.id) {
             <span class="priority-nav-item"
                   [class.priority-nav-hidden]="!isServerSide && isOverflowing(item)"
                   [ngClass]="hideBelowClass(item)">
@@ -43,7 +43,7 @@
     <div class="priority-nav-overflow"
          [class.priority-nav-overflow-open]="!isServerSide && isMoreOpen()"
          [class.priority-nav-overflow-align-start]="!isServerSide && fullyCollapsed()">
-        @for (item of itemList(); track item.id) {
+        @for (item of items(); track item.id) {
             <span class="priority-nav-overflow-item"
                   [class.priority-nav-overflow-hidden]="!isServerSide && !isOverflowing(item)"
                   [ngClass]="hideBelowClass(item)">

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.html
@@ -26,7 +26,9 @@
 
         @if (isServerSide) {
             <label [for]="uid + '-more'" class="priority-nav-more-toggle priority-nav-more-toggle-noscript"
-                   role="button" tabindex="0">
+                   role="button" tabindex="0"
+                   aria-haspopup="true"
+                   [attr.aria-controls]="uid + '-overflow'">
                 <ng-container *ngTemplateOutlet="moreLabelTemplate() ?? defaultMoreLabel; context: { $implicit: false }"></ng-container>
             </label>
         } @else {
@@ -34,17 +36,22 @@
                     class="priority-nav-more-toggle"
                     [class.priority-nav-hidden]="!showMoreButton()"
                     (click)="toggleMore()"
+                    aria-haspopup="true"
+                    [attr.aria-controls]="uid + '-overflow'"
                     [attr.aria-expanded]="isMoreOpen()">
                 <ng-container *ngTemplateOutlet="moreLabelTemplate() ?? defaultMoreLabel; context: { $implicit: isMoreOpen() }"></ng-container>
             </button>
         }
     </div>
 
-    <div class="priority-nav-overflow"
+    <div [id]="uid + '-overflow'"
+         class="priority-nav-overflow"
+         role="menu"
          [class.priority-nav-overflow-open]="!isServerSide && isMoreOpen()"
          [class.priority-nav-overflow-align-start]="!isServerSide && fullyCollapsed()">
         @for (entry of itemsWithMeta(); track entry.item.id) {
             <span class="priority-nav-overflow-item"
+                  role="menuitem"
                   [class.priority-nav-overflow-hidden]="entry.hideInOverflow"
                   [ngClass]="entry.hideBelowClass">
                 <ng-container *ngTemplateOutlet="entry.item.templateRef"></ng-container>

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.scss
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.scss
@@ -1,0 +1,137 @@
+:host {
+    display: block;
+}
+
+.priority-nav {
+    position: relative;
+}
+
+// Off-screen measurement strip. Wrapped in a zero-size, overflow-hidden box
+// so its natural-width children don't extend the document's scrollWidth.
+.priority-nav-measure-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.priority-nav-measure {
+    visibility: hidden;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+
+    .priority-nav-measure-item {
+        display: inline-flex;
+        align-items: center;
+        flex-shrink: 0;
+    }
+}
+
+.priority-nav-strip {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    overflow: hidden;
+
+    .priority-nav-item {
+        display: inline-flex;
+        align-items: center;
+        flex-shrink: 0;
+    }
+}
+
+.priority-nav-hidden {
+    display: none !important;
+}
+
+.priority-nav-overflow-hidden {
+    display: none !important;
+}
+
+.priority-nav-more-toggle {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: inherit;
+    font: inherit;
+
+    &:focus-visible {
+        outline: 2px solid var(--bs-primary, #0d6efd);
+        outline-offset: 2px;
+    }
+
+    .priority-nav-caret {
+        font-size: 0.75em;
+        line-height: 1;
+    }
+}
+
+.priority-nav-overflow {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 1000;
+    min-width: 10rem;
+    padding: 0.5rem 0;
+    margin: 0.125rem 0 0;
+    background-color: var(--bs-body-bg, #fff);
+    border: var(--bs-border-width, 1px) solid var(--bs-border-color, rgba(0, 0, 0, 0.175));
+    border-radius: var(--bs-border-radius, 0.375rem);
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+
+    .priority-nav-overflow-item {
+        display: block;
+        padding: 0.25rem 1rem;
+    }
+}
+
+.priority-nav-overflow-open {
+    display: block;
+}
+
+// ---------- Noscript fallback ----------
+
+.priority-nav.noscript {
+    .priority-nav-strip {
+        // Items hide inline at-or-below the breakpoint they declare
+        .priority-nav-item-hide-below-sm  { @media (max-width: 575.98px)  { display: none; } }
+        .priority-nav-item-hide-below-md  { @media (max-width: 767.98px)  { display: none; } }
+        .priority-nav-item-hide-below-lg  { @media (max-width: 991.98px)  { display: none; } }
+        .priority-nav-item-hide-below-xl  { @media (max-width: 1199.98px) { display: none; } }
+        .priority-nav-item-hide-below-xxl { @media (max-width: 1399.98px) { display: none; } }
+    }
+
+    .priority-nav-overflow {
+        // Default: items without a hideBelow class never appear in overflow
+        .priority-nav-overflow-item {
+            display: none;
+        }
+
+        // Show in overflow only when the matching media query fires
+        .priority-nav-item-hide-below-sm  { @media (max-width: 575.98px)  { display: block; } }
+        .priority-nav-item-hide-below-md  { @media (max-width: 767.98px)  { display: block; } }
+        .priority-nav-item-hide-below-lg  { @media (max-width: 991.98px)  { display: block; } }
+        .priority-nav-item-hide-below-xl  { @media (max-width: 1199.98px) { display: block; } }
+        .priority-nav-item-hide-below-xxl { @media (max-width: 1399.98px) { display: block; } }
+    }
+
+    // CSS-only More toggle: checkbox sibling reveals the overflow menu
+    > input.priority-nav-more-checkbox.noscript:checked ~ .priority-nav-overflow {
+        display: block;
+    }
+
+    .priority-nav-more-toggle-noscript {
+        cursor: pointer;
+        user-select: none;
+    }
+}

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.scss
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.scss
@@ -99,6 +99,13 @@
     display: block;
 }
 
+// When every item has overflowed, the toggle is at the start edge of the
+// strip — anchor the dropdown to the same side so it stays attached.
+.priority-nav-overflow-align-start {
+    left: 0;
+    right: auto;
+}
+
 // ---------- Noscript fallback ----------
 
 .priority-nav.noscript {

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { BsPriorityNavComponent } from './priority-nav.component';
+import { BsPriorityNavItemDirective } from '../priority-nav-item/priority-nav-item.directive';
+
+@Component({
+  selector: 'priority-nav-test',
+  imports: [BsPriorityNavComponent, BsPriorityNavItemDirective],
+  template: `
+    <bs-priority-nav>
+      <a *bsPriorityNavItem="1; hideBelow: 'md'" href="#a">A</a>
+      <a *bsPriorityNavItem="2; hideBelow: 'lg'" href="#b">B</a>
+      <a *bsPriorityNavItem="3" href="#c">C</a>
+    </bs-priority-nav>
+  `,
+})
+class TestHostComponent {}
+
+describe('BsPriorityNavComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should render all items in the inline strip', () => {
+    const links = fixture.nativeElement.querySelectorAll('.priority-nav-strip .priority-nav-item');
+    expect(links.length).toBe(3);
+  });
+
+  it('should also render items in the overflow menu (dual render)', () => {
+    const overflowItems = fixture.nativeElement.querySelectorAll('.priority-nav-overflow .priority-nav-overflow-item');
+    expect(overflowItems.length).toBe(3);
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
@@ -1,0 +1,183 @@
+import { isPlatformServer, NgClass, NgTemplateOutlet } from '@angular/common';
+import {
+  ChangeDetectionStrategy, Component, computed, contentChildren, effect, ElementRef,
+  inject, input, output, PLATFORM_ID, signal, TemplateRef, viewChild, viewChildren
+} from '@angular/core';
+import { Breakpoint } from '@mintplayer/ng-bootstrap';
+import { BsNoNoscriptDirective } from '@mintplayer/ng-bootstrap/no-noscript';
+import { BsObserveSizeDirective } from '@mintplayer/ng-swiper/observe-size';
+import { BsPriorityNavItemDirective } from '../priority-nav-item/priority-nav-item.directive';
+
+@Component({
+  selector: 'bs-priority-nav',
+  templateUrl: './priority-nav.component.html',
+  styleUrls: ['./priority-nav.component.scss'],
+  imports: [NgClass, NgTemplateOutlet, BsNoNoscriptDirective, BsObserveSizeDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(document:click)': 'onDocumentClick($event)',
+    '(window:resize)': 'onWindowResize()',
+  },
+})
+export class BsPriorityNavComponent {
+  private platformId = inject(PLATFORM_ID);
+  private element = inject(ElementRef);
+
+  isServerSide = isPlatformServer(this.platformId);
+
+  private static counter = 0;
+  uid = `pn-${++BsPriorityNavComponent.counter}`;
+
+  // Inputs
+  moreLabel = input('More');
+  moreLabelTemplate = input<TemplateRef<{ $implicit: boolean }> | null>(null);
+  collapseAt = input<Breakpoint | null>(null);
+  overflowFrom = input<'start' | 'end'>('end');
+  hideEmptyMore = input(true);
+
+  // Outputs
+  overflowChange = output<BsPriorityNavItemDirective[]>();
+
+  // Children
+  readonly items = contentChildren(BsPriorityNavItemDirective);
+
+  // Per-item width measurements (from the off-screen measure strip)
+  private measureSizers = viewChildren<BsObserveSizeDirective>('measureItem');
+  // Visible strip width
+  stripSizer = viewChild<BsObserveSizeDirective>('stripSize');
+  // More button width
+  moreSizer = viewChild<BsObserveSizeDirective>('moreSize');
+
+  // Open/closed state for the More menu (JS path)
+  isMoreOpen = signal(false);
+  windowWidth = signal<number>(0);
+
+  collapseAtPx = computed(() => {
+    switch (this.collapseAt()) {
+      case 'xxl': return 1400;
+      case 'xl': return 1200;
+      case 'lg': return 992;
+      case 'md': return 768;
+      case 'sm': return 576;
+      case 'xs': return 0;
+      default: return null;
+    }
+  });
+
+  forceCollapse = computed(() => {
+    const bp = this.collapseAtPx();
+    if (bp === null) return false;
+    const w = this.windowWidth();
+    return w > 0 && w < bp;
+  });
+
+  // Items in declaration order
+  itemList = computed(() => this.items());
+
+  // Items in overflow order. Convention: a LOWER priority number means MORE
+  // important (priority: 1 stays visible longest). Items without a priority
+  // are treated as least important and overflow before any prioritized item.
+  // Tiebreaker uses declaration order (last-declared overflows first when
+  // overflowFrom='end').
+  overflowOrder = computed(() => {
+    const items = this.items();
+    const fromEnd = this.overflowFrom() === 'end';
+    return [...items]
+      .map((item, index) => ({ item, index }))
+      .sort((a, b) => {
+        const pa = a.item.priority;
+        const pb = b.item.priority;
+        // Unprioritized items overflow first
+        if (pa === null && pb !== null) return -1;
+        if (pa !== null && pb === null) return 1;
+        // Both prioritized: higher number overflows first (less important)
+        if (pa !== null && pb !== null && pa !== pb) return pb - pa;
+        // Tiebreaker by declaration order
+        return fromEnd ? b.index - a.index : a.index - b.index;
+      })
+      .map(x => x.item);
+  });
+
+  // Per-item width map (from measure strip, indexed by item id, in items() order)
+  itemWidths = computed<Map<number, number>>(() => {
+    if (this.isServerSide) return new Map();
+    const sizers = this.measureSizers();
+    const items = this.items();
+    const map = new Map<number, number>();
+    items.forEach((item, i) => {
+      const sizer = sizers[i];
+      if (!sizer) return;
+      const w = sizer.width();
+      if (w !== undefined) map.set(item.id, w);
+    });
+    return map;
+  });
+
+  overflowingIds = computed<Set<number>>(() => {
+    if (this.isServerSide) return new Set();
+    if (this.forceCollapse()) {
+      return new Set(this.items().map(i => i.id));
+    }
+
+    const stripWidth = this.stripSizer()?.width() ?? 0;
+    const moreWidth = this.moreSizer()?.width() ?? 0;
+    const widths = this.itemWidths();
+
+    if (stripWidth === 0 || widths.size === 0) return new Set();
+
+    const totalNeeded = Array.from(widths.values()).reduce((a, b) => a + b, 0);
+    if (totalNeeded <= stripWidth) return new Set();
+
+    // Reserve space for the More toggle, then walk overflow order kicking items out.
+    const overflowing = new Set<number>();
+    let used = totalNeeded;
+    const budget = stripWidth - moreWidth;
+
+    for (const item of this.overflowOrder()) {
+      if (used <= budget) break;
+      overflowing.add(item.id);
+      used -= widths.get(item.id) ?? 0;
+    }
+    return overflowing;
+  });
+
+  hasAnyOverflow = computed(() => this.overflowingIds().size > 0);
+  showMoreButton = computed(() => !this.hideEmptyMore() || this.hasAnyOverflow());
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      this.windowWidth.set(window.innerWidth);
+    }
+
+    effect(() => {
+      const overflowing = this.overflowingIds();
+      const overflowingItems = this.items().filter(i => overflowing.has(i.id));
+      this.overflowChange.emit(overflowingItems);
+    });
+  }
+
+  onWindowResize() {
+    if (typeof window !== 'undefined') {
+      this.windowWidth.set(window.innerWidth);
+    }
+  }
+
+  toggleMore() {
+    this.isMoreOpen.update(v => !v);
+  }
+
+  onDocumentClick(event: MouseEvent) {
+    if (!this.isMoreOpen()) return;
+    if (!this.element.nativeElement.contains(event.target as Node)) {
+      this.isMoreOpen.set(false);
+    }
+  }
+
+  isOverflowing(item: BsPriorityNavItemDirective): boolean {
+    return this.overflowingIds().has(item.id);
+  }
+
+  hideBelowClass(item: BsPriorityNavItemDirective): string {
+    return item.hideBelow ? `priority-nav-item-hide-below-${item.hideBelow}` : '';
+  }
+}

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
@@ -149,6 +149,28 @@ export class BsPriorityNavComponent {
     return items.length > 0 && this.overflowingIds().size === items.length;
   });
 
+  // Derived per-item view used by all three rendering passes (measure strip,
+  // inline strip, overflow menu). Pre-computes the breakpoint class string and
+  // the JS-mode-only hide flags so the template can stay purely declarative —
+  // no method calls, no inline `!isServerSide` guards. The SSR/noscript path
+  // relies on CSS media queries instead of these flags, so both `hideInline`
+  // and `hideInOverflow` are forced to false on the server.
+  itemsWithMeta = computed(() => {
+    const items = this.items();
+    const overflowing = this.overflowingIds();
+    const ssr = this.isServerSide;
+    return items.map(item => {
+      const bp = item.hideBelow();
+      const isOverflowing = overflowing.has(item.id);
+      return {
+        item,
+        hideBelowClass: bp ? `priority-nav-item-hide-below-${bp}` : '',
+        hideInline: !ssr && isOverflowing,
+        hideInOverflow: !ssr && !isOverflowing,
+      };
+    });
+  });
+
   constructor() {
     if (typeof window !== 'undefined') {
       this.windowWidth.set(window.innerWidth);
@@ -178,12 +200,4 @@ export class BsPriorityNavComponent {
     }
   }
 
-  isOverflowing(item: BsPriorityNavItemDirective): boolean {
-    return this.overflowingIds().has(item.id);
-  }
-
-  hideBelowClass(item: BsPriorityNavItemDirective): string {
-    const breakpoint = item.hideBelow();
-    return breakpoint ? `priority-nav-item-hide-below-${breakpoint}` : '';
-  }
 }

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
@@ -71,9 +71,6 @@ export class BsPriorityNavComponent {
     return w > 0 && w < bp;
   });
 
-  // Items in declaration order
-  itemList = computed(() => this.items());
-
   // Items in overflow order. Convention: a LOWER priority number means MORE
   // important (priority: 1 stays visible longest). Items without a priority
   // are treated as least important and overflow before any prioritized item.
@@ -83,15 +80,15 @@ export class BsPriorityNavComponent {
     const items = this.items();
     const fromEnd = this.overflowFrom() === 'end';
     return [...items]
-      .map((item, index) => ({ item, index }))
+      .map((item, index) => ({ item, index, priority: item.priority() }))
       .sort((a, b) => {
-        const pa = a.item.priority;
-        const pb = b.item.priority;
         // Unprioritized items overflow first
-        if (pa === null && pb !== null) return -1;
-        if (pa !== null && pb === null) return 1;
+        if (a.priority === null && b.priority !== null) return -1;
+        if (a.priority !== null && b.priority === null) return 1;
         // Both prioritized: higher number overflows first (less important)
-        if (pa !== null && pb !== null && pa !== pb) return pb - pa;
+        if (a.priority !== null && b.priority !== null && a.priority !== b.priority) {
+          return b.priority - a.priority;
+        }
         // Tiebreaker by declaration order
         return fromEnd ? b.index - a.index : a.index - b.index;
       })
@@ -186,6 +183,7 @@ export class BsPriorityNavComponent {
   }
 
   hideBelowClass(item: BsPriorityNavItemDirective): string {
-    return item.hideBelow ? `priority-nav-item-hide-below-${item.hideBelow}` : '';
+    const breakpoint = item.hideBelow();
+    return breakpoint ? `priority-nav-item-hide-below-${breakpoint}` : '';
   }
 }

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
@@ -144,6 +144,14 @@ export class BsPriorityNavComponent {
   hasAnyOverflow = computed(() => this.overflowingIds().size > 0);
   showMoreButton = computed(() => !this.hideEmptyMore() || this.hasAnyOverflow());
 
+  // When every item is overflowing the toggle ends up at the start edge of
+  // the strip (no inline items push it). Anchor the dropdown to that side
+  // so it stays visually attached to the toggle.
+  fullyCollapsed = computed(() => {
+    const items = this.items();
+    return items.length > 0 && this.overflowingIds().size === items.length;
+  });
+
   constructor() {
     if (typeof window !== 'undefined') {
       this.windowWidth.set(window.innerWidth);

--- a/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
+++ b/libs/mintplayer-ng-bootstrap/priority-nav/src/priority-nav/priority-nav.component.ts
@@ -16,6 +16,7 @@ import { BsPriorityNavItemDirective } from '../priority-nav-item/priority-nav-it
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '(document:click)': 'onDocumentClick($event)',
+    '(document:keydown.escape)': 'onEscape()',
     '(window:resize)': 'onWindowResize()',
   },
 })
@@ -43,8 +44,9 @@ export class BsPriorityNavComponent {
 
   // Per-item width measurements (from the off-screen measure strip)
   private measureSizers = viewChildren<BsObserveSizeDirective>('measureItem');
-  // Visible strip width
+  // Visible strip width and its element (for reading computed `column-gap`)
   stripSizer = viewChild<BsObserveSizeDirective>('stripSize');
+  private stripElement = viewChild('stripSize', { read: ElementRef });
   // More button width
   moreSizer = viewChild<BsObserveSizeDirective>('moreSize');
 
@@ -110,6 +112,21 @@ export class BsPriorityNavComponent {
     return map;
   });
 
+  // The strip's `column-gap` (or `gap`) value in pixels. Read from computed
+  // style so consumers' `gap` declarations get factored into the overflow math
+  // — without this, items overflow late or layout-shift when a gap is set.
+  // Re-read whenever the strip width changes (covers media-query gap changes
+  // that piggy-back on the same breakpoint).
+  itemGap = computed(() => {
+    if (this.isServerSide) return 0;
+    this.stripSizer()?.width();
+    const el = this.stripElement()?.nativeElement as HTMLElement | undefined;
+    if (!el) return 0;
+    const cs = getComputedStyle(el);
+    const raw = parseFloat(cs.columnGap || cs.gap || '0');
+    return Number.isFinite(raw) ? raw : 0;
+  });
+
   overflowingIds = computed<Set<number>>(() => {
     if (this.isServerSide) return new Set();
     if (this.forceCollapse()) {
@@ -119,21 +136,27 @@ export class BsPriorityNavComponent {
     const stripWidth = this.stripSizer()?.width() ?? 0;
     const moreWidth = this.moreSizer()?.width() ?? 0;
     const widths = this.itemWidths();
+    const gap = this.itemGap();
 
     if (stripWidth === 0 || widths.size === 0) return new Set();
 
-    const totalNeeded = Array.from(widths.values()).reduce((a, b) => a + b, 0);
-    if (totalNeeded <= stripWidth) return new Set();
+    // Layout when all items fit (no More toggle): N items separated by N-1 gaps
+    const sumWidths = Array.from(widths.values()).reduce((a, b) => a + b, 0);
+    const allVisibleWidth = sumWidths + gap * Math.max(0, widths.size - 1);
+    if (allVisibleWidth <= stripWidth) return new Set();
 
-    // Reserve space for the More toggle, then walk overflow order kicking items out.
+    // Need overflow → More toggle is shown. Layout when K items are kicked:
+    //   (N - K) items + 1 More toggle = (N - K + 1) elements with (N - K) gaps
     const overflowing = new Set<number>();
-    let used = totalNeeded;
-    const budget = stripWidth - moreWidth;
+    let visibleSum = sumWidths;
+    let visibleCount = widths.size;
 
     for (const item of this.overflowOrder()) {
-      if (used <= budget) break;
+      const totalWithMore = visibleSum + moreWidth + gap * visibleCount;
+      if (totalWithMore <= stripWidth) break;
+      visibleSum -= widths.get(item.id) ?? 0;
+      visibleCount -= 1;
       overflowing.add(item.id);
-      used -= widths.get(item.id) ?? 0;
     }
     return overflowing;
   });
@@ -172,7 +195,7 @@ export class BsPriorityNavComponent {
   });
 
   constructor() {
-    if (typeof window !== 'undefined') {
+    if (!this.isServerSide) {
       this.windowWidth.set(window.innerWidth);
     }
 
@@ -184,7 +207,7 @@ export class BsPriorityNavComponent {
   }
 
   onWindowResize() {
-    if (typeof window !== 'undefined') {
+    if (!this.isServerSide) {
       this.windowWidth.set(window.innerWidth);
     }
   }
@@ -193,8 +216,12 @@ export class BsPriorityNavComponent {
     this.isMoreOpen.update(v => !v);
   }
 
+  onEscape() {
+    if (this.isMoreOpen()) this.isMoreOpen.set(false);
+  }
+
   onDocumentClick(event: MouseEvent) {
-    if (!this.isMoreOpen()) return;
+    if (event.button !== 0 || !this.isMoreOpen()) return;
     if (!this.element.nativeElement.contains(event.target as Node)) {
       this.isMoreOpen.set(false);
     }

--- a/libs/mintplayer-ng-bootstrap/resizable/src/resizable/resizable.component.html
+++ b/libs/mintplayer-ng-bootstrap/resizable/src/resizable/resizable.component.html
@@ -1,11 +1,17 @@
 <div [class]="wrapperPosition()" class="h-100">
-    <div class="cursor-nw-resize" [bsResizeGlyph]="['top', 'start']"></div>
-    <div class="cursor-n-resize" [bsResizeGlyph]="['top']"></div>
-    <div class="cursor-ne-resize" [bsResizeGlyph]="['top', 'end']"></div>
-    <div class="cursor-e-resize" [bsResizeGlyph]="['end']"></div>
-    <div class="cursor-se-resize" [bsResizeGlyph]="['bottom', 'end']"></div>
-    <div class="cursor-s-resize" [bsResizeGlyph]="['bottom']"></div>
-    <div class="cursor-sw-resize" [bsResizeGlyph]="['bottom', 'start']"></div>
-    <div class="cursor-w-resize" [bsResizeGlyph]="['start']"></div>
+    @if (showCorners()) {
+        <div class="cursor-nw-resize" [bsResizeGlyph]="['top', 'start']"></div>
+        <div class="cursor-ne-resize" [bsResizeGlyph]="['top', 'end']"></div>
+        <div class="cursor-se-resize" [bsResizeGlyph]="['bottom', 'end']"></div>
+        <div class="cursor-sw-resize" [bsResizeGlyph]="['bottom', 'start']"></div>
+    }
+    @if (vertical()) {
+        <div class="cursor-n-resize" [bsResizeGlyph]="['top']"></div>
+        <div class="cursor-s-resize" [bsResizeGlyph]="['bottom']"></div>
+    }
+    @if (horizontal()) {
+        <div class="cursor-e-resize" [bsResizeGlyph]="['end']"></div>
+        <div class="cursor-w-resize" [bsResizeGlyph]="['start']"></div>
+    }
     <ng-content></ng-content>
 </div>

--- a/libs/mintplayer-ng-bootstrap/resizable/src/resizable/resizable.component.ts
+++ b/libs/mintplayer-ng-bootstrap/resizable/src/resizable/resizable.component.ts
@@ -33,6 +33,11 @@ export class BsResizableComponent {
 
   resizeAction?: ResizeAction;
   positioning = input<ResizablePositioning>('inline');
+  horizontal = input(true);
+  vertical = input(true);
+  corners = input(true);
+
+  showCorners = computed(() => this.horizontal() && this.vertical() && this.corners());
 
   hostPosition = computed(() => {
     const positioning = this.positioning();

--- a/libs/mintplayer-ng-bootstrap/resizable/src/resize-glyph/resize-glyph.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/resizable/src/resize-glyph/resize-glyph.directive.ts
@@ -136,59 +136,73 @@ export class BsResizeGlyphDirective {
     if (this.resizable.resizeAction && !this.isBusy) {
       ev.preventDefault();
       this.isBusy = true;
-      const rct = this.resizable.element.nativeElement.getBoundingClientRect();
-      if (this.resizable.resizeAction.start && this.positions()?.includes('end')) {
-        // Right glyph
-        const x = (ev.clientX < rct.left + 10) ? rct.left + 10 : ev.clientX;
+      const action = this.resizable.resizeAction;
+      // Note: the live bounding rect must NOT be used in the size/margin math.
+      // Reading it per-frame creates a feedback loop when content inside the
+      // host changes layout during the drag (e.g. a child component that
+      // shows/hides items in response to width). Use the captured `action`
+      // values from pointer-down — they're stable for the duration of the drag.
+
+      if (action.start && this.positions()?.includes('end')) {
+        // Right glyph — fixed left edge
+        const initialLeft = action.start.edge;
+        const initialRight = action.start.edge + action.start.size;
+        const x = (ev.clientX < initialLeft + 10) ? initialLeft + 10 : ev.clientX;
         switch (this.resizable.positioning()) {
           case 'inline': {
-            const initalMargin = this.resizable.marginRight() ?? 0;
-            this.resizable.marginRight.set(initalMargin - (x - rct.right));
+            const initialMargin = action.start.dragMargin ?? 0;
+            this.resizable.marginRight.set(initialMargin + (initialRight - x));
           } break;
           case 'absolute': {
-            this.resizable.width.set(x - rct.left);
+            this.resizable.width.set(x - initialLeft);
           } break;
         }
-      } else if (this.resizable.resizeAction.end && this.positions()?.includes('start')) {
-        // Left glyph
-        const x = (ev.clientX > rct.right - 10) ? rct.right - 10 : ev.clientX;
+      } else if (action.end && this.positions()?.includes('start')) {
+        // Left glyph — fixed right edge
+        const initialRight = action.end.edge;
+        const initialLeft = action.end.edge - action.end.size;
+        const x = (ev.clientX > initialRight - 10) ? initialRight - 10 : ev.clientX;
         switch (this.resizable.positioning()) {
           case 'inline': {
-            const initalMargin = this.resizable.marginLeft() ?? 0;
-            this.resizable.marginLeft.set(initalMargin + x - rct.left);
+            const initialMargin = action.end.dragMargin ?? 0;
+            this.resizable.marginLeft.set(initialMargin + (x - initialLeft));
           } break;
           case 'absolute': {
             this.resizable.left.set(x);
-            this.resizable.width.set(this.resizable.resizeAction.end.edge - x);
+            this.resizable.width.set(initialRight - x);
           } break;
         }
       }
 
-      if (this.resizable.resizeAction.top && this.positions()?.includes('bottom')) {
-        // Bottom glyph
-        const y = (ev.clientY < rct.top + 10) ? rct.top + 10 : ev.clientY;
+      if (action.top && this.positions()?.includes('bottom')) {
+        // Bottom glyph — fixed top edge. action.top.edge = captured rect.top
+        const initialTop = action.top.edge;
+        const initialBottom = action.top.edge + action.top.size;
+        const y = (ev.clientY < initialTop + 10) ? initialTop + 10 : ev.clientY;
         switch (this.resizable.positioning()) {
           case 'inline': {
-            const initalMargin = this.resizable.marginBottom() ?? 0;
-            this.resizable.height.set(y - rct.top);
-            this.resizable.marginBottom.set(initalMargin - (y - rct.bottom));
+            const initialMargin = action.top.dragMargin ?? 0;
+            this.resizable.height.set(y - initialTop);
+            this.resizable.marginBottom.set(initialMargin + (initialBottom - y));
           } break;
           case 'absolute': {
-            this.resizable.height.set(y - rct.top);
+            this.resizable.height.set(y - initialTop);
           } break;
         }
-      } else if (this.resizable.resizeAction.bottom && this.positions()?.includes('top')) {
-        // Top glyph
-        const y = (ev.clientY > rct.bottom - 10) ? rct.bottom - 10 : ev.clientY;
+      } else if (action.bottom && this.positions()?.includes('top')) {
+        // Top glyph — fixed bottom edge. action.bottom.edge = captured rect.bottom
+        const initialBottom = action.bottom.edge;
+        const initialTop = action.bottom.edge - action.bottom.size;
+        const y = (ev.clientY > initialBottom - 10) ? initialBottom - 10 : ev.clientY;
         switch (this.resizable.positioning()) {
           case 'inline': {
-            const initalMargin = this.resizable.marginTop() ?? 0;
-            this.resizable.height.set(rct.bottom - y);
-            this.resizable.marginTop.set(initalMargin + y - rct.top);
+            const initialMargin = action.bottom.dragMargin ?? 0;
+            this.resizable.height.set(initialBottom - y);
+            this.resizable.marginTop.set(initialMargin + (y - initialTop));
           } break;
           case 'absolute': {
             this.resizable.top.set(y);
-            this.resizable.height.set(this.resizable.resizeAction.bottom.edge - y);
+            this.resizable.height.set(initialBottom - y);
           } break;
         }
       }


### PR DESCRIPTION
## Summary

- Adds `bs-priority-nav` + `*bsPriorityNavItem` — a generic horizontal navigation that keeps as many items visible as fit and moves overflowing items into a "More" dropdown. Width measured per-item via `bsObserveSize`, recomputed on container resize through the signal graph.
- **Noscript-compatible** via the same hidden-checkbox + `<label for>` pattern used by `bs-carousel` / `bs-tab-control`. Items dual-render (inline strip + overflow menu); CSS media queries gated by each item's `hideBelow` breakpoint hide them inline and reveal them in the overflow menu without JS.
- New demo page at `Advanced → Priority navigation` with two interactive sections (resize-to-trigger via `bs-resizable`, and `collapseAt='sm'`).
- PRD: `docs/prd/priority-navigation.md`.

Closes #196.

## Public API

```html
<bs-priority-nav [moreLabel]="'More'" [collapseAt]="null" [overflowFrom]="'end'" [hideEmptyMore]="true">
  <a *bsPriorityNavItem="1; hideBelow: 'sm'" [routerLink]="['/home']">Home</a>
  <a *bsPriorityNavItem="2; hideBelow: 'md'" [routerLink]="['/products']">Products</a>
  ...
</bs-priority-nav>
```

- `priority` — lower number = more important, stays visible longer. Unset items overflow first.
- `hideBelow` — noscript-only hint: at this breakpoint and below, the item is hidden inline and shown in the overflow menu via media queries.

## Test plan

- [x] All 5 priority-nav unit tests pass (`nx test mintplayer-ng-bootstrap --testFile priority-nav`)
- [x] Full library suite green (169 tests)
- [x] `nx build ng-bootstrap-demo` clean
- [x] Manual: 1280px viewport — all items inline, no More button (hideEmptyMore default)
- [x] Manual: 500px viewport — Home/Products/Services/Pricing inline, More dropdown with Blog/Careers/Support/Contact
- [x] Manual: clicking More opens the overflow menu with the right items
- [x] Manual: `collapseAt='sm'` collapses everything to the More menu under 576px
- [x] Manual: `document.scrollWidth === document.clientWidth` at narrow viewports (no horizontal scroll)
- [x] SSR HTML inspected: `.priority-nav.noscript` host, hidden `<input type="checkbox">` with `bsNoNoscript`, `<label for>` toggle, dual-rendered items with `priority-nav-item-hide-below-*` classes
- [x] Verify in a browser with JS actually disabled (DevTools → Disable JavaScript) — reviewer to confirm noscript path renders and the More toggle opens via CSS only

## Notes for reviewers

- **Off-screen measurement** — items are rendered a third time inside a `width: 0; height: 0; overflow: hidden` clip wrapper to read their natural widths via `bsObserveSize`. The clip wrapper is required: bare `top: -9999px` extends `document.scrollWidth` and reintroduces a horizontal scrollbar. PRD has a "Constraint to preserve" note about this.
- **Priority semantic** — chose lower-number = more-important to match common everyday usage ("priority 1 = top priority"). Resolved question, see PRD.
- **`collapseAt` is JS-only** — the noscript fallback uses per-item `hideBelow` for hiding. Documented as a known limitation in the PRD.