### PR TITLE
chore(ci): Switch to self-hosted Nx remote cache

### DIFF
--- a/.github/workflows/build-any.yml
+++ b/.github/workflows/build-any.yml
@@ -9,7 +9,13 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
-      
+
+# Self-hosted Nx remote cache. RW token is only used on push to the default
+# branch; everything else (PRs, feature branches) gets the read-only token.
+env:
+  NX_SELF_HOSTED_REMOTE_CACHE_SERVER: ${{ secrets.NX_CACHE_SERVER }}
+  NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) && secrets.NX_CACHE_RW_TOKEN || secrets.NX_CACHE_RO_TOKEN }}
+
 jobs:
   build:
   
@@ -37,34 +43,8 @@ jobs:
       run: npm ci
     
     - name: Build
-      id: BuildWithCloud
       timeout-minutes: 15
-      run: |
-        set +e
-        npx nx build --configuration=production 2>&1 | tee build_output.txt
-        BUILD_EXIT_CODE=${PIPESTATUS[0]}
-
-        if [ $BUILD_EXIT_CODE -eq 0 ]; then
-          echo "Build succeeded with NX Cloud"
-          exit 0
-        fi
-
-        # Check if failure was due to NX Cloud credits/plan limits
-        if grep -qiE "(out of credits|credit limit|quota exceeded|no cloud credits|credits exhausted|unable to be authorized|disabled due to exceeding|This Nx Cloud organization has been disabled due to exceeding the)" build_output.txt; then
-          echo "NX_CLOUD_CREDITS_EXHAUSTED=true" >> $GITHUB_OUTPUT
-          echo "Build failed due to NX Cloud credits - will retry without cloud"
-          exit 0
-        else
-          echo "Build failed due to actual errors"
-          cat build_output.txt
-          exit 1
-        fi
-
-    - name: BuildWithoutCloud
-      id: BuildWithoutCloud
-      if: ${{ steps.BuildWithCloud.outputs.NX_CLOUD_CREDITS_EXHAUSTED == 'true' }}
-      timeout-minutes: 15
-      run: npx nx build --configuration=production --no-cloud
+      run: npx nx build --configuration=production
 
     #- name: Test
     #  run: npm run test -- --watch=false

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -8,10 +8,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions: 
+permissions:
   contents: read
-  packages: write 
-  
+  packages: write
+
+# Self-hosted Nx remote cache. RW token is only used on push to the default
+# branch; everything else (PRs, feature branches) gets the read-only token.
+env:
+  NX_SELF_HOSTED_REMOTE_CACHE_SERVER: ${{ secrets.NX_CACHE_SERVER }}
+  NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) && secrets.NX_CACHE_RW_TOKEN || secrets.NX_CACHE_RO_TOKEN }}
+
 jobs:
   build:
   
@@ -42,62 +48,11 @@ jobs:
       run: npm ci
     
     - name: Build
-      id: BuildWithCloud
       timeout-minutes: 15
-      run: |
-        set +e
-        npx nx build --configuration=production 2>&1 | tee build_output.txt
-        BUILD_EXIT_CODE=${PIPESTATUS[0]}
-
-        if [ $BUILD_EXIT_CODE -eq 0 ]; then
-          echo "Build succeeded with NX Cloud"
-          exit 0
-        fi
-
-        # Check if failure was due to NX Cloud credits/plan limits
-        if grep -qiE "(out of credits|credit limit|quota exceeded|no cloud credits|credits exhausted|unable to be authorized|disabled due to exceeding|This Nx Cloud organization has been disabled due to exceeding the)" build_output.txt; then
-          echo "NX_CLOUD_CREDITS_EXHAUSTED=true" >> $GITHUB_OUTPUT
-          echo "Build failed due to NX Cloud credits - will retry without cloud"
-          exit 0
-        else
-          echo "Build failed due to actual errors"
-          cat build_output.txt
-          exit 1
-        fi
-
-    - name: BuildWithoutCloud
-      id: BuildWithoutCloud
-      if: ${{ steps.BuildWithCloud.outputs.NX_CLOUD_CREDITS_EXHAUSTED == 'true' }}
-      timeout-minutes: 15
-      run: npx nx build --configuration=production --no-cloud
+      run: npx nx build --configuration=production
 
     - name: Test
-      id: TestWithCloud
-      run: |
-        set +e
-        npx nx affected --target=test --watch=false --parallel=true 2>&1 | tee test_output.txt
-        TEST_EXIT_CODE=${PIPESTATUS[0]}
-
-        if [ $TEST_EXIT_CODE -eq 0 ]; then
-          echo "Tests succeeded with NX Cloud"
-          exit 0
-        fi
-
-        # Check if failure was due to NX Cloud credits/plan limits
-        if grep -qiE "(out of credits|credit limit|quota exceeded|no cloud credits|credits exhausted|unable to be authorized|disabled due to exceeding|This Nx Cloud organization has been disabled due to exceeding the)" test_output.txt; then
-          echo "NX_CLOUD_CREDITS_EXHAUSTED=true" >> $GITHUB_OUTPUT
-          echo "Tests failed due to NX Cloud credits - will retry without cloud"
-          exit 0
-        else
-          echo "Tests failed due to actual errors"
-          cat test_output.txt
-          exit 1
-        fi
-
-    - name: TestWithoutCloud
-      id: TestWithoutCloud
-      if: ${{ steps.TestWithCloud.outputs.NX_CLOUD_CREDITS_EXHAUSTED == 'true' }}
-      run: npx nx affected --target=test --watch=false --parallel=true --no-cloud
+      run: npx nx affected --target=test --watch=false --parallel=true
 
     ## ng-animations
     - name: Push to NPM

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Self-hosted Nx remote cache. RW token is only used on push to the default
+# branch; everything else (PRs, feature branches) gets the read-only token.
+env:
+  NX_SELF_HOSTED_REMOTE_CACHE_SERVER: ${{ secrets.NX_CACHE_SERVER }}
+  NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) && secrets.NX_CACHE_RW_TOKEN || secrets.NX_CACHE_RO_TOKEN }}
+
 jobs:
   build:
   
@@ -37,62 +43,11 @@ jobs:
       run: npm ci
     
     - name: Build
-      id: BuildWithCloud
       timeout-minutes: 15
-      run: |
-        set +e
-        npx nx build --configuration=production 2>&1 | tee build_output.txt
-        BUILD_EXIT_CODE=${PIPESTATUS[0]}
-
-        if [ $BUILD_EXIT_CODE -eq 0 ]; then
-          echo "Build succeeded with NX Cloud"
-          exit 0
-        fi
-
-        # Check if failure was due to NX Cloud credits/plan limits
-        if grep -qiE "(out of credits|credit limit|quota exceeded|no cloud credits|credits exhausted|unable to be authorized|disabled due to exceeding|This Nx Cloud organization has been disabled due to exceeding the)" build_output.txt; then
-          echo "NX_CLOUD_CREDITS_EXHAUSTED=true" >> $GITHUB_OUTPUT
-          echo "Build failed due to NX Cloud credits - will retry without cloud"
-          exit 0
-        else
-          echo "Build failed due to actual errors"
-          cat build_output.txt
-          exit 1
-        fi
-
-    - name: BuildWithoutCloud
-      id: BuildWithoutCloud
-      if: ${{ steps.BuildWithCloud.outputs.NX_CLOUD_CREDITS_EXHAUSTED == 'true' }}
-      timeout-minutes: 15
-      run: npx nx build --configuration=production --no-cloud
+      run: npx nx build --configuration=production
 
     - name: Test
-      id: TestWithCloud
-      run: |
-        set +e
-        npx nx affected --target=test --watch=false --parallel=true --base=${{ github.event.pull_request.base.sha }} --head=${{ github.event.pull_request.head.sha }} 2>&1 | tee test_output.txt
-        TEST_EXIT_CODE=${PIPESTATUS[0]}
-
-        if [ $TEST_EXIT_CODE -eq 0 ]; then
-          echo "Tests succeeded with NX Cloud"
-          exit 0
-        fi
-
-        # Check if failure was due to NX Cloud credits/plan limits
-        if grep -qiE "(out of credits|credit limit|quota exceeded|no cloud credits|credits exhausted|unable to be authorized|disabled due to exceeding|This Nx Cloud organization has been disabled due to exceeding the)" test_output.txt; then
-          echo "NX_CLOUD_CREDITS_EXHAUSTED=true" >> $GITHUB_OUTPUT
-          echo "Tests failed due to NX Cloud credits - will retry without cloud"
-          exit 0
-        else
-          echo "Tests failed due to actual errors"
-          cat test_output.txt
-          exit 1
-        fi
-
-    - name: TestWithoutCloud
-      id: TestWithoutCloud
-      if: ${{ steps.TestWithCloud.outputs.NX_CLOUD_CREDITS_EXHAUSTED == 'true' }}
-      run: npx nx affected --target=test --watch=false --parallel=true --base=${{ github.event.pull_request.base.sha }} --head=${{ github.event.pull_request.head.sha }} --no-cloud
+      run: npx nx affected --target=test --watch=false --parallel=true --base=${{ github.event.pull_request.base.sha }} --head=${{ github.event.pull_request.head.sha }}
 
     ## Dry-run publish to verify package.json files exist in dist
     - name: Dry-run publish ng-animations

--- a/nx.json
+++ b/nx.json
@@ -59,7 +59,6 @@
     ]
   },
   "useDaemonProcess": false,
-  "nxCloudAccessToken": "OTQ3ODE1NTgtOTNjZi00ZTQwLTgxOGUtYWQ0MWQ0NGJkNDU2fHJlYWQtd3JpdGU=",
   "useInferencePlugins": false,
   "defaultBase": "master"
 }


### PR DESCRIPTION
## Summary

The previous Nx Cloud organization is disabled (every CI run today logs *\"This Nx Cloud organization has been disabled due to exceeding the FREE plan\"*). Switch the workspace to the self-hosted cache at https://nx-cache.mintplayer.com — same setup [MintPlayer.Spark already uses](https://github.com/MintPlayer/MintPlayer.Spark/blob/master/.github/workflows/pull-request.yml).

## Changes

- **\`nx.json\`** — drop the dead \`nxCloudAccessToken\`. Without it, Nx auto-detects the self-hosted cache via the env vars below.
- **All three workflows** (\`build-any\`, \`pull-request\`, \`publish-master\`) — add a workflow-level \`env\` block:
  \`\`\`yaml
  env:
    NX_SELF_HOSTED_REMOTE_CACHE_SERVER: \${{ secrets.NX_CACHE_SERVER }}
    NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: \${{ (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) && secrets.NX_CACHE_RW_TOKEN || secrets.NX_CACHE_RO_TOKEN }}
  \`\`\`
  RW token only when pushing to the default branch (i.e. \`publish-master\`); everything else (PRs, feature branches) gets the RO token.
- **Cleanup**: drop the elaborate \`BuildWithCloud\`/\`BuildWithoutCloud\` and \`TestWithCloud\`/\`TestWithoutCloud\` step pairs. They existed to detect Nx Cloud credit-exhaustion errors and retry with \`--no-cloud\`. The self-hosted cache has no credit limit, so the retry path is dead code. Net diff: **+27 / -138 lines**.

## Required org secrets

Already configured at the GitHub organization level (the user confirmed this):

| Secret | Value |
| --- | --- |
| \`NX_CACHE_SERVER\` | \`https://nx-cache.mintplayer.com\` |
| \`NX_CACHE_RW_TOKEN\` | read/write token (used on push to master) |
| \`NX_CACHE_RO_TOKEN\` | read-only token (used everywhere else) |

## Test plan

- [ ] Open a no-op PR to trigger \`pull-request\` and confirm the \`Build\`/\`Test\` steps no longer log the \"organization disabled\" error
- [ ] Confirm cache reads from the self-hosted server (Nx logs \`remote cache hit/miss\` lines on each task)
- [ ] After merge, confirm \`publish-master\` populates the cache (RW token path)

## Notes

- This is independent of #283 (priority-nav). Either order of merge is fine; #283 will pick up the new cache config on its next CI run.