### PR TITLE
chore: post-zoneless follow-ups (code-snippet, version, tsconfig)

### DIFF
--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.html
@@ -15,30 +15,11 @@
 <demo-rxjs-host></demo-rxjs-host>
 
 <h2>How to do it</h2>
-<p>Declare a signal (or wrap an Observable with <code>toSignal()</code>) and call it from the <code>host</code> metadata:</p>
-
-<pre><code>{{ '@Component({\n'
-+ '  selector: "my-thing",\n'
-+ '  template: `...`,\n'
-+ '  host: {\n'
-+ '    "[style.padding.px]": "padding()",\n'
-+ '    "[class.fw-bold]":   "isBold()",\n'
-+ '  },\n'
-+ '})\n'
-+ 'export class MyThing {\n'
-+ '  padding = signal(0);\n'
-+ '  isBold  = signal(false);\n'
-+ '}\n' }}</code></pre>
+<p>Declare a signal and call it from the <code>host</code> metadata:</p>
+<bs-code-snippet [codeToCopy]="signalHostExample" [language]="'ts'"></bs-code-snippet>
 
 <p>For a value that arrives from an Observable, use <code>toSignal()</code> from <code>&#64;angular/core/rxjs-interop</code>:</p>
-
-<pre><code>{{ 'import { toSignal } from "@angular/core/rxjs-interop";\n\n'
-+ '@Component({\n'
-+ '  host: { "[style.padding.px]": "tick()" },\n'
-+ '})\n'
-+ 'export class MyThing {\n'
-+ '  readonly tick = toSignal(this.someService.tick$, { initialValue: 0 });\n'
-+ '}\n' }}</code></pre>
+<bs-code-snippet [codeToCopy]="toSignalExample" [language]="'ts'"></bs-code-snippet>
 
 <bs-alert [type]="colors.success">
   No special provider is needed. Signals integrate natively with Angular's change detector, in both zone-based and

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.spec.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.spec.ts
@@ -4,6 +4,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { AsyncHostBindingComponent, HelloComponent, RxjsHostComponent } from './async-host-binding.component';
 import { MockComponent } from 'ng-mocks';
 import { BsAlertComponent, BsAlertCloseComponent } from '@mintplayer/ng-bootstrap/alert';
+import { BsCodeSnippetComponent } from '@mintplayer/ng-bootstrap/code-snippet';
 
 describe('AsyncHostBindingComponent', () => {
   let component: AsyncHostBindingComponent;
@@ -14,6 +15,7 @@ describe('AsyncHostBindingComponent', () => {
       imports: [
         NoopAnimationsModule,
         MockComponent(BsAlertComponent), MockComponent(BsAlertCloseComponent),
+        MockComponent(BsCodeSnippetComponent),
         MockComponent(HelloComponent),
         MockComponent(RxjsHostComponent),
         AsyncHostBindingComponent,

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.ts
@@ -68,7 +68,9 @@ export class RxjsHostComponent {
 export class AsyncHostBindingComponent {
   colors = Color;
 
-  signalHostExample = dedent`
+  readonly signalHostExample = dedent`
+    import { Component, signal } from '@angular/core';
+
     @Component({
       selector: 'my-thing',
       template: \`...\`,
@@ -82,7 +84,8 @@ export class AsyncHostBindingComponent {
       isBold  = signal(false);
     }`;
 
-  toSignalExample = dedent`
+  readonly toSignalExample = dedent`
+    import { Component } from '@angular/core';
     import { toSignal } from '@angular/core/rxjs-interop';
 
     @Component({

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/async-host-binding/async-host-binding.component.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, input, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { interval, map } from 'rxjs';
+import { dedent } from 'ts-dedent';
 import { Color } from '@mintplayer/ng-bootstrap';
 import { BsAlertComponent } from '@mintplayer/ng-bootstrap/alert';
+import { BsCodeSnippetComponent } from '@mintplayer/ng-bootstrap/code-snippet';
 
 @Component({
   selector: "demo-hello",
@@ -58,10 +60,35 @@ export class RxjsHostComponent {
   styleUrls: ['./async-host-binding.component.scss'],
   imports: [
     BsAlertComponent,
+    BsCodeSnippetComponent,
     HelloComponent,
     RxjsHostComponent
   ]
 })
 export class AsyncHostBindingComponent {
   colors = Color;
+
+  signalHostExample = dedent`
+    @Component({
+      selector: 'my-thing',
+      template: \`...\`,
+      host: {
+        '[style.padding.px]': 'padding()',
+        '[class.fw-bold]':    'isBold()',
+      },
+    })
+    export class MyThing {
+      padding = signal(0);
+      isBold  = signal(false);
+    }`;
+
+  toSignalExample = dedent`
+    import { toSignal } from '@angular/core/rxjs-interop';
+
+    @Component({
+      host: { '[style.padding.px]': 'tick()' },
+    })
+    export class MyThing {
+      readonly tick = toSignal(this.someService.tick$, { initialValue: 0 });
+    }`;
 }

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.13.0",
+  "version": "21.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "5.0",
     "paths": {
       "@mintplayer/dijkstra": ["libs/mintplayer-dijkstra/src/index.ts"],
       "@mintplayer/encode-utf8": ["libs/mintplayer-encode-utf8/src/index.ts"],


### PR DESCRIPTION
## Summary
- Swap the raw `<pre><code>` blocks on the **Host Bindings with Signals** demo page for `<bs-code-snippet>`, matching every other demo page in the repo. Code samples are stored as `dedent`-ed strings on the component.
- Bump `@mintplayer/ng-bootstrap` package version to **21.14.0**.
- Silence the TypeScript *"Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0"* warning by adding `"ignoreDeprecations": "5.0"` to `tsconfig.base.json`.

## Why baseUrl can't be removed yet
TypeScript itself is fine without `baseUrl` (paths resolve relative to the tsconfig file), but Nx's vite tsconfig-paths plugin **does** still need it. The plugin (still current in `@nx/vite` 22.7.0) calls the `tsconfig-paths` npm package's `loadConfig()`, which fails when `baseUrl` is missing — vitest immediately could not resolve `@mintplayer/*` aliases. Removing `baseUrl` broke 43/89 demo test files in this branch's first attempt.

So the practical fix is the workaround the warning itself suggests: silence the deprecation. Note: TS 5.9 only accepts `"5.0"` as the `ignoreDeprecations` value — `"6.0"` yields `TS5103: Invalid value for '--ignoreDeprecations'`.

## Test plan
- [x] `nx test ng-bootstrap-demo` — 87/87 pass (2 pre-existing skips)
- [x] `nx build ng-bootstrap-demo` — clean build, no TS5103 warning
- [ ] Open the **Advanced → Async HostBinding** page and confirm the two `<bs-code-snippet>` blocks render with syntax highlighting
- [ ] Confirm the page's "Copy" button works on each snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)