### PR TITLE
refactor(signals): file-upload.fileTemplate → signal (#280, part 3/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ package version aligns its major with the supported Angular major.
 
 ## [Unreleased]
 
+## [21.16.0] — 2026-04-27
+
+### Breaking
+
+- `BsFileUploadComponent.fileTemplate` is now a
+  `WritableSignal<TemplateRef<FileUpload> | undefined>`. Code that wrote
+  `component.fileTemplate = ref` must now call
+  `component.fileTemplate.set(ref)`. The `BsFileUploadTemplateDirective` does
+  this transparently — only direct assignments to the field are affected.
+
 ## [21.15.0] — 2026-04-27
 
 ### Breaking

--- a/docs/prd-signal-migration-280.md
+++ b/docs/prd-signal-migration-280.md
@@ -150,10 +150,10 @@ For nullish-coalesce patterns (`foo ?? defaultFoo`):
 *ngTemplateOutlet="foo ?? defaultFoo; context: …"
 
 <!-- after -->
-*ngTemplateOutlet="foo()! ?? defaultFoo; context: …"
+*ngTemplateOutlet="foo() ?? defaultFoo; context: …"
 ```
 
-The `!` is needed because `signal<X | undefined>` typing keeps `undefined` in the union; the `??` short-circuits at runtime, but the type system doesn't know that without help.
+**No `!` here.** The `??` operator already widens the type from `TemplateRef<TContext> | undefined` to `TemplateRef<TContext> | TemplateRef<TDefaultContext>`. Adding `!` over-tightens the left side to `TemplateRef<TContext>` only and breaks Angular's strict template type-checker for any `context:` argument that isn't shape-compatible with `TContext` (verified empirically — broke the file-upload build with `TS2353: '$implicit' does not exist on type 'FileUpload'`). Use `!` only when the surrounding `@if`/guard already proved non-null and the TS narrowing didn't carry across the signal call.
 
 ### Pattern D — Post-increment (only `imageCounter`)
 

--- a/libs/mintplayer-ng-bootstrap/file-upload/src/component/file-upload.component.html
+++ b/libs/mintplayer-ng-bootstrap/file-upload/src/component/file-upload.component.html
@@ -7,7 +7,7 @@
 <bs-list-group class="files-list">
     @for (upload of files(); track upload.index) {
         <bs-list-group-item>
-            <ng-container *ngTemplateOutlet="fileTemplate ?? defaultFileTemplate; context: { $implicit: upload }"></ng-container>
+            <ng-container *ngTemplateOutlet="fileTemplate() ?? defaultFileTemplate; context: { $implicit: upload }"></ng-container>
         </bs-list-group-item>
     }
 </bs-list-group>

--- a/libs/mintplayer-ng-bootstrap/file-upload/src/component/file-upload.component.ts
+++ b/libs/mintplayer-ng-bootstrap/file-upload/src/component/file-upload.component.ts
@@ -28,7 +28,7 @@ export class BsFileUploadComponent {
 
   readonly colors = Color;
   isDraggingFile = signal(false);
-  fileTemplate?: TemplateRef<FileUpload>;
+  readonly fileTemplate = signal<TemplateRef<FileUpload> | undefined>(undefined);
   readonly files = model<FileUpload[]>([]);
   readonly filesDropped = output<FileUpload[]>();
 

--- a/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.spec.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { Component, Input, signal, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MockComponent } from 'ng-mocks';
+import { MockComponent, MockInstance } from 'ng-mocks';
 import { BsFileUploadComponent } from '../component/file-upload.component';
 import { BsFileUploadTemplateDirective } from './file-upload-template.directive';
 
@@ -32,7 +32,13 @@ interface MockFileUpload {
 
 describe('BsContextMenuDirective', () => {
   let fixture: ComponentFixture<FileUploadTestComponent>;
-  
+
+  MockInstance.scope();
+
+  beforeEach(() => {
+    MockInstance(BsFileUploadComponent, 'fileTemplate', signal<TemplateRef<any> | undefined>(undefined));
+  });
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
@@ -61,6 +67,6 @@ describe('BsContextMenuDirective', () => {
   });
 
   it('should contain a template', () => {
-    expect(fixture.componentInstance.fileUpload.fileTemplate).toBeDefined();
+    expect(fixture.componentInstance.fileUpload.fileTemplate()).toBeDefined();
   });
 });

--- a/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, signal, TemplateRef, ViewChild } from '@angular/core';
+import { Component, signal, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockInstance } from 'ng-mocks';
 import { BsFileUploadComponent } from '../component/file-upload.component';
@@ -30,7 +30,7 @@ interface MockFileUpload {
   progress: number;
 }
 
-describe('BsContextMenuDirective', () => {
+describe('BsFileUploadTemplateDirective', () => {
   let fixture: ComponentFixture<FileUploadTestComponent>;
 
   MockInstance.scope();

--- a/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.ts
@@ -11,9 +11,6 @@ export class BsFileUploadTemplateDirective {
   constructor() {
     const templateRef = inject(TemplateRef);
     this.fileUploadComponent.fileTemplate.set(templateRef);
-
-    // TODO: fileUploadComponent.files is now an input() signal and cannot be assigned from the directive.
-    // Consider converting files to model() on BsFileUploadComponent to restore this functionality.
   }
 
   readonly bsFileUploadTemplateOf = input<FileUpload[] | undefined>(undefined);

--- a/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/file-upload/src/directive/file-upload-template.directive.ts
@@ -10,7 +10,7 @@ export class BsFileUploadTemplateDirective {
 
   constructor() {
     const templateRef = inject(TemplateRef);
-    this.fileUploadComponent.fileTemplate = templateRef;
+    this.fileUploadComponent.fileTemplate.set(templateRef);
 
     // TODO: fileUploadComponent.files is now an input() signal and cannot be assigned from the directive.
     // Consider converting files to model() on BsFileUploadComponent to restore this functionality.

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.15.0",
+  "version": "21.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
Third PR of the signal migration plan in #280. Implements **PR-3** from `docs/prd-signal-migration-280.md` — the first Cat 3 (TemplateRef → signal) migration.

## Scope

| File | Change |
|---|---|
| `file-upload.component.ts` | `fileTemplate?: TemplateRef<FileUpload>` → `readonly fileTemplate = signal<…>(undefined)` |
| `file-upload.component.html` | `*ngTemplateOutlet="fileTemplate ?? defaultFileTemplate"` → `fileTemplate() ?? defaultFileTemplate` |
| `file-upload-template.directive.ts` | sibling directive now calls `.set(templateRef)` |
| `file-upload-template.directive.spec.ts` | added `MockInstance(BsFileUploadComponent, 'fileTemplate', signal(undefined))` so the mocked component exposes a writable signal — same pattern as the existing `dropdown-toggle.directive.spec.ts` mock for `dropdowns` |

## Breaking change

`BsFileUploadComponent.fileTemplate` is now a `WritableSignal<TemplateRef<FileUpload> | undefined>`. External code that wrote `component.fileTemplate = ref` must call `component.fileTemplate.set(ref)`. The `BsFileUploadTemplateDirective` does this transparently — only direct assignments to the field are affected.

- Bumped `libs/mintplayer-ng-bootstrap/package.json` to **21.16.0**.
- Cut `## [21.16.0] — 2026-04-27` in `CHANGELOG.md`.

## PRD correction

Pattern C in the PRD originally said to use `foo()! ?? defaultFoo` for nullish-coalesce TemplateOutlets. That advice was **wrong** — the `!` over-tightens the left side of `??` from `TemplateRef<TContext> | undefined` to `TemplateRef<TContext>`, which then collapses the union with the default's TemplateRef<…> and breaks Angular's strict template type-checker. Verified empirically by a `TS2353: '$implicit' does not exist on type 'FileUpload'` build failure during this PR. Fixed in the same commit; PR-4 and PR-5 should follow the corrected pattern (`foo() ?? defaultFoo`, no bang).

## Test plan
- [x] `nx test mintplayer-ng-bootstrap` — 169/169 pass (including 3/3 in `file-upload-template.directive.spec.ts`)
- [x] `nx test ng-bootstrap-demo` — 87/87 pass
- [x] `nx build ng-bootstrap-demo` — clean (after dropping the spurious `!`)
- [ ] CI green

## Next up
PR-4 — select2 `itemTemplate` + `suggestionTemplate` → signals (also Pattern C, two fields, two specs to update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)