### PR TITLE
refactor(signals): select2 itemTemplate + suggestionTemplate → signals (#280, part 4/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ package version aligns its major with the supported Angular major.
 
 ## [Unreleased]
 
+## [21.17.0] — 2026-04-27
+
+### Breaking
+
+- `BsSelect2Component.itemTemplate` and `BsSelect2Component.suggestionTemplate`
+  are now `WritableSignal<TemplateRef<T> | undefined>`. Code that wrote
+  `component.itemTemplate = ref` or `component.suggestionTemplate = ref` must
+  call `.set(ref)`. The `BsItemTemplateDirective` and
+  `BsSuggestionTemplateDirective` do this transparently — only direct
+  assignments to the fields are affected.
+
+### Fixed
+
+- `BsSuggestionTemplateDirective`'s spec mock declared `itemTemplate`
+  (a copy-paste from the item-template spec) instead of
+  `suggestionTemplate`. Plain assignment masked the bug at runtime; the
+  signal migration surfaced it. Now declares `suggestionTemplate`.
+
 ## [21.16.0] — 2026-04-27
 
 ### Breaking

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.16.0",
+  "version": "21.17.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-bootstrap/select2/src/component/select2.component.html
+++ b/libs/mintplayer-ng-bootstrap/select2/src/component/select2.component.html
@@ -1,7 +1,7 @@
 <bs-has-overlay></bs-has-overlay>
 <div bsDropdown [(isOpen)]="isOpen" [hasBackdrop]="false" [sameDropdownWidth]="true" #itemsBox class="items-box text-wrap" role="combobox" [attr.aria-expanded]="isOpen()">
     @for (item of selectedItems(); track item) {
-        <ng-container *ngTemplateOutlet="itemTemplate ?? defaultItemTemplate; context: { $implicit: item, select2: this }"></ng-container>
+        <ng-container *ngTemplateOutlet="itemTemplate() ?? defaultItemTemplate; context: { $implicit: item, select2: this }"></ng-container>
     }
 
     <input type="text" autocomplete="off"
@@ -16,7 +16,7 @@
     <bs-dropdown-menu *bsDropdownMenu [maxHeight]="200" role="listbox">
         @for (suggestion of suggestions(); track $index) {
             <bs-dropdown-item (click)="onSuggestionClicked(suggestion)" [isSelected]="selectedItems() | bsInList:suggestion.id" role="option" [attr.aria-selected]="(selectedItems() | bsInList:suggestion.id) || null">
-                <ng-container *ngTemplateOutlet="suggestionTemplate ?? defaultSuggestionTemplate; context: { $implicit: suggestion, select2: this }"></ng-container>
+                <ng-container *ngTemplateOutlet="suggestionTemplate() ?? defaultSuggestionTemplate; context: { $implicit: suggestion, select2: this }"></ng-container>
             </bs-dropdown-item>
         }
     </bs-dropdown-menu>

--- a/libs/mintplayer-ng-bootstrap/select2/src/component/select2.component.ts
+++ b/libs/mintplayer-ng-bootstrap/select2/src/component/select2.component.ts
@@ -45,8 +45,8 @@ export class BsSelect2Component<T extends HasId<U>, U> {
 
   private readonly charWidth = 10;
   searchWidth = signal(20);
-  itemTemplate?: TemplateRef<T>;
-  suggestionTemplate?: TemplateRef<T>;
+  readonly itemTemplate = signal<TemplateRef<T> | undefined>(undefined);
+  readonly suggestionTemplate = signal<TemplateRef<T> | undefined>(undefined);
 
   constructor() {
     effect(() => {

--- a/libs/mintplayer-ng-bootstrap/select2/src/directive/item-template/item-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/select2/src/directive/item-template/item-template.directive.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, DebugElement, TemplateRef } from '@angular/core';
+import { Component, DebugElement, signal, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BsItemTemplateDirective } from './item-template.directive';
@@ -20,7 +20,7 @@ class BsItemTemplateTestComponent { }
   selector: 'select2',
 })
 class MockBsSelect2Component {
-  itemTemplate?: TemplateRef<any>;
+  readonly itemTemplate = signal<TemplateRef<any> | undefined>(undefined);
 }
 
 describe('BsItemTemplateDirective', () => {

--- a/libs/mintplayer-ng-bootstrap/select2/src/directive/item-template/item-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/select2/src/directive/item-template/item-template.directive.ts
@@ -12,7 +12,7 @@ export class BsItemTemplateDirective<T extends HasId<U>, U> {
   private lastSourceValue?: T[];
 
   constructor() {
-    this.select2component.itemTemplate = this.templateRef;
+    this.select2component.itemTemplate.set(this.templateRef);
 
     // Sync input value to component
     effect(() => {

--- a/libs/mintplayer-ng-bootstrap/select2/src/directive/suggestion-template/suggestion-template.directive.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/select2/src/directive/suggestion-template/suggestion-template.directive.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, DebugElement, TemplateRef } from '@angular/core';
+import { Component, DebugElement, signal, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BsSuggestionTemplateDirective } from './suggestion-template.directive';
@@ -18,7 +18,7 @@ class BsSuggestionTemplateTestComponent { }
   selector: 'select2',
 })
 class MockBsSelect2Component {
-  itemTemplate?: TemplateRef<any>;
+  readonly suggestionTemplate = signal<TemplateRef<any> | undefined>(undefined);
 }
 
 describe('BsSuggestionTemplateDirective', () => {

--- a/libs/mintplayer-ng-bootstrap/select2/src/directive/suggestion-template/suggestion-template.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/select2/src/directive/suggestion-template/suggestion-template.directive.ts
@@ -10,7 +10,7 @@ export class BsSuggestionTemplateDirective<T extends HasId<U>, U> {
 
   constructor() {
     const templateRef = inject<TemplateRef<T>>(TemplateRef);
-    this.select2component.suggestionTemplate = templateRef;
+    this.select2component.suggestionTemplate.set(templateRef);
 
     effect(() => {
       const value = this.bsSuggestionTemplateOf();


### PR DESCRIPTION
Fourth PR of the signal migration plan in #280. Implements **PR-4** from `docs/prd-signal-migration-280.md`.

## Scope

| File | Change |
|---|---|
| `select2.component.ts` | Both `itemTemplate?` and `suggestionTemplate?` → `signal<TemplateRef<T> \| undefined>(undefined)`. Generic `T` preserved. |
| `select2.component.html` | Two `*ngTemplateOutlet="X ?? defaultX"` → `X() ?? defaultX` (no `!`, following the PR-3 correction to Pattern C). |
| `item-template.directive.ts` | `.set(templateRef)` instead of plain assignment. |
| `suggestion-template.directive.ts` | Same. |
| `item-template.directive.spec.ts` | Mock `MockBsSelect2Component.itemTemplate` is now a writable signal. |
| `suggestion-template.directive.spec.ts` | Same — and **fixed a pre-existing copy-paste bug**: the mock declared `itemTemplate` (carried over from the item-template spec) instead of `suggestionTemplate`. Plain assignment masked the bug; the signal migration surfaced it. |

## Breaking change

`BsSelect2Component.itemTemplate` and `BsSelect2Component.suggestionTemplate` are now `WritableSignal<TemplateRef<T> | undefined>`. Code that wrote `component.itemTemplate = ref` or `component.suggestionTemplate = ref` must call `.set(ref)`. The two sibling directives do this transparently — only direct assignments to the fields are affected.

- Bumped `libs/mintplayer-ng-bootstrap/package.json` to **21.17.0**.
- Cut `## [21.17.0] — 2026-04-27` in `CHANGELOG.md` with both the breaking change and the fixed mock bug.

## Test plan
- [x] `nx test mintplayer-ng-bootstrap` — 169/169 pass
- [x] `nx test ng-bootstrap-demo` — 87/87 pass
- [x] `nx build ng-bootstrap-demo` — clean
- [ ] CI green

## Next up
PR-5 — searchbox 3 templates (`suggestionTemplate`, `enterSearchtermTemplate`, `noResultsTemplate`) → signals. Same Pattern C, three fields, six template edits, three sibling directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)