### PR TITLE
fix(carousel): constrain image width in SSR/noscript path

### DIFF
--- a/libs/mintplayer-ng-bootstrap/carousel/src/carousel/carousel.component.scss
+++ b/libs/mintplayer-ng-bootstrap/carousel/src/carousel/carousel.component.scss
@@ -49,6 +49,18 @@
             .carousel-indicators {
                 z-index: 10;
             }
+
+            // The .carousel-item > * { width: 100% !important; } rule below
+            // doesn't reach the image in the noscript path because there's an
+            // extra .w-100.position-relative wrapper between the carousel-item
+            // and the rendered <img> (the wrapper hosts per-slide indicator
+            // labels for the radio-driven CSS-only navigation). Constrain the
+            // image directly so it can't render at its intrinsic width during
+            // the pre-hydration paint.
+            .carousel-item img {
+                width: 100%;
+                height: auto;
+            }
         }
 
         .carousel-item > * {

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.18.3",
+  "version": "21.18.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
## Summary

On initial SSR paint (before Angular hydrates), images render at their **natural intrinsic width** instead of fitting the carousel. At narrow viewports (e.g. 332px), this means a flash where images overflow the carousel by hundreds of pixels, then snap to the right size once JS takes over.

## Root cause

The carousel component already has this rule (`carousel.component.scss:54-56`):

\`\`\`scss
.carousel-item > * {
    width: 100% !important;
}
\`\`\`

It targets **direct** children of \`.carousel-item\`. On the client path, the rendered \`<img>\` is a direct child via \`*ngTemplateOutlet\`, so the rule applies and the image is 100% wide.

In the SSR/noscript path, the template wraps the image in an extra \`<div class=\"w-100 position-relative\">\` (which hosts per-slide indicator labels for the radio-driven CSS-only navigation). The rule applies to that wrapper instead — the wrapper is 100% wide (redundantly, since it already has \`w-100\`) but the image two levels deep is unconstrained, so it renders at its intrinsic 500px width.

## Fix

One scoped SCSS rule:

\`\`\`scss
.carousel.noscript .carousel-item img {
    width: 100%;
    height: auto;
}
\`\`\`

\`height: auto\` preserves aspect ratio in case any ancestor passes down a height constraint.

## Versions

- \`@mintplayer/ng-bootstrap\`: 21.18.3 → 21.18.4 (patch)
- \`@mintplayer/ng-swiper\`: unchanged

## Test plan

- [x] \`nx build mintplayer-ng-bootstrap\` — clean
- [ ] Disable JavaScript in browser DevTools, navigate to \`/basic/carousel\`, confirm images fit at narrow viewports (e.g. 332px) — no overflow.
- [ ] Re-enable JS, refresh, confirm initial pre-hydration paint also fits (no flash).
- [ ] Confirm client-side rendering at the same viewport is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)