### PR TITLE
fix(swiper,carousel): restore Firefox Android PTR suppression via bsSwipeViewport

### DIFF
--- a/libs/mintplayer-ng-bootstrap/carousel/src/carousel/carousel.component.html
+++ b/libs/mintplayer-ng-bootstrap/carousel/src/carousel/carousel.component.html
@@ -49,7 +49,7 @@
                 }
             </div>
         }
-        <div class="carousel-inner" #innerElement [style.height.px]="slideHeight()">
+        <div class="carousel-inner" bsSwipeViewport #innerElement [style.height.px]="slideHeight()">
             <div bsSwipeContainer #container="bsSwipeContainer"
                 [minimumOffset]="50"
                 [animation]="animation()"

--- a/libs/mintplayer-ng-bootstrap/carousel/src/carousel/carousel.component.ts
+++ b/libs/mintplayer-ng-bootstrap/carousel/src/carousel/carousel.component.ts
@@ -1,7 +1,7 @@
 import { isPlatformServer, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, computed, contentChildren, DestroyRef, effect, ElementRef, forwardRef, inject, input, OnDestroy, output, PLATFORM_ID, signal, TemplateRef, viewChild } from '@angular/core';
 import { Color } from '@mintplayer/ng-bootstrap';
-import { BsSwipeContainerDirective, BsSwipeDirective } from '@mintplayer/ng-swiper/swiper';
+import { BsSwipeContainerDirective, BsSwipeDirective, BsSwipeViewportDirective } from '@mintplayer/ng-swiper/swiper';
 import { BsNoNoscriptDirective } from '@mintplayer/ng-bootstrap/no-noscript';
 import { BsCarouselImageDirective } from '../carousel-image/carousel-image.directive';
 
@@ -13,6 +13,7 @@ import { BsCarouselImageDirective } from '../carousel-image/carousel-image.direc
     NgTemplateOutlet,
     BsSwipeContainerDirective,
     BsSwipeDirective,
+    BsSwipeViewportDirective,
     BsNoNoscriptDirective,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.19.1",
+  "version": "21.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-swiper/package.json
+++ b/libs/mintplayer-ng-swiper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-swiper",
   "private": false,
-  "version": "21.5.1",
+  "version": "21.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-swiper/swiper/src/directives/index.ts
+++ b/libs/mintplayer-ng-swiper/swiper/src/directives/index.ts
@@ -1,2 +1,3 @@
 export * from './swipe/swipe.directive';
 export * from './swipe-container/swipe-container.directive';
+export * from './swipe-viewport/swipe-viewport.directive';

--- a/libs/mintplayer-ng-swiper/swiper/src/directives/swipe-viewport/swipe-viewport.directive.ts
+++ b/libs/mintplayer-ng-swiper/swiper/src/directives/swipe-viewport/swipe-viewport.directive.ts
@@ -1,0 +1,30 @@
+import { Directive } from '@angular/core';
+
+/**
+ * Marks an element as the static viewport that wraps a `bsSwipeContainer`'s
+ * moving track. The element it's applied to is expected to have
+ * `overflow: hidden` (via a class or its own styling) so the moving track
+ * is clipped to a fixed window.
+ *
+ * Applies the CSS that historically lived on the consuming component's
+ * outer wrapper (bs-carousel's `.carousel-inner`):
+ *
+ * - `overscroll-behavior: contain` — keeps Firefox Android's APZ from
+ *   chaining a vertical drag into the document and triggering native
+ *   pull-to-refresh. Even though Firefox documented this as not honoured
+ *   for PTR historically, the empirical behaviour on the carousel demo
+ *   showed this property was load-bearing alongside the per-slide
+ *   `touch-action: pan-x`.
+ *
+ * - `pointer-events: none` — pairs with the `bsSwipe`'s `pe-auto` so taps
+ *   on the gaps between slides (or on the viewport's letterboxing) pass
+ *   through, while the slides themselves remain interactive.
+ */
+@Directive({
+  selector: '[bsSwipeViewport]',
+  host: {
+    '[style.overscroll-behavior]': '"contain"',
+    '[style.pointer-events]': '"none"',
+  },
+})
+export class BsSwipeViewportDirective {}


### PR DESCRIPTION
## Summary

Firefox Android pull-to-refresh started triggering on the vertical carousel again after #293 + #295. The deployed #291 build at bootstrap.mintplayer.com still suppresses PTR correctly, but master does not.

## Root cause

#293 stripped four utility classes from \`.carousel-inner\` and hoisted equivalent styles onto \`bsSwipeContainer\`'s host bindings. But \`bsSwipeContainer\` is the *moving inner layer*, not the \`overflow:hidden\` scroll container — and **\`overscroll-behavior: contain\` only takes effect on a scroll container**. On a non-scroll element, it's a no-op.

The actual scroll container is \`.carousel-inner\` (one level up), and after #293 it lost:

| Property | Was on \`.carousel-inner\` (#291) | After #293 |
|---|---|---|
| \`overscroll-behavior\` | \`contain\` (from \`.carousel-inner-vertical\`) | \`auto\` |
| \`pointer-events\` | \`none\` (from \`.pe-none\` utility class) | \`auto\` |
| \`display\` / \`flex-direction\` | \`flex\` / \`column\` | \`block\` / — |

Per-slide \`touch-action: pan-x\` is still in place, but on this user's device Firefox APZ apparently needs the \`overscroll-behavior: contain\` on the actual scroll container as a corroborating signal — the empirical regression confirms it.

## Fix

A new directive **\`bsSwipeViewport\`** in \`@mintplayer/ng-swiper\` that any consumer can apply to whichever element wraps a \`bsSwipeContainer\`'s moving track:

\`\`\`typescript
@Directive({
  selector: '[bsSwipeViewport]',
  host: {
    '[style.overscroll-behavior]': '"contain"',
    '[style.pointer-events]': '"none"',
  },
})
export class BsSwipeViewportDirective {}
\`\`\`

Carousel's \`.carousel-inner\` now has \`bsSwipeViewport\` on it. The library is self-contained: any other consumer that wraps \`bsSwipeContainer\` in an \`overflow:hidden\` element marked \`[bsSwipeViewport]\` gets the same Firefox Android suppression for free, without copying carousel SCSS.

## Why a directive instead of SCSS in bs-carousel

Per the user: putting these in \`bs-carousel\` SCSS would mean any other component using \`bsSwipeContainer\`/\`bsSwipe\` directly would silently regress on Firefox Android. The directive places the responsibility on the swipe library where it belongs.

## Versions

- \`@mintplayer/ng-swiper\`: 21.5.1 → 21.6.0 (minor — new public directive)
- \`@mintplayer/ng-bootstrap\`: 21.19.1 → 21.20.0 (minor — wires the new directive into the carousel)

## Test plan

- [x] \`nx test mintplayer-ng-swiper\` — passes
- [x] \`nx build mintplayer-ng-bootstrap\` — clean
- [ ] **Real-device test on Firefox Android** at \`localhost:4200/basic/carousel\` (vertical mode): ≥ 9/10 downward swipes advance the slide without triggering PTR overlay (parity with the #291 deployed build)
- [ ] Sanity-check that pe-auto on individual slides still receives touch correctly (gaps between slides should be click-through, slides themselves still tappable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)