### PR TITLE
chore(demo): add serve:network configuration for LAN testing

### DIFF
--- a/apps/ng-bootstrap-demo/project.json
+++ b/apps/ng-bootstrap-demo/project.json
@@ -88,6 +88,11 @@
         },
         "development": {
           "buildTarget": "ng-bootstrap-demo:build:development"
+        },
+        "network": {
+          "buildTarget": "ng-bootstrap-demo:build:development",
+          "host": "0.0.0.0",
+          "allowedHosts": ["all"]
         }
       },
       "defaultConfiguration": "development",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "nx": "nx",
     "postinstall": "node ./decorate-angular-cli.js",
     "start": "nx serve",
+    "start:network": "nx serve --configuration=network",
     "build": "nx build",
     "build:wba": "nx build --stats-json",
     "analyze:wba": "webpack-bundle-analyzer dist/apps/ng-bootstrap-demo/stats.json",


### PR DESCRIPTION
## Summary

Adds a `network` configuration on the demo app's `serve` target so the dev server can be reached from other devices on the local Wi-Fi (mainly: real-device Firefox Android testing for the carousel PTR work).

\`\`\`json
\"network\": {
  \"buildTarget\": \"ng-bootstrap-demo:build:development\",
  \"host\": \"0.0.0.0\",
  \"allowedHosts\": [\"all\"]
}
\`\`\`

`host: 0.0.0.0` binds to every interface (so the dev server is reachable at the laptop's LAN IP). `allowedHosts: [\"all\"]` skips Vite's host-header check, which would otherwise refuse requests to non-localhost hostnames.

A matching `start:network` npm script wraps it:

\`\`\`
npm run start:network
\`\`\`

Default `npm start` behaviour is unchanged.

## Test plan

- [ ] `npm run start:network` prints both `Local:` and `Network:` URLs
- [ ] `http://<laptop-ip>:4200` loads from another browser on the same Wi-Fi (firewall permitting)
- [ ] Plain `npm start` still binds to localhost only (no regression for the default flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)