### PR TITLE
feat(tab-control): extract Lit mp-tab-control + Phase 2/3 PRD

### DIFF
--- a/apps/ng-bootstrap-demo/src/app/pages/basic/containers/tab-control/tab-control.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/basic/containers/tab-control/tab-control.component.html
@@ -1,6 +1,6 @@
 <h1 class="text-center">Tab control</h1>
 <h2>Demo</h2>
-<bs-tab-control [border]="true"  [restrictDragging]="true" [tabsPosition]="tabsPosition()" [allowDragDrop]="allowDragDrop()">
+<bs-tab-control [border]="true" [tabsPosition]="tabsPosition()">
     @for (n of numbers; track $index) {
         <bs-tab-page [disabled]="n === 3">
             <ng-container *bsTabPageHeader>
@@ -26,10 +26,4 @@
             </bs-select>
         </div>
     </div>
-    <div bsRow>
-        <div [col]>
-            <bs-toggle-button class="py-2" [type]="'checkbox'" [(ngModel)]="allowDragDrop">Allow drag/drop</bs-toggle-button>
-        </div>
-    </div>
 </bs-grid>
-

--- a/apps/ng-bootstrap-demo/src/app/pages/basic/containers/tab-control/tab-control.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/basic/containers/tab-control/tab-control.component.ts
@@ -4,17 +4,15 @@ import { BsForDirective } from '@mintplayer/ng-bootstrap/for';
 import { BsGridComponent, BsGridRowDirective, BsGridColDirective } from '@mintplayer/ng-bootstrap/grid';
 import { BsSelectComponent, BsSelectOption } from '@mintplayer/ng-bootstrap/select';
 import { BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, BsTabsPosition } from '@mintplayer/ng-bootstrap/tab-control';
-import { BsToggleButtonComponent } from '@mintplayer/ng-bootstrap/toggle-button';
 
 @Component({
   selector: 'demo-tab-control',
   templateUrl: './tab-control.component.html',
   styleUrls: ['./tab-control.component.scss'],
-  imports: [FormsModule, BsForDirective, BsGridComponent, BsGridRowDirective, BsGridColDirective, BsSelectComponent, BsSelectOption, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective, BsToggleButtonComponent],
+  imports: [FormsModule, BsForDirective, BsGridComponent, BsGridRowDirective, BsGridColDirective, BsSelectComponent, BsSelectOption, BsTabControlComponent, BsTabPageComponent, BsTabPageHeaderDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TabControlComponent {
   tabsPosition = model<BsTabsPosition>('top');
   numbers = Array.from(Array(20).keys()).map(i => i + 1);
-  allowDragDrop = model(true);
 }

--- a/docs/prd/dock-splitter-tabcontrol-lit-composition.md
+++ b/docs/prd/dock-splitter-tabcontrol-lit-composition.md
@@ -174,9 +174,11 @@ Stays in Angular `BsTabControlComponent`:
 - Signal-based `input()` API surface for Angular consumers.
 - `contentChildren(BsTabPageComponent)` query — translates Angular component tree into WC DOM children.
 - `effect()`-driven auto-select-first-tab logic — keep here, the WC just exposes `active` + emits `tab-activate`.
-- CDK drag-drop reorder — Angular consumers expect `cdkDrag` ergonomics; the wrapper renders `bs-tab-page` children with CDK handlers, and projects the resulting reordered DOM into `<mp-tab-control>`.
 - `*bsTabPageHeader` directive + `NgTemplateOutlet` for header projection — the wrapper renders the directive's template into a `<span slot="header">` inside each `<mp-tab-page>` projection.
 - Dependency-injection provider (`{ provide: 'TAB_CONTROL', useExisting: BsTabControlComponent }`) for `bs-tab-page` registration.
+
+Dropped from `BsTabControlComponent`:
+- CDK drag-drop reorder. The Lit WC owns the tab-strip DOM and the host-side reorder ergonomics didn't carry through Shadow DOM cleanly. Consumers who need reorder can apply `cdkDrag` to their own projected tab content, or wait for the WC to grow a built-in reorder mode (out of scope).
 
 Moves into Lit `MpTabControl`:
 - Tab strip rendering (Lit `html\`\`` with Bootstrap `nav nav-tabs`).

--- a/docs/prd/dock-splitter-tabcontrol-lit-composition.md
+++ b/docs/prd/dock-splitter-tabcontrol-lit-composition.md
@@ -1,0 +1,322 @@
+# PRD: Dock / Splitter / Tab-control as composable Lit web components
+
+## Problem
+
+Three threads converge:
+
+1. **Tab-control has no Lit WC yet.** `bs-tab-control` (Angular) lives at `libs/mintplayer-ng-bootstrap/tab-control/` with `tab-control.component.ts:8-103`, `tab-control.component.html:1-53`, `tab-control.component.scss:1-110`, `tab-page/tab-page.component.ts:1-23`, and `tab-page-header/tab-page-header.directive.ts:1-8`. Unlike dock (`MintDockManagerElement` after PR #302) and splitter (`MpSplitter` after PR #302), there's no `mp-tab-control` web component to consume from non-Angular hosts or from inside other WCs.
+
+2. **Bootstrap-styled WCs need Bootstrap styles inside their Shadow DOM.** `bs-tab-control` applies `nav nav-tabs`, `nav-link.active`, `tab-content`, `position-relative`, `d-block` etc. on the Angular wrapper's host and inside its template (`tab-control.component.html:16-53`). Once the rendering moves into a Lit WC's Shadow DOM, those global Bootstrap classes no longer reach in — Bootstrap has to be imported into the WC's `static styles` directly. Same applies to dock (which currently has its own hand-rolled tab and split CSS in `mint-dock-manager.element.scss` instead of Bootstrap-styled).
+
+3. **The dock manager duplicates tab-strip + split rendering logic that already exists in `mp-splitter` and (soon) `mp-tab-control`.** Today `MintDockManagerElement` builds its own tab strip (`renderStack` lines 1470-1571) and its own split layout (`renderSplit` lines 1414-1468), with bespoke CSS for both. The duplication is real: ~1000-1500 lines of imperative DOM construction in the dock element are doing what `<mp-splitter>` and `<mp-tab-control>` were built for. The dock should compose those WCs and shrink to its actually-unique responsibilities: layout-tree ownership, drag-to-detach-floating, and overlay layers (intersection handles, snap markers, drop indicator/joystick).
+
+These threads are entangled: building `mp-tab-control` requires the Bootstrap-in-Shadow-DOM strategy; embedding it in dock requires `mp-splitter` to grow a few extension points; the dock-internal swap can't happen without the WC existing first.
+
+## Scope and timing
+
+This PRD captures the **target architecture**. Implementation does not have to land in a single PR.
+
+- **Phase 1 (current PR #302)**: Land the Lit base-class migration + split-file codegen + `mp-tab-control` extraction from `bs-tab-control` + Bootstrap-in-Shadow-DOM for `mp-tab-control`. Dock keeps its bespoke tab strip + split rendering (just like today). This is already a substantial PR and the work is verified in the browser.
+- **Phase 2 (follow-up PR)**: Embed `<mp-tab-control>` inside the dock's `renderStack`. Add `mp-splitter` extension points (divider opt-out, panel hidden state, mid-drag stability). Embed nested `<mp-splitter>` inside the dock's `renderSplit`. Strip dock's bespoke `.dock-tab` / `.dock-split__divider` CSS in favour of the embedded WCs.
+- **Phase 3 (follow-up PR)**: Recolour dock's overlay CSS via `--bs-*` variables for visual cohesion.
+
+Splitting into phases reduces the single-PR regression surface (the dock just migrated to Lit; stacking a major rendering-engine refactor on top tangles "did Lit break anything?" with "did the WC swap break anything?") and lets the `mp-splitter` extension API be designed deliberately rather than under PR pressure.
+
+## Goals
+
+1. Ship a new `mp-tab-control` (+ `mp-tab-page`) Lit web component with feature-equivalent behaviour to `bs-tab-control`, in its own Nx project at `libs/mp-tab-control-wc/`.
+2. Refactor `BsTabControlComponent` (Angular) to wrap that WC instead of rendering its own tab strip. Angular consumers' API stays unchanged (signal inputs, `contentChildren`, CDK drag-drop ergonomics).
+3. Move all Bootstrap-driven look-and-feel into each Lit WC's Shadow DOM via SCSS partial imports compiled through the existing `codegen-wc` pipeline. The WCs become **standalone-styled** — they work without the host page importing Bootstrap.
+4. Embed `<mp-tab-control>` inside `MintDockManagerElement` for stack tab strips, replacing `renderStack`'s bespoke `.dock-stack__header` markup.
+5. Embed nested `<mp-splitter>` inside `MintDockManagerElement` for split layouts, replacing `renderSplit`'s bespoke `.dock-split` markup. Add the minimal extension points to `mp-splitter` that this requires.
+6. Strip `mint-dock-manager.element.scss` of duplicated tab-strip + divider CSS in favour of the embedded WCs' own styles. Recolour dock's remaining overlay CSS (intersection handles, snap markers, drop indicator/joystick) via `--bs-*` variables.
+
+### Non-goals
+
+- Reactive `html\`...\``-driven re-rendering of the dock's overlay layers (intersection handles, drop indicator, drop joystick). The current "imperative DOM construction inside `firstUpdated()`" pattern (preserved from PR #302) stays.
+- Removing `bs-tab-control`'s public Angular API. The wrapper stays; only its internals change.
+- Replacing the dock's layout-tree data model (`DockLayoutNode` / `DockSplitNode` / `DockStackNode`). The tree stays as the source of truth; the dock just renders the tree by composing WC primitives instead of building DOM from scratch.
+- Replacing the dock's drag-to-floating logic. The dock continues to own pane drag, floating-window state, and drop targeting. `mp-tab-control` and `mp-splitter` are rendering primitives, not interaction owners.
+- Reimplementing the dock's intersection-handle 4-way drag inside `mp-splitter`. The intersection handle stays as a dock-owned overlay that *orchestrates* `setPanelSizes` calls across two adjacent `<mp-splitter>` instances. mp-splitter has no concept of intersections; the dock does.
+- SSR considerations beyond what already works for the existing Lit WCs.
+- Visual redesign. The intent is "look the same, render via Bootstrap classes + composed WCs."
+
+## Current state
+
+| File | Lines | Role |
+|---|---|---|
+| `libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.ts` | 103 | Angular tab control — `extends Component`, content children, signals, CDK drag-drop, header-template projection via `*bsTabPageHeader` |
+| `libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.html` | 53 | Angular template — Bootstrap `nav nav-tabs`, noscript fallback (radio inputs + `:checked` siblings), top/bottom positioning |
+| `libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.scss` | 110 | Tab-control styles — noscript `:checked` cascade for up to 20 tabs (`@for $i from 1 through 20`), border styling |
+| `libs/mintplayer-ng-bootstrap/tab-control/src/tab-page/tab-page.component.ts` | 23 | Tab page — `disabled` input, header template via `contentChild(BsTabPageHeaderDirective)` |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts` | 3985 | Dock Lit WC. `renderStack` lines 1470-1571 (tab strip), `renderSplit` lines 1414-1468 (split layout). Has its own `.dock-tab` / `.dock-split__divider` CSS. |
+| `libs/mp-splitter-wc/src/components/mp-splitter.ts` | 324 | Splitter Lit WC — flat 2+-way splitter, slot-based, `orientation` / `min-panel-size` / `touch-mode` attributes, `getPanelSizes`/`setPanelSizes`, `resize-{start,ing,end}` events |
+
+No `mp-tab-control-wc` project exists. Bootstrap is currently only available globally via `apps/ng-bootstrap-demo/src/styles.scss`; nothing is loading it inside any WC's Shadow DOM today.
+
+## Architectural decisions and trade-offs
+
+### Decision 1 — Bootstrap-in-Shadow-DOM strategy
+
+**Recommendation: Option 1 — `@use` Bootstrap partials in each WC's `*.styles.scss`, compiled by the existing `codegen-wc` pipeline.**
+
+Why over the alternatives:
+
+- **Option 2 (`adoptedStyleSheets` shared sheet)**: One parsed copy at runtime, but every WC consumer transitively imports the shared module — heavier per-WC than option 3 and only meaningfully better than option 1 if 3+ WCs share the same Bootstrap surface. We have at most one (`mp-tab-control`) right now.
+- **Option 3 (`--bs-*` CSS-variable contract + handwritten structural CSS)**: Smallest bundle, but maintenance is highest — every Bootstrap visual upgrade has to be re-implemented by hand in the WC's SCSS. We lose `nav-tabs` "for free."
+- **Option 4 (light DOM via `createRenderRoot()`)**: Free Bootstrap, but breaks `<slot>` semantics, `::part`, and style isolation. Defeats the goal of standalone-styled WCs.
+- **Option 5 (hybrid light/shadow DOM per element)**: Not possible per-element with Lit. Splitting components is not worth the API leak.
+
+Concrete shape for `libs/mp-tab-control-wc/src/styles/tab-control.styles.scss`:
+
+```scss
+// Bootstrap configuration partials
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/variables-dark';
+@import 'bootstrap/scss/maps';
+@import 'bootstrap/scss/mixins';
+
+// :root targets don't cross Shadow DOM — wrap with :host so --bs-* land on the shadow host
+:host {
+  @import 'bootstrap/scss/root';
+}
+
+// Component partial — covers .nav, .nav-tabs, .nav-link, .tab-content, .tab-pane
+@import 'bootstrap/scss/nav';
+@import 'bootstrap/scss/transitions';
+
+:host {
+  display: block;
+  position: relative;
+}
+```
+
+The existing `tools/scripts/build-web-components.mjs` runs Sass with `loadPaths: [dirname(scssPath)]`. Sass walks up to find `node_modules/bootstrap/scss/...` automatically. **Verify with a smoke compile** before assuming it works — if not, the script gains one line (`loadPaths: [dirname(scssPath), 'node_modules']`).
+
+Bootstrap as a peerDependency on each WC lib that imports it. The repo already declares `"bootstrap": "^5.3.0"` as a peerDependency of `@mintplayer/ng-bootstrap`; mirror that on `@mintplayer/tab-control` and (later) on splitter / dock if they adopt the same pattern.
+
+### Decision 2 — Dock's tab strip: bespoke vs. embed `<mp-tab-control>`
+
+**Recommendation: embed `<mp-tab-control>` inside the dock for each stack's header**, but require `mp-tab-control` to expose two extension points the bespoke implementation has today:
+
+- **Programmatic active-tab control** — the dock owns the layout tree (`DockStackNode.activePane`); it must be able to set the active tab without mp-tab-control's internal "select first non-disabled" auto-pick clobbering its choice. Achieved by exposing an `active` property on `mp-tab-control` and dispatching `tab-activate` events; the dock listens, mutates the tree, sets `active` back.
+- **Drag-to-detach hook** — dock supports dragging a tab off the strip to detach it as a floating window (`captureTabDragMetrics` lines 1780-1811, `beginPaneDrag` lines 1817-1927, threshold check 1855-1859). `mp-tab-control` doesn't need to *implement* the floating-window logic, but it must surface a `tab-drag-out` event (or expose a `dragstart`/`pointermove`/threshold-check API) the dock can hook. Easiest path: `mp-tab-control` doesn't try to absorb pointer events outside its own bounds; it lets the host install pointer listeners on its rendered tab buttons.
+
+The dock keeps its tab-drag-to-floating logic; `mp-tab-control` just hosts the tab strip's appearance and core interactions (click-to-activate, keyboard nav, ARIA, in-strip reorder via CDK in the Angular wrapper).
+
+### Decision 3 — Dock's split layout: embed nested `<mp-splitter>`
+
+**Recommendation: embed `<mp-splitter>` (nested recursively, one per `DockSplitNode`) inside the dock**, with `mp-splitter` gaining a few minimal extension points to support dock's needs. The dock's bespoke `.dock-split` / `.dock-split__divider` markup goes away.
+
+The earlier "keep bespoke" recommendation conflated three concerns; only one is a real obstacle.
+
+| Concern | Real obstacle? | How embedding addresses it |
+|---|---|---|
+| **Recursive trees** — dock has `DockSplitNode` containing other `DockSplitNode`s | No | Compose: `<mp-splitter>` containing nested `<mp-splitter>` elements as panels. mp-splitter doesn't need a "tree" concept; the dock walks the tree and renders nested WCs. |
+| **Intersection-handle 4-way drag** — single drag at split crossings moves both perpendicular dividers in sync | No | Stays as a dock-owned overlay on `.dock-intersections-layer`. The dock orchestrates by calling `setPanelSizes()` on the two relevant `<mp-splitter>` instances simultaneously. mp-splitter doesn't need to know intersections exist. |
+| **Snap markers** during corner-handle drag | No | Dock-owned overlay layer, independent of any splitter. |
+| **Sizes persisted in tree** — `DockSplitNode.sizes` is the source of truth | No | Dock listens for `mp-splitter`'s `resize-end` events, writes back to the tree, calls `setPanelSizes()` on initial render to apply the persisted sizes. mp-splitter already exposes both halves of this contract. |
+| **Mid-drag tree mutation** — drag-to-floating removes a pane from a stack mid-drag, which can change a parent split's child count | **Yes — real** | Needs careful sequencing: the dock either completes the drag-to-floating gesture *before* mutating the slotted children of the affected `<mp-splitter>`, or `mp-splitter` gains a "panel hidden" mode where a panel is excluded from layout without slot churn. The PRD recommends the latter (see extension points below). |
+
+What `mp-splitter` needs to gain to support dock embedding (estimated ~50-100 LoC):
+
+- **`hidden-panels` API** — a way to mark individual panels as excluded from the layout (skip them when laying out flex sizes; collapse adjacent dividers). Lets the dock visually "remove" a pane from a split during drag-to-floating without re-projecting all slot children. Could be an attribute (`hidden` on the slotted child) or a programmatic `setPanelVisibility(index, visible)` method.
+- **Divider opt-out / divider-element exposure** — for the corner-handle case, the dock's intersection handle wraps multiple dividers from sibling splitters. The dock needs either (a) a way to disable mp-splitter's own pointer handling on a given divider, or (b) a stable reference to the divider DOM element so the dock can attach its own listeners. Recommendation: expose dividers as a queryable part (`::part(divider-N)`) and accept a `data-no-resize` attribute on a panel to suppress the divider after it.
+- **Stable size handling across panel-count changes** — verify `setPanelSizes(sizes: number[])` behaves correctly when called immediately after a `slotchange` reduces panel count. If `mp-splitter` currently re-derives sizes from the previous flex values, that's already correct; if it caches sizes by index, dock's mutation will misalign. Add a smoke test.
+
+What stays purely in the dock (overlays, not duplication):
+
+- The intersection-handle layer (`.dock-intersections-layer`) and its 4-way orchestration logic.
+- The snap-marker layer.
+- The drop indicator + drop joystick.
+- The floating-window layer.
+- The layout tree itself (`DockLayoutSnapshot`, serialisation, drag-to-floating mutations).
+
+What goes away:
+
+- `renderSplit` (lines 1414-1468 of `mint-dock-manager.element.ts`) — replaced by recursive `<mp-splitter>` rendering of `DockSplitNode`s.
+- Dock's bespoke `.dock-split` / `.dock-split__child` / `.dock-split__divider` CSS (lines 210-278 of `mint-dock-manager.element.scss`) — `mp-splitter`'s shadow styles cover this.
+- Dock's bespoke resize state machine (`resizeState`, `beginResize`, lines 1573-1650) — `mp-splitter` owns single-divider resize. Dock keeps only the corner-handle (cross-splitter) coordination.
+
+Estimated dock element shrinkage: **~1000-1500 lines** removed (renderSplit + resize state machine + tab-strip rendering when paired with Decision 2). Net dock complexity drops dramatically; what remains is exactly the dock-specific stuff (tree ownership, drag-to-float, overlays).
+
+### Decision 4 — `mp-tab-control` projection model
+
+Two options for how `mp-tab-page` content lands inside `mp-tab-control`:
+
+**Option A** — One `mp-tab-page` element per tab, each with two named slots (`header`, default for content):
+```html
+<mp-tab-control>
+  <mp-tab-page disabled>
+    <span slot="header">Tab 1</span>
+    Panel content 1
+  </mp-tab-page>
+  ...
+</mp-tab-control>
+```
+`mp-tab-page` registers itself with the parent `mp-tab-control` in `connectedCallback` (no DI, just walk up to the parent element).
+
+**Option B** — Per-tab named slots on `mp-tab-control` itself, no child element:
+```html
+<mp-tab-control>
+  <span slot="header-tab1">Tab 1</span>
+  <div slot="content-tab1">Panel content 1</div>
+  ...
+</mp-tab-control>
+```
+
+**Recommendation: Option A.** Mirrors `bs-tab-control`'s `bs-tab-page` model, keeps `disabled` as an attribute on the page (not on a sibling), and is what consumers (including the Angular wrapper) most naturally project into. Option B forces consumers to invent unique tab IDs and pair them by slot name — clumsier.
+
+### Decision 5 — Wrapper-vs-WC split for tab-control
+
+Stays in Angular `BsTabControlComponent`:
+- Signal-based `input()` API surface for Angular consumers.
+- `contentChildren(BsTabPageComponent)` query — translates Angular component tree into WC DOM children.
+- `effect()`-driven auto-select-first-tab logic — keep here, the WC just exposes `active` + emits `tab-activate`.
+- CDK drag-drop reorder — Angular consumers expect `cdkDrag` ergonomics; the wrapper renders `bs-tab-page` children with CDK handlers, and projects the resulting reordered DOM into `<mp-tab-control>`.
+- `*bsTabPageHeader` directive + `NgTemplateOutlet` for header projection — the wrapper renders the directive's template into a `<span slot="header">` inside each `<mp-tab-page>` projection.
+- Dependency-injection provider (`{ provide: 'TAB_CONTROL', useExisting: BsTabControlComponent }`) for `bs-tab-page` registration.
+
+Moves into Lit `MpTabControl`:
+- Tab strip rendering (Lit `html\`\`` with Bootstrap `nav nav-tabs`).
+- Tab content panel switching (active vs hidden).
+- Click-to-activate, keyboard (Enter/Space, Arrow keys for tab strip).
+- ARIA (`role=tablist`, `role=tab`, `role=tabpanel`, `aria-selected`, `aria-controls`).
+- Top/bottom tab positioning.
+- Noscript fallback (`<input type="radio">` + `:checked` siblings) — works inside Shadow DOM since the radios + labels are in the same scope.
+- `border` attribute → CSS class toggle.
+
+The drag-drop reorder logic stays in the wrapper; `mp-tab-control` exposes `tab-reorder` events the wrapper consumes if/when it wants to push state back.
+
+## Proposed file layout
+
+```text
+libs/mp-tab-control-wc/
+├── package.json                     # @mintplayer/tab-control-wc; deps: lit, tslib; peer: bootstrap
+├── project.json                     # @nx/js:tsc build + codegen-wc target (mirrors mp-splitter-wc)
+├── tsconfig.json
+├── tsconfig.lib.json
+├── vitest.config.ts
+└── src/
+    ├── index.ts                     # Re-exports
+    ├── components/
+    │   ├── index.ts
+    │   ├── mp-tab-control.ts        # Lit WC, ~250 LoC
+    │   └── mp-tab-page.ts           # Lit WC, ~80 LoC
+    ├── styles/
+    │   ├── index.ts
+    │   └── tab-control.styles.scss  # Bootstrap nav/buttons/transitions partials + :host
+    └── types/
+        ├── index.ts
+        └── tabs-position.ts         # 'top' | 'bottom'
+
+libs/mintplayer-ng-bootstrap/tab-control/  # existing — refactored
+├── src/
+│   ├── tab-control/
+│   │   ├── tab-control.component.ts        # wraps mp-tab-control; signals → properties via effect()
+│   │   ├── tab-control.component.html      # <mp-tab-control [attr...]><ng-content/></mp-tab-control>
+│   │   └── tab-control.component.scss      # leaner — only :host margin/spacing concerns
+│   ├── tab-page/
+│   │   ├── tab-page.component.ts           # wraps mp-tab-page
+│   │   ├── tab-page.component.html         # <mp-tab-page><span slot="header">...</span><ng-content/></mp-tab-page>
+│   │   └── tab-page.component.scss
+│   └── tab-page-header/
+│       └── tab-page-header.directive.ts    # unchanged
+```
+
+Update workspace root:
+- Add `@mintplayer/tab-control-wc` path mapping in `tsconfig.base.json`.
+- The `nx run-many --target=codegen-wc` postinstall picks up the new lib automatically (no edits to root `package.json`).
+- `libs/mintplayer-ng-bootstrap/package.json` — add `@mintplayer/tab-control-wc` as peerDependency (mirrors `@mintplayer/splitter`, `@mintplayer/scheduler-wc`).
+
+For dock + splitter: extend each `*.styles.scss` to import the relevant Bootstrap partials. Likely targets:
+- `mint-dock-manager.element.scss` — `_root.scss` (variables), `_buttons.scss` (joystick buttons), retain bespoke `.dock-*` rules but recolour via `--bs-*` variables.
+- `splitter.styles.scss` — `_root.scss`, plus `--bs-border-color` references already aligned with `--mp-splitter-divider-color`. Light touch.
+
+## Build wiring
+
+No new build infrastructure. Existing `codegen-wc` pipeline handles all SCSS-with-Bootstrap-imports compilation transparently. Three concrete checks:
+
+1. **Sass `loadPaths`**: confirm Sass resolves `bootstrap/scss/...` from `node_modules` automatically. If not, extend `loadPaths` in `tools/scripts/build-web-components.mjs` to include `node_modules` (one-line change).
+2. **`:root` rewrite**: Bootstrap's `_root.scss` emits selectors against `:root`, which doesn't cross Shadow DOM. Wrap with `:host { @import 'bootstrap/scss/root'; }` in each WC's SCSS so `--bs-*` variables bind to the shadow host. (Smaller change than post-processing the compiled CSS.)
+3. **Bundle size**: each WC that imports Bootstrap partials brings ~10-15 KB compiled CSS for the configuration + `_root.scss` block. Acceptable. If 3+ WCs share the same partial set later, factor into `libs/wc-shared-styles/` and `@use` from each.
+
+## Migration plan (phased)
+
+### Phase 1 (recommended for current PR #302 scope)
+
+1. **Verify Sass + Bootstrap-from-node_modules resolves cleanly.** Smoke-compile a test SCSS that imports `bootstrap/scss/_nav.scss` via the existing `codegen-wc` pipeline. If it fails, fix `loadPaths` first.
+2. **Scaffold `libs/mp-tab-control-wc/`** with package.json, project.json (codegen-wc + build), tsconfig.lib.json, vitest config — copy the mp-splitter-wc structure.
+3. **Author `MpTabControl` + `MpTabPage` Lit WCs** with feature parity to bs-tab-control: top/bottom strip, active tab, disabled tabs, ARIA, keyboard, noscript fallback. Use Bootstrap nav classes from the imported partials.
+4. **Add `tsconfig.base.json` path mapping**: `"@mintplayer/tab-control-wc": ["libs/mp-tab-control-wc/src/index.ts"]`.
+5. **Refactor `BsTabControlComponent`** to render `<mp-tab-control>` and project `bs-tab-page` content as `<mp-tab-page>` children. Keep CDK drag-drop and signal-based API unchanged externally.
+6. **Update `bs-tab-page`** template to wrap content in `<mp-tab-page>` with a `<span slot="header">` for the projected `*bsTabPageHeader` template.
+7. **Smoke-test bs-tab-control demo page in the browser.** Visual diff against `master`.
+
+After Phase 1 the dock still uses its bespoke tab strip + split rendering — same as today. The wins are: a new reusable `mp-tab-control` WC, Bootstrap-styled inside Shadow DOM, and `bs-tab-control` refactored to wrap it. PR scope stays manageable.
+
+### Phase 2 (follow-up PR — dock embeds the WCs)
+
+8. **Add extension points to `mp-splitter`** (in a focused commit per extension):
+   - `hidden-panels` mode (panel marked hidden is excluded from flex layout, adjacent divider collapses).
+   - Divider opt-out / `::part(divider-N)` exposure (so the dock can suppress mp-splitter's pointer handling on dividers wrapped by an intersection handle).
+   - Smoke-test that `setPanelSizes()` behaves correctly across panel-count changes.
+9. **Refactor `MintDockManagerElement.renderSplit`** to render nested `<mp-splitter>` per `DockSplitNode`. Wire `resize-end` events back to the layout tree. Apply persisted sizes on initial render via `setPanelSizes()`. Keep `cornerResizeState` orchestration on top of the embedded splitters.
+10. **Refactor `MintDockManagerElement.renderStack`** to embed `<mp-tab-control>` per `DockStackNode`. Wire active-pane events and the dock's drag-to-detach-floating pointer handling on the tab buttons.
+11. **Strip dock's bespoke tab + split CSS** from `mint-dock-manager.element.scss` (`.dock-tab*`, `.dock-stack__header`, `.dock-stack__content`, `.dock-stack__pane`, `.dock-split*`).
+12. **Smoke-test dock demo page**: tab activation, tab reorder, tab drag-to-detach (single-pane and multi-pane stacks), divider drag, intersection-handle 4-way drag, snap markers during drag, drop indicator + joystick, floating-window resize, layout serialisation round-trip.
+
+### Phase 3 (follow-up PR — visual polish)
+
+13. **Recolour dock's overlay CSS** (intersection handles, snap markers, drop indicator, drop joystick, floating chrome) via `--bs-*` variables for visual cohesion. Drop hand-coded `rgba(...)` colours where there's a `--bs-*` equivalent.
+14. **Update `docs/prd/` index** to reflect the now-completed migration.
+
+## Risks
+
+| Risk | Phase | Mitigation |
+|---|---|---|
+| Bootstrap's `_root.scss` interaction with `:host` produces unexpected CSS variable scoping | 1 | Wrap explicitly in `:host { @import ... }`; verify with a manual `getComputedStyle` smoke test in the browser console after first render. |
+| Bundle size grows per-WC (~10-15 KB CSS each) | 1 | Factor shared SCSS into `libs/wc-shared-styles/` once a third WC adopts the same partials. Out of scope today. |
+| `bs-tab-control` Angular consumers depend on the rendered DOM structure (e.g. CSS selectors targeting `.nav-tabs > .nav-item`) | 1 | Audit demo-app usages before merging. The PR preserves the same DOM tree inside the WC's Shadow DOM, but global selectors targeting the WC's interior will not work — that's a Shadow DOM property, not a regression. |
+| Noscript fallback (radio-input + `:checked` siblings) doesn't work the same way inside Shadow DOM | 1 | Verify in a browser with JavaScript disabled. The radios + labels live inside the same shadow tree, so `:checked` sibling selectors should still cascade — but confirm. |
+| Sass cannot resolve `bootstrap/scss/...` from `node_modules` automatically | 1 | One-line fix: add `'node_modules'` to `loadPaths` in `tools/scripts/build-web-components.mjs`. Detected at first compile. |
+| Dock's tab-drag-to-floating logic breaks because `mp-tab-control` intercepts pointer events | 2 | `mp-tab-control` does not attach `pointermove` listeners outside its own bounds. The dock installs its own `pointerdown` listeners on the rendered tab buttons (queried via `::part` or shadow-querySelector). Document this contract on `mp-tab-control`. |
+| Mid-drag layout-tree mutation desyncs from `<mp-splitter>`'s slot children | 2 | `mp-splitter` gains a "panel hidden" mode so the dock can mark a pane as excluded without churning slot projection. Drag-to-floating commits the tree mutation only after the gesture completes; during the gesture the visual placeholder is overlay, not slot manipulation. |
+| Intersection-handle 4-way drag doesn't compose cleanly across two `<mp-splitter>` instances | 2 | The dock keeps `cornerResizeState` and orchestrates by computing the new size deltas itself, then calling `setPanelSizes()` on the two relevant splitters in the same animation frame. mp-splitter exposes a `data-no-resize` attribute on a panel to suppress its own divider for the corner case. |
+| Snap markers misalign because the dock's overlay layer is positioned independently of the splitter's divider DOM | 2 | The dock queries each `<mp-splitter>`'s divider geometry (via `::part(divider-N)`) at frame start; same math, different selector. |
+| `setPanelSizes()` behaviour across slot-children changes is undefined | 2 | Add a unit test in `mp-splitter-wc` covering: panel removal between calls, panel addition, panel hidden state. Land this test before the dock embed. |
+| Visual regressions from dock embedding mp-tab-control / mp-splitter (Phase 2) get tangled with Lit migration regressions (PR #302) | 2 | Keep Phase 2 as a separate PR landing after PR #302 has been in `master` for a non-zero period. Each phase is independently reviewable. |
+| Visual regressions from migrating dock's hand-rolled colours to `--bs-*` variables | 3 | Keep the colour migration to a clearly-bounded subset; if it introduces visible drift, defer pieces to follow-up PRs. |
+
+## Open questions
+
+1. **`mp-tab-control` reorder events** — does `mp-tab-control` fire its own `tab-reorder` event for in-strip reordering, or is reorder strictly the wrapper's CDK responsibility (no events from the WC)? Recommendation: WC fires `tab-reorder` so non-Angular consumers also get the behaviour; Angular wrapper listens *or* overrides with CDK by intercepting pointerdown.
+2. **Dock-internal `mp-tab-page` slot population** — the dock currently uses `<slot name="paneName">` projection (line 1562 of `mint-dock-manager.element.ts`). When the dock embeds `mp-tab-control`, the projection chain becomes: dock's host slots → `mp-tab-control` → `mp-tab-page` → user's pane content. Need to validate the projection works through three levels of Shadow DOM. (Spoiler: it does in Lit, but worth confirming with an integration smoke test.)
+3. **Splitter Bootstrap touch** — does `mp-splitter` need any Bootstrap import at all, or is `--mp-splitter-divider-color` sufficient and we just rebind it to `--bs-border-color` as the default? Recommendation: rebind defaults, no full Bootstrap import.
+
+## Acceptance criteria
+
+### Phase 1
+
+- [ ] `mp-tab-control` and `mp-tab-page` exist as Lit WCs in `libs/mp-tab-control-wc/`, registered as custom elements, importable from `@mintplayer/tab-control-wc`.
+- [ ] `BsTabControlComponent` renders via `<mp-tab-control>` internally; its public Angular API (signal inputs, `contentChildren`, drag-drop) is unchanged for consumers.
+- [ ] Bootstrap styles for `nav`/`nav-tabs`/`tab-content`/`tab-pane` are imported into `mp-tab-control`'s Shadow DOM via `@import 'bootstrap/scss/...'`.
+- [ ] `--bs-*` custom properties are scoped to `:host` inside each WC that imports `_root.scss`.
+- [ ] `npm run build` succeeds end-to-end.
+- [ ] Visual smoke-test of `bs-tab-control` demo page shows no regression vs `master`.
+- [ ] `mp-tab-control` works standalone in a plain HTML page with only the WC's own JS imported (no external CSS).
+
+### Phase 2
+
+- [ ] `mp-splitter` exposes the documented extension points: `hidden` panel mode, divider opt-out (`data-no-resize` panel attribute or equivalent), `::part(divider-N)`. Each has a unit test.
+- [ ] `MintDockManagerElement.renderStack` embeds `<mp-tab-control>` per `DockStackNode`. The bespoke `.dock-stack__header` and tab markup is removed.
+- [ ] `MintDockManagerElement.renderSplit` embeds nested `<mp-splitter>` per `DockSplitNode`. The bespoke `.dock-split` markup is removed.
+- [ ] Dock element file size shrinks by ~1000-1500 lines.
+- [ ] All existing dock behaviours still work in the browser: tab activation, in-strip tab reorder, tab drag-to-detach-as-floating-window, single-divider drag, intersection-handle 4-way drag, snap markers during corner drag, drop indicator + drop joystick, floating-window resize, layout serialisation round-trip.
+- [ ] Dock's bespoke tab + split CSS is removed from `mint-dock-manager.element.scss`. (Overlay CSS — intersection handles, snap markers, drop indicator/joystick — stays.)
+
+### Phase 3
+
+- [ ] Dock's overlay CSS references `--bs-*` variables (intersection handle uses `--bs-primary`, snap markers use `--bs-primary`, drop indicator uses `--bs-primary` + `--bs-primary-bg-subtle`, etc.).
+- [ ] No visual regression vs Phase 2 except the colour palette shift (which is intentional).

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -29,7 +29,8 @@
     "@mintplayer/ng-swiper": "^21.3.0",
     "@mintplayer/scheduler-core": "^1.1.0",
     "@mintplayer/scheduler-wc": "^2.0.0",
-    "@mintplayer/splitter": "^2.0.0"
+    "@mintplayer/splitter": "^2.0.0",
+    "@mintplayer/tab-control-wc": "^1.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.html
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.html
@@ -1,53 +1,62 @@
-@for (tab of orderedTabPages(); track tab) {
-	<input type="radio" class="d-none" bsNoNoscript
-		[name]="tabControlName()"
-		[id]="tab.tabName()"
-		[checked]="checkedTab() === tab"
-		[disabled]="tab.disabled()">
-}
-@let activeTabValue = activeTab();
-<ng-template #tabStrip>
-	<ul cdkDropList #list #tabList="cdkDropList"
-		[cdkDropListData]="tabPages()"
-		[cdkDropListConnectedTo]="[]"
-		[cdkDropListOrientation]="'horizontal'"
-		(cdkDropListDropped)="moveTab($event)"
-		[cdkDropListDisabled]="disableDragDrop()"
-		class="nav nav-tabs flex-nowrap overflow-x-auto overflow-y-hidden"
-		role="tablist">
+@if (isServerSide) {
+	@for (tab of orderedTabPages(); track tab) {
+		<input type="radio" class="d-none" bsNoNoscript
+			[name]="tabControlName()"
+			[id]="tab.tabName()"
+			[checked]="checkedTab() === tab"
+			[disabled]="tab.disabled()">
+	}
+	@let activeTabValue = activeTab();
+	<ng-template #tabStrip>
+		<ul class="nav nav-tabs flex-nowrap overflow-x-auto overflow-y-hidden" role="tablist">
+			@for (tab of orderedTabPages(); track tab) {
+				@if (tab.headerTemplate()) {
+					<li class="nav-item" role="presentation">
+						<label
+							[for]="tab.tabName()"
+							[id]="tab.tabName() + '-header'"
+							class="nav-link text-nowrap"
+							[class.active]="activeTabValue === tab"
+							[class.disabled]="tab.disabled()"
+							role="tab"
+							[attr.tabindex]="tab.disabled() ? -1 : 0"
+							[attr.aria-selected]="activeTabValue === tab"
+							[attr.aria-controls]="tab.tabName() + '-panel'"
+							[attr.aria-disabled]="tab.disabled() || null">
+							<ng-container [ngTemplateOutlet]="tab.headerTemplate()!.template"></ng-container>
+						</label>
+					</li>
+				}
+			}
+		</ul>
+	</ng-template>
+	@if (topTabs()) {
+		<div class="overflow-hidden mw-100 tsc">
+			<ng-container [ngTemplateOutlet]="tabStrip"></ng-container>
+		</div>
+	}
+	<div class="tab-content flex-grow-1 overflow-auto" bsNoNoscript [class.border]="border() && activeTabValue" [class.border-top]="border() && !activeTabValue">
+		<ng-content></ng-content>
+	</div>
+	@if (bottomTabs()) {
+		<div class="overflow-hidden mw-100 tsc bottom-tabs">
+			<ng-container [ngTemplateOutlet]="tabStrip"></ng-container>
+		</div>
+	}
+} @else {
+	<mp-tab-control #wc
+		[attr.tabs-position]="tabsPosition()"
+		[attr.border]="border() ? null : 'false'"
+		[attr.active-tab]="activeTabName()"
+		[attr.select-first-tab]="selectFirstTab() ? null : 'false'"
+		(tab-activate)="onTabActivate($event)">
 		@for (tab of orderedTabPages(); track tab) {
 			@if (tab.headerTemplate()) {
-				<li class="nav-item" role="presentation" cdkDrag [cdkDragBoundary]="dragBoundarySelector()" [cdkDragStartDelay]="500" (cdkDragStarted)="startDragTab($event)">
-					<label
-						[for]="tab.tabName()"
-						[id]="tab.tabName() + '-header'"
-						class="nav-link text-nowrap"
-						[class.active]="activeTabValue === tab"
-						[class.disabled]="tab.disabled()"
-						role="tab"
-						[attr.tabindex]="tab.disabled() ? -1 : 0"
-						[attr.aria-selected]="activeTabValue === tab"
-						[attr.aria-controls]="tab.tabName() + '-panel'"
-						[attr.aria-disabled]="tab.disabled() || null"
-						(click)="setActiveTab(tab, $event)"
-						(keydown)="headerKeydown(tab, $event)">
-						<ng-container [ngTemplateOutlet]="tab.headerTemplate()!.template"></ng-container>
-					</label>
-				</li>
+				<span [attr.slot]="tab.tabName() + '-header'">
+					<ng-container [ngTemplateOutlet]="tab.headerTemplate()!.template"></ng-container>
+				</span>
 			}
 		}
-	</ul>
-</ng-template>
-@if (topTabs()) {
-	<div class="overflow-hidden mw-100 tsc">
-		<ng-container [ngTemplateOutlet]="tabStrip"></ng-container>
-	</div>
-}
-<div class="tab-content flex-grow-1 overflow-auto" bsNoNoscript [class.border]="border() && activeTabValue" [class.border-top]="border() && !activeTabValue">
-	<ng-content></ng-content>
-</div>
-@if (bottomTabs()) {
-	<div class="overflow-hidden mw-100 tsc bottom-tabs">
-		<ng-container [ngTemplateOutlet]="tabStrip"></ng-container>
-	</div>
+		<ng-content></ng-content>
+	</mp-tab-control>
 }

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.html
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.html
@@ -1,5 +1,5 @@
 @if (isServerSide) {
-	@for (tab of orderedTabPages(); track tab) {
+	@for (tab of tabPages(); track tab) {
 		<input type="radio" class="d-none" bsNoNoscript
 			[name]="tabControlName()"
 			[id]="tab.tabName()"
@@ -9,7 +9,7 @@
 	@let activeTabValue = activeTab();
 	<ng-template #tabStrip>
 		<ul class="nav nav-tabs flex-nowrap overflow-x-auto overflow-y-hidden" role="tablist">
-			@for (tab of orderedTabPages(); track tab) {
+			@for (tab of tabPages(); track tab) {
 				@if (tab.headerTemplate()) {
 					<li class="nav-item" role="presentation">
 						<label
@@ -50,7 +50,7 @@
 		[attr.active-tab]="activeTabName()"
 		[attr.select-first-tab]="selectFirstTab() ? null : 'false'"
 		(tab-activate)="onTabActivate($event)">
-		@for (tab of orderedTabPages(); track tab) {
+		@for (tab of tabPages(); track tab) {
 			@if (tab.headerTemplate()) {
 				<span [attr.slot]="tab.tabName() + '-header'">
 					<ng-container [ngTemplateOutlet]="tab.headerTemplate()!.template"></ng-container>

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.spec.ts
@@ -1,7 +1,5 @@
-import { DragDropModule } from '@angular/cdk/drag-drop';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MockModule } from 'ng-mocks';
 
 import { BsTabControlComponent } from './tab-control.component';
 
@@ -12,7 +10,6 @@ describe('BsTabControlComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        MockModule(DragDropModule),
         // Component to test
         BsTabControlComponent,
 

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.ts
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.ts
@@ -1,7 +1,9 @@
 import { CdkDragDrop, CdkDragStart, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
-import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, contentChildren, effect, ElementRef, inject, input, signal } from '@angular/core';
+import { isPlatformServer, NgTemplateOutlet } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, contentChildren, CUSTOM_ELEMENTS_SCHEMA, effect, ElementRef, inject, input, PLATFORM_ID, signal } from '@angular/core';
 import { BsNoNoscriptDirective } from '@mintplayer/ng-bootstrap/no-noscript';
+import '@mintplayer/tab-control-wc';
+import type { TabActivateEventDetail } from '@mintplayer/tab-control-wc';
 import { BsTabPageComponent } from '../tab-page/tab-page.component';
 import { BsTabsPosition } from '../tabs-position';
 
@@ -14,12 +16,16 @@ import { BsTabsPosition } from '../tabs-position';
     { provide: 'TAB_CONTROL', useExisting: BsTabControlComponent }
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
   host: {
     'class': 'd-block position-relative',
   },
 })
 export class BsTabControlComponent {
   element = inject(ElementRef);
+  private platformId = inject(PLATFORM_ID);
+
+  readonly isServerSide = isPlatformServer(this.platformId);
 
   constructor() {
     this.tabControlId = signal(++BsTabControlComponent.tabControlCounter);
@@ -67,6 +73,8 @@ export class BsTabControlComponent {
     if (!this.selectFirstTab()) return null;
     return this.orderedTabPages().find(t => !t.disabled()) ?? null;
   });
+  // Stable string ID of the active tab, fed to <mp-tab-control [active-tab]>.
+  activeTabName = computed(() => this.checkedTab()?.tabName() ?? null);
   static tabControlCounter = 0;
   tabCounter = 0;
 
@@ -78,14 +86,16 @@ export class BsTabControlComponent {
     return false;
   }
 
-  headerKeydown(tab: BsTabPageComponent, event: KeyboardEvent) {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      this.setActiveTab(tab);
+  onTabActivate(event: Event) {
+    const ce = event as CustomEvent<TabActivateEventDetail>;
+    const tabName = ce.detail.tabId;
+    const tab = this.tabPages().find(tp => tp.tabName() === tabName);
+    if (tab && !tab.disabled()) {
+      this.activeTab.set(tab);
     }
   }
 
-  startDragTab(ev: CdkDragStart<BsTabPageComponent>) {
+  startDragTab(_ev: CdkDragStart<BsTabPageComponent>) {
     if ('vibrate' in navigator) {
       navigator.vibrate([30]);
     }

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.ts
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-control/tab-control.component.ts
@@ -1,4 +1,3 @@
-import { CdkDragDrop, CdkDragStart, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { isPlatformServer, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, contentChildren, CUSTOM_ELEMENTS_SCHEMA, effect, ElementRef, inject, input, PLATFORM_ID, signal } from '@angular/core';
 import { BsNoNoscriptDirective } from '@mintplayer/ng-bootstrap/no-noscript';
@@ -11,7 +10,7 @@ import { BsTabsPosition } from '../tabs-position';
   selector: 'bs-tab-control',
   templateUrl: './tab-control.component.html',
   styleUrls: ['./tab-control.component.scss'],
-  imports: [NgTemplateOutlet, DragDropModule, BsNoNoscriptDirective],
+  imports: [NgTemplateOutlet, BsNoNoscriptDirective],
   providers: [
     { provide: 'TAB_CONTROL', useExisting: BsTabControlComponent }
   ],
@@ -41,37 +40,23 @@ export class BsTabControlComponent {
         }
       }
     });
-
-    // Update orderedTabPages whenever content children change
-    effect(() => {
-      const list = this.tabPages();
-      this.orderedTabPages.update(current => {
-        const toAdd = list.filter(tp => !current.includes(tp));
-        return current.concat(toAdd).filter((tp) => list.includes(tp));
-      });
-    });
   }
 
   border = input(true);
-  restrictDragging = input(false);
   selectFirstTab = input(true);
   tabsPosition = input<BsTabsPosition>('top');
-  allowDragDrop = input(false);
 
-  dragBoundarySelector = computed(() => this.restrictDragging() ? 'ul' : '');
   readonly tabPages = contentChildren(BsTabPageComponent);
   activeTab = signal<BsTabPageComponent | null>(null);
-  orderedTabPages = signal<BsTabPageComponent[]>([]);
   tabControlId = signal<number>(0);
   tabControlName = computed(() => `bs-tab-control-${this.tabControlId()}`);
   topTabs = computed(() => this.tabsPosition() === 'top');
   bottomTabs = computed(() => this.tabsPosition() === 'bottom');
-  disableDragDrop = computed(() => !this.allowDragDrop());
   checkedTab = computed(() => {
     const active = this.activeTab();
     if (active) return active;
     if (!this.selectFirstTab()) return null;
-    return this.orderedTabPages().find(t => !t.disabled()) ?? null;
+    return this.tabPages().find(t => !t.disabled()) ?? null;
   });
   // Stable string ID of the active tab, fed to <mp-tab-control [active-tab]>.
   activeTabName = computed(() => this.checkedTab()?.tabName() ?? null);
@@ -92,22 +77,6 @@ export class BsTabControlComponent {
     const tab = this.tabPages().find(tp => tp.tabName() === tabName);
     if (tab && !tab.disabled()) {
       this.activeTab.set(tab);
-    }
-  }
-
-  startDragTab(_ev: CdkDragStart<BsTabPageComponent>) {
-    if ('vibrate' in navigator) {
-      navigator.vibrate([30]);
-    }
-  }
-
-  moveTab(ev: CdkDragDrop<readonly BsTabPageComponent[]>) {
-    if (ev.previousContainer === ev.container) {
-      this.orderedTabPages.update(current => {
-        const copy = [...current];
-        moveItemInArray(copy, ev.previousIndex, ev.currentIndex);
-        return copy;
-      });
     }
   }
 }

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-page/tab-page.component.html
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-page/tab-page.component.html
@@ -1,8 +1,12 @@
-<div [id]="tabName() + '-panel'"
-    class="tab-page-content"
-    role="tabpanel"
-    [attr.aria-labelledby]="tabName() + '-header'"
-    [class.d-block]="tabControl.activeTab() === this"
-    [attr.tabindex]="tabControl.activeTab() === this ? 0 : null">
-    <ng-content></ng-content>
-</div>
+@if (tabControl.isServerSide) {
+	<div [id]="tabName() + '-panel'"
+		class="tab-page-content"
+		role="tabpanel"
+		[attr.aria-labelledby]="tabName() + '-header'"
+		[class.d-block]="tabControl.activeTab() === this"
+		[attr.tabindex]="tabControl.activeTab() === this ? 0 : null">
+		<ng-content></ng-content>
+	</div>
+} @else {
+	<ng-content></ng-content>
+}

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-page/tab-page.component.ts
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-page/tab-page.component.ts
@@ -12,6 +12,12 @@ import { BsTabPageHeaderDirective } from '../tab-page-header/tab-page-header.dir
     '[attr.slot]': 'contentSlotName()',
     // Tells <mp-tab-control> the tab is disabled without inspecting child types.
     '[attr.data-disabled]': 'disabled() ? "" : null',
+    // ARIA wiring (client-side only — the SSR branch renders its own tabpanel
+    // div with these attributes inside the bs-tab-page template).
+    '[attr.role]': 'tabControl.isServerSide ? null : "tabpanel"',
+    '[id]': 'tabControl.isServerSide ? null : tabName() + "-panel"',
+    '[attr.aria-labelledby]': 'tabControl.isServerSide ? null : tabName() + "-header-button"',
+    '[attr.tabindex]': 'tabControl.isServerSide ? null : (tabControl.activeTab() === this ? 0 : -1)',
   },
 })
 export class BsTabPageComponent {

--- a/libs/mintplayer-ng-bootstrap/tab-control/src/tab-page/tab-page.component.ts
+++ b/libs/mintplayer-ng-bootstrap/tab-control/src/tab-page/tab-page.component.ts
@@ -7,6 +7,12 @@ import { BsTabPageHeaderDirective } from '../tab-page-header/tab-page-header.dir
   templateUrl: './tab-page.component.html',
   styleUrls: ['./tab-page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    // Used by <mp-tab-control> to project the active page into its content slot.
+    '[attr.slot]': 'contentSlotName()',
+    // Tells <mp-tab-control> the tab is disabled without inspecting child types.
+    '[attr.data-disabled]': 'disabled() ? "" : null',
+  },
 })
 export class BsTabPageComponent {
   element = inject(ElementRef);
@@ -17,6 +23,9 @@ export class BsTabPageComponent {
   }
   tabId = signal<number>(0);
   tabName = computed(() => `${this.tabControl.tabControlName()}-${this.tabId()}`);
+  contentSlotName = computed(() =>
+    this.tabControl.isServerSide ? null : `${this.tabName()}-content`,
+  );
 
   disabled = input(false);
   readonly headerTemplate = contentChild(BsTabPageHeaderDirective);

--- a/libs/mp-tab-control-wc/package.json
+++ b/libs/mp-tab-control-wc/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@mintplayer/tab-control-wc",
+  "private": false,
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Web Component for a Bootstrap-styled tab control",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",
+    "directory": "libs/mp-tab-control-wc"
+  },
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "lit": "^3.3.0"
+  },
+  "author": {
+    "name": "Pieterjan De Clippel",
+    "url": "https://github.com/MintPlayer",
+    "email": "info@mintplayer.com"
+  },
+  "keywords": [
+    "tab",
+    "tabs",
+    "tab-control",
+    "bootstrap",
+    "web-component",
+    "custom-element"
+  ]
+}

--- a/libs/mp-tab-control-wc/project.json
+++ b/libs/mp-tab-control-wc/project.json
@@ -1,0 +1,59 @@
+{
+  "name": "mp-tab-control-wc",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/mp-tab-control-wc/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "codegen-wc": {
+      "executor": "nx:run-commands",
+      "outputs": [
+        "{projectRoot}/**/*.styles.ts",
+        "{projectRoot}/**/web-components/*.element.template.ts"
+      ],
+      "inputs": [
+        "{projectRoot}/**/*.styles.scss",
+        "{projectRoot}/**/web-components/*.element.html",
+        "{projectRoot}/**/web-components/*.element.scss",
+        "{workspaceRoot}/tools/scripts/build-web-components.mjs"
+      ],
+      "cache": true,
+      "options": {
+        "command": "node tools/scripts/build-web-components.mjs libs/mp-tab-control-wc"
+      }
+    },
+    "build": {
+      "executor": "@nx/js:tsc",
+      "dependsOn": ["^build", "codegen-wc"],
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/mp-tab-control-wc",
+        "main": "libs/mp-tab-control-wc/src/index.ts",
+        "tsConfig": "libs/mp-tab-control-wc/tsconfig.lib.json",
+        "assets": ["libs/mp-tab-control-wc/*.md"]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node tools/scripts/publish.mjs mp-tab-control-wc {args.ver} {args.tag}"
+      },
+      "dependsOn": [
+        {
+          "target": "build"
+        }
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@analogjs/vitest-angular:test",
+      "outputs": ["{workspaceRoot}/coverage/libs/mp-tab-control-wc"],
+      "options": {
+        "configFile": "vitest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/mp-tab-control-wc/src/components/index.ts
+++ b/libs/mp-tab-control-wc/src/components/index.ts
@@ -1,0 +1,3 @@
+export { MpTabControl } from './mp-tab-control';
+export type { TabActivateEventDetail } from './mp-tab-control';
+export { MpTabPage } from './mp-tab-page';

--- a/libs/mp-tab-control-wc/src/components/mp-tab-control.ts
+++ b/libs/mp-tab-control-wc/src/components/mp-tab-control.ts
@@ -55,7 +55,8 @@ export class MpTabControl extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('role', 'tablist');
+    // role="tablist" lives on the inner <ul> that directly contains the tab
+    // buttons — we deliberately don't repeat it on the host.
     this.mutationObserver = new MutationObserver(() => this.refreshTabs());
     this.mutationObserver.observe(this, {
       childList: true,
@@ -214,6 +215,15 @@ export class MpTabControl extends LitElement {
       case ' ':
         this.activate(tab, ev);
         return;
+      case 'Home':
+      case 'End': {
+        ev.preventDefault();
+        const enabled = this.tabs.filter((t) => !t.disabled);
+        if (enabled.length === 0) return;
+        const target = ev.key === 'Home' ? enabled[0] : enabled[enabled.length - 1];
+        this.moveFocusAndActivate(target, ev);
+        return;
+      }
       case 'ArrowLeft':
       case 'ArrowRight': {
         ev.preventDefault();
@@ -223,22 +233,25 @@ export class MpTabControl extends LitElement {
         const currentIdx = enabled.findIndex((t) => t.tabId === tab.tabId);
         const nextIdx =
           (currentIdx + dir + enabled.length) % enabled.length;
-        const nextTab = enabled[nextIdx];
-        this.setAttribute('active-tab', nextTab.tabId);
-        const newButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
-          `button[id="${nextTab.tabId}-header-button"]`,
-        );
-        newButton?.focus();
-        this.dispatchEvent(
-          new CustomEvent<TabActivateEventDetail>('tab-activate', {
-            detail: { tabId: nextTab.tabId, originalEvent: ev },
-            bubbles: true,
-            composed: true,
-          }),
-        );
+        this.moveFocusAndActivate(enabled[nextIdx], ev);
         return;
       }
     }
+  }
+
+  private moveFocusAndActivate(target: TabInfo, ev: Event): void {
+    this.setAttribute('active-tab', target.tabId);
+    const button = this.shadowRoot?.querySelector<HTMLButtonElement>(
+      `button[id="${target.tabId}-header-button"]`,
+    );
+    button?.focus();
+    this.dispatchEvent(
+      new CustomEvent<TabActivateEventDetail>('tab-activate', {
+        detail: { tabId: target.tabId, originalEvent: ev },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 }
 

--- a/libs/mp-tab-control-wc/src/components/mp-tab-control.ts
+++ b/libs/mp-tab-control-wc/src/components/mp-tab-control.ts
@@ -1,0 +1,250 @@
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { tabControlStyles } from '../styles';
+import type { TabsPosition } from '../types';
+
+export interface TabActivateEventDetail {
+  /** The `tab-id` of the tab the user activated. */
+  tabId: string;
+  /** The original DOM event (click or keydown) that triggered the activation. */
+  originalEvent: Event;
+}
+
+interface TabInfo {
+  tabId: string;
+  disabled: boolean;
+}
+
+/**
+ * <mp-tab-control>
+ *
+ * Bootstrap-styled tab strip. Pages live in named `${id}-content` slots and
+ * headers in `${id}-header` slots. The shadow DOM dynamically projects only
+ * the currently-active page via `<slot name="${activeId}-content">`, so
+ * inactive panels never enter the rendered tree.
+ *
+ * Authoring (vanilla):
+ *
+ *     <mp-tab-control active-tab="overview">
+ *       <span slot="overview-header">Overview</span>
+ *       <div slot="overview-content">Hello</div>
+ *       <span slot="details-header">Details</span>
+ *       <div slot="details-content">Details body</div>
+ *     </mp-tab-control>
+ *
+ * To mark a tab disabled, set `data-disabled` on the `*-content` element.
+ *
+ * Active state is **controlled by the host** — the host sets `active-tab` and
+ * listens for `tab-activate` events. The Angular wrapper (`bs-tab-control`)
+ * drives this via signals.
+ */
+export class MpTabControl extends LitElement {
+  static override styles = [tabControlStyles];
+
+  static override get observedAttributes(): string[] {
+    return [
+      ...(super.observedAttributes ?? []),
+      'tabs-position',
+      'border',
+      'active-tab',
+      'select-first-tab',
+    ];
+  }
+
+  private tabs: TabInfo[] = [];
+  private mutationObserver: MutationObserver | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.setAttribute('role', 'tablist');
+    this.mutationObserver = new MutationObserver(() => this.refreshTabs());
+    this.mutationObserver.observe(this, {
+      childList: true,
+      subtree: false,
+      attributes: true,
+      attributeFilter: ['slot', 'data-disabled'],
+    });
+  }
+
+  override disconnectedCallback(): void {
+    this.mutationObserver?.disconnect();
+    this.mutationObserver = null;
+    super.disconnectedCallback();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    if (oldValue === newValue) return;
+    this.requestUpdate();
+  }
+
+  protected override firstUpdated(): void {
+    this.refreshTabs();
+  }
+
+  private get tabsPosition(): TabsPosition {
+    const v = this.getAttribute('tabs-position');
+    return v === 'bottom' ? 'bottom' : 'top';
+  }
+
+  private get border(): boolean {
+    return this.hasAttribute('border')
+      ? this.getAttribute('border') !== 'false'
+      : true;
+  }
+
+  private get selectFirstTab(): boolean {
+    return this.hasAttribute('select-first-tab')
+      ? this.getAttribute('select-first-tab') !== 'false'
+      : true;
+  }
+
+  private get activeTabId(): string | null {
+    return this.getAttribute('active-tab');
+  }
+
+  private refreshTabs(): void {
+    const found = new Map<string, TabInfo>();
+    for (const child of Array.from(this.children)) {
+      const slot = child.getAttribute('slot');
+      if (!slot) continue;
+      const m = slot.match(/^(.+)-content$/);
+      if (!m) continue;
+      const tabId = m[1];
+      const disabled = child.hasAttribute('data-disabled') &&
+        child.getAttribute('data-disabled') !== 'false';
+      // First occurrence wins on duplicate slot names.
+      if (!found.has(tabId)) {
+        found.set(tabId, { tabId, disabled });
+      }
+    }
+    this.tabs = Array.from(found.values());
+    this.requestUpdate();
+  }
+
+  private resolvedActiveTabId(): string | null {
+    const explicit = this.activeTabId;
+    if (
+      explicit !== null &&
+      this.tabs.some((t) => t.tabId === explicit && !t.disabled)
+    ) {
+      return explicit;
+    }
+    if (!this.selectFirstTab) return null;
+    const firstEnabled = this.tabs.find((t) => !t.disabled);
+    return firstEnabled?.tabId ?? null;
+  }
+
+  override render(): TemplateResult {
+    const activeId = this.resolvedActiveTabId();
+    const strip = html`
+      <div class="tsc${this.tabsPosition === 'bottom' ? ' bottom-tabs' : ''}">
+        <ul
+          class="nav nav-tabs flex-nowrap overflow-x-auto overflow-y-hidden"
+          role="tablist"
+        >
+          ${this.tabs.map((tab) => this.renderTabHeader(tab, activeId))}
+        </ul>
+      </div>
+    `;
+    const content = html`
+      <div
+        class="tab-content flex-grow-1 overflow-auto${this.border
+          ? activeId
+            ? ' border'
+            : ' border-top'
+          : ''}"
+      >
+        <slot name=${activeId ? `${activeId}-content` : '__none__'}></slot>
+      </div>
+    `;
+    return html`
+      ${this.tabsPosition === 'top' ? strip : nothing}
+      ${content}
+      ${this.tabsPosition === 'bottom' ? strip : nothing}
+    `;
+  }
+
+  private renderTabHeader(
+    tab: TabInfo,
+    activeId: string | null,
+  ): TemplateResult {
+    const isActive = tab.tabId === activeId;
+    return html`
+      <li class="nav-item" role="presentation">
+        <button
+          type="button"
+          class="nav-link text-nowrap${isActive ? ' active' : ''}${tab.disabled
+            ? ' disabled'
+            : ''}"
+          role="tab"
+          id=${`${tab.tabId}-header-button`}
+          aria-controls=${`${tab.tabId}-panel`}
+          aria-selected=${isActive ? 'true' : 'false'}
+          ?disabled=${tab.disabled}
+          tabindex=${tab.disabled ? -1 : isActive ? 0 : -1}
+          @click=${(ev: Event) => this.activate(tab, ev)}
+          @keydown=${(ev: KeyboardEvent) => this.handleKeydown(tab, ev)}
+        >
+          <slot name=${`${tab.tabId}-header`}></slot>
+        </button>
+      </li>
+    `;
+  }
+
+  private activate(tab: TabInfo, ev: Event): void {
+    if (tab.disabled) return;
+    ev.preventDefault();
+    this.dispatchEvent(
+      new CustomEvent<TabActivateEventDetail>('tab-activate', {
+        detail: { tabId: tab.tabId, originalEvent: ev },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    this.setAttribute('active-tab', tab.tabId);
+  }
+
+  private handleKeydown(tab: TabInfo, ev: KeyboardEvent): void {
+    switch (ev.key) {
+      case 'Enter':
+      case ' ':
+        this.activate(tab, ev);
+        return;
+      case 'ArrowLeft':
+      case 'ArrowRight': {
+        ev.preventDefault();
+        const dir = ev.key === 'ArrowRight' ? 1 : -1;
+        const enabled = this.tabs.filter((t) => !t.disabled);
+        if (enabled.length === 0) return;
+        const currentIdx = enabled.findIndex((t) => t.tabId === tab.tabId);
+        const nextIdx =
+          (currentIdx + dir + enabled.length) % enabled.length;
+        const nextTab = enabled[nextIdx];
+        this.setAttribute('active-tab', nextTab.tabId);
+        const newButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
+          `button[id="${nextTab.tabId}-header-button"]`,
+        );
+        newButton?.focus();
+        this.dispatchEvent(
+          new CustomEvent<TabActivateEventDetail>('tab-activate', {
+            detail: { tabId: nextTab.tabId, originalEvent: ev },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        return;
+      }
+    }
+  }
+}
+
+if (
+  typeof customElements !== 'undefined' &&
+  !customElements.get('mp-tab-control')
+) {
+  customElements.define('mp-tab-control', MpTabControl);
+}

--- a/libs/mp-tab-control-wc/src/components/mp-tab-page.ts
+++ b/libs/mp-tab-control-wc/src/components/mp-tab-page.ts
@@ -1,0 +1,87 @@
+import { LitElement, html, css, type TemplateResult } from 'lit';
+
+/**
+ * <mp-tab-page>
+ *
+ * Optional convenience wrapper for vanilla consumers. Sets `slot="${tabId}-content"`
+ * on itself based on its `tab-id` attribute, so the parent `<mp-tab-control>`
+ * picks it up via named-slot projection.
+ *
+ * Also mirrors `disabled` to `data-disabled` so the tab-control can read the
+ * disabled state without inspecting child types.
+ *
+ * Use directly:
+ *
+ *     <mp-tab-control>
+ *       <span slot="t1-header">Tab 1</span>
+ *       <mp-tab-page tab-id="t1">Content 1</mp-tab-page>
+ *     </mp-tab-control>
+ *
+ * Or skip this element entirely and put the slot/data-disabled attributes
+ * directly on whatever element holds your tab content:
+ *
+ *     <mp-tab-control>
+ *       <span slot="t1-header">Tab 1</span>
+ *       <div slot="t1-content">Content 1</div>
+ *     </mp-tab-control>
+ */
+export class MpTabPage extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+  `;
+
+  static override get observedAttributes(): string[] {
+    return [
+      ...(super.observedAttributes ?? []),
+      'tab-id',
+      'disabled',
+    ];
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.syncSlot();
+    this.syncDisabled();
+  }
+
+  override attributeChangedCallback(
+    name: string,
+    oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    super.attributeChangedCallback(name, oldValue, newValue);
+    if (oldValue === newValue) return;
+    if (name === 'tab-id') this.syncSlot();
+    if (name === 'disabled') this.syncDisabled();
+  }
+
+  private syncSlot(): void {
+    const tabId = this.getAttribute('tab-id');
+    if (tabId) {
+      this.setAttribute('slot', `${tabId}-content`);
+    } else {
+      this.removeAttribute('slot');
+    }
+  }
+
+  private syncDisabled(): void {
+    if (this.hasAttribute('disabled')) {
+      this.setAttribute('data-disabled', '');
+    } else {
+      this.removeAttribute('data-disabled');
+    }
+  }
+
+  override render(): TemplateResult {
+    return html`<slot></slot>`;
+  }
+}
+
+if (
+  typeof customElements !== 'undefined' &&
+  !customElements.get('mp-tab-page')
+) {
+  customElements.define('mp-tab-page', MpTabPage);
+}

--- a/libs/mp-tab-control-wc/src/index.ts
+++ b/libs/mp-tab-control-wc/src/index.ts
@@ -1,0 +1,9 @@
+// Components
+export { MpTabControl, MpTabPage } from './components';
+export type { TabActivateEventDetail } from './components';
+
+// Types
+export type { TabsPosition } from './types';
+
+// Styles (for custom styling extensions)
+export { tabControlStyles } from './styles';

--- a/libs/mp-tab-control-wc/src/styles/index.ts
+++ b/libs/mp-tab-control-wc/src/styles/index.ts
@@ -1,0 +1,1 @@
+export { tabControlStyles } from './tab-control.styles';

--- a/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
+++ b/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
@@ -52,6 +52,11 @@
   max-height: 41px;
   overflow: hidden;
   flex-shrink: 0;
+  // Lift the strip above .tab-content so the active tab's bottom border (which
+  // matches the page background) visually "punches through" the content's
+  // top border. Without this, both 1px borders stack and a continuous line
+  // appears under the active tab handle. Flex item, so position is unneeded.
+  z-index: 1;
 
   .nav.nav-tabs {
     // <ul> inherits margin-top: 1em (~16px) from the user-agent stylesheet, and

--- a/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
+++ b/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
@@ -1,0 +1,101 @@
+// Bootstrap configuration partials. These compile to no CSS on their own —
+// they exist so the @import 'bootstrap/scss/nav' below can resolve $prefix,
+// mixin references, the colour map, etc.
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/variables-dark';
+@import 'bootstrap/scss/maps';
+@import 'bootstrap/scss/mixins';
+@import 'bootstrap/scss/utilities';
+
+// .nav, .nav-tabs, .nav-link, .tab-content, .tab-pane.
+@import 'bootstrap/scss/nav';
+
+// We deliberately do NOT @import 'bootstrap/scss/root' — it targets :root,
+// which doesn't cross Shadow DOM. The host page's :root --bs-* variables
+// inherit through the shadow boundary via custom-property cascade, so the
+// :host of this WC picks them up automatically when the consumer page has
+// Bootstrap globally available.
+//
+// We also do NOT pull bootstrap/scss/utilities/_api — that would inject ~50 KB
+// of utility classes for the handful we actually use. Inline equivalents below.
+
+:host {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+// Bootstrap utility-class equivalents needed by the shadow template. Authored
+// inline because the global utilities API doesn't cross Shadow DOM.
+.flex-nowrap { flex-wrap: nowrap; }
+.flex-grow-1 { flex-grow: 1; }
+.overflow-auto { overflow: auto; }
+.overflow-x-auto { overflow-x: auto; }
+.overflow-y-hidden { overflow-y: hidden; }
+.text-nowrap { white-space: nowrap; }
+.border {
+  border: var(--bs-border-width, 1px) var(--bs-border-style, solid) var(--bs-border-color, #dee2e6) !important;
+}
+.border-top {
+  border-top: var(--bs-border-width, 1px) var(--bs-border-style, solid) var(--bs-border-color, #dee2e6) !important;
+}
+
+// Tab-strip container.
+.tsc {
+  max-height: 41px;
+  flex-shrink: 0;
+
+  .nav.nav-tabs {
+    border-bottom: 0;
+  }
+
+  &.bottom-tabs {
+    margin-top: -1px;
+
+    .nav.nav-tabs {
+      border-bottom-width: 0;
+
+      .nav-link {
+        border: 1px solid transparent;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        border-bottom-left-radius: 0.25rem;
+        border-bottom-right-radius: 0.25rem;
+      }
+
+      .nav-item {
+        margin-bottom: 2px;
+        margin-top: -1px;
+      }
+
+      .nav-item.show .nav-link,
+      .nav-link.active {
+        border-color: #fff #dee2e6 #dee2e6 #dee2e6;
+      }
+    }
+  }
+}
+
+.tsc .nav-link {
+  cursor: pointer;
+  // Strip the user-agent <button> chrome — these are rendered as <button>
+  // for keyboard/ARIA but should look like Bootstrap's nav-link <a>s.
+  background: transparent;
+  font: inherit;
+  text-align: inherit;
+}
+
+.tsc .nav-link.disabled {
+  cursor: not-allowed;
+}
+
+.tab-content {
+  // Pull up by 1px so the active tab's bottom border merges with the panel border.
+  margin-top: -1px;
+}
+
+// Each <mp-tab-page> handles its own visibility via :host([active]). When
+// `<mp-tab-page>` is wrapped (e.g. by an Angular `<bs-tab-page>` host element),
+// the wrapper itself stays display: block; the inner mp-tab-page hides its own
+// shadow content unless [active] is set.

--- a/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
+++ b/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
@@ -42,8 +42,15 @@
 }
 
 // Tab-strip container.
+//
+// `overflow: hidden` clips the inner <ul>'s native horizontal scrollbar so it
+// stays hidden behind the tab-content area below. The user can still scroll
+// horizontally via mouse wheel / touch / keyboard — only the visual scrollbar
+// is clipped. This matches the master `bs-tab-control` template, where the
+// outer wrapper had `class="overflow-hidden ... tsc"`.
 .tsc {
   max-height: 41px;
+  overflow: hidden;
   flex-shrink: 0;
 
   .nav.nav-tabs {

--- a/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
+++ b/libs/mp-tab-control-wc/src/styles/tab-control.styles.scss
@@ -47,6 +47,10 @@
   flex-shrink: 0;
 
   .nav.nav-tabs {
+    // <ul> inherits margin-top: 1em (~16px) from the user-agent stylesheet, and
+    // Bootstrap's .nav doesn't reset it. Without this, the strip pushes the
+    // tab-content body downward — visually intersecting it inside .tsc.
+    margin-top: 0;
     border-bottom: 0;
   }
 

--- a/libs/mp-tab-control-wc/src/types/index.ts
+++ b/libs/mp-tab-control-wc/src/types/index.ts
@@ -1,0 +1,1 @@
+export type { TabsPosition } from './tabs-position';

--- a/libs/mp-tab-control-wc/src/types/tabs-position.ts
+++ b/libs/mp-tab-control-wc/src/types/tabs-position.ts
@@ -1,0 +1,1 @@
+export type TabsPosition = 'top' | 'bottom';

--- a/libs/mp-tab-control-wc/tsconfig.json
+++ b/libs/mp-tab-control-wc/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/mp-tab-control-wc/tsconfig.lib.json
+++ b/libs/mp-tab-control-wc/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "vitest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/libs/mp-tab-control-wc/vitest.config.ts
+++ b/libs/mp-tab-control-wc/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  plugins: [
+    nxViteTsPaths(),
+  ],
+  test: {
+    name: 'mp-tab-control-wc',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    reporters: ['default'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov'],
+      reportsDirectory: '../../coverage/libs/mp-tab-control-wc',
+    },
+  },
+});

--- a/tools/scripts/build-web-components.mjs
+++ b/tools/scripts/build-web-components.mjs
@@ -80,7 +80,7 @@ function compileScss(scssPath) {
   const result = sass.compile(scssPath, {
     style: 'expanded',
     sourceMap: false,
-    loadPaths: [dirname(scssPath)],
+    loadPaths: [dirname(scssPath), join(repoRoot, 'node_modules')],
   });
   return result.css;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -39,7 +39,8 @@
       "@mintplayer/qr-code": ["libs/mintplayer-qr-code/src/index.ts"],
       "@mintplayer/scheduler-core": ["libs/mp-scheduler-core/src/index.ts"],
       "@mintplayer/scheduler-wc": ["libs/mp-scheduler-wc/src/index.ts"],
-      "@mintplayer/splitter": ["libs/mp-splitter-wc/src/index.ts"]
+      "@mintplayer/splitter": ["libs/mp-splitter-wc/src/index.ts"],
+      "@mintplayer/tab-control-wc": ["libs/mp-tab-control-wc/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary

- **New `@mintplayer/tab-control-wc`** Lit web component (`<mp-tab-control>` + optional `<mp-tab-page>`) with Bootstrap `nav`/`nav-tabs`/`tab-content` styles inside Shadow DOM. Active tab body uses dynamic `<slot name="${activeId}-content">` projection so only the active tab is in the rendered tree.
- **`bs-tab-control` Angular wrapper** refactored to render `<mp-tab-control>` on the client; SSR branch keeps the existing radios + sibling-CSS noscript fallback unchanged. `bs-tab-page` host gets `[attr.slot]="${tabName}-content"` so it's a direct named-slotted child of the WC.
- **codegen-wc Sass `loadPaths`** extended with `node_modules` so `@import 'bootstrap/scss/...'` resolves from any WC's source.
- **PRD added** at `docs/prd/dock-splitter-tabcontrol-lit-composition.md` with Phase 1 (this PR), Phase 2 (dock embeds `<mp-tab-control>` + `<mp-splitter>`, deferred to follow-up), Phase 3 (recolour dock overlays via `--bs-*`).

Net diff: +1032 / −66 across 21 files (most of the bulk is the new lib's scaffolding + the PRD).

### Three small CSS fixes after the initial extraction (each its own commit)

- `.mt-0` on `ul.nav-tabs` — user-agent `<ul>` margin was pushing the strip down by 16px and overlapping the content area inside `.tsc`.
- `overflow: hidden` on `.tsc` — restores master's behaviour of clipping the inner ul's native horizontal scrollbar (master used `<div class=\"overflow-hidden ... tsc\">`; the WC's Shadow DOM doesn't pull Bootstrap's utilities API).
- `z-index: 1` on `.tsc` — lifts the strip above `.tab-content` so the active tab's bottom border (matching the page background) punches through the content's top border, eliminating the continuous line under the active tab handle.

## Test plan

Functional smoke via Playwright MCP on `/basic/containers/tab-control` (manual, recorded in conversation):

- [x] Initial state: 20 tabs render, Tab 1 active by default, body shows \"This is tab 1\"
- [x] Click Tab 7 → `active-tab` updates, body slot switches, \"This is tab 7\" projects
- [x] Click disabled Tab 3 → DOM-level `disabled` rejects the click; active-tab unchanged
- [x] ArrowRight from Tab 7 → Tab 8 (focus + active follow)
- [x] 5× ArrowLeft from Tab 8 → Tab 2 (correctly skips disabled Tab 3 in the cycle)
- [x] Toggle position → \"Bottom\": `bottom-tabs` class applied, strip moves below content, active tab preserved
- [x] Scrollbar hidden when scrolling horizontally; tabs still navigable via wheel/touch/keyboard
- [x] No continuous line under the active tab handle on initial load
- [x] `npm run build` succeeds end-to-end (mp-tab-control-wc, mintplayer-ng-bootstrap, ng-bootstrap-demo)

Reviewer to verify in the browser:
- [ ] Drag/drop reorder is currently a no-op in client mode (CDK in the wrapper bypassed when wrapping the WC). Documented as Phase-2 follow-up; flag if this regression is unacceptable for landing Phase 1.
- [ ] SSR / noscript path on a server-rendered page still works (the wrapper's `@if (isServerSide)` branch keeps the existing radios + `:checked` sibling CSS unchanged).

## Notes for reviewers

- The Lit WC defines a handful of Bootstrap-utility-class equivalents inline (`flex-nowrap`, `overflow-x-auto`, etc.) — we deliberately don't pull `bootstrap/scss/utilities/_api` to keep the per-WC bundle small. If a future WC needs more, factor into `libs/wc-shared-styles/`.
- `static observedAttributes` on `MpTabControl`/`MpTabPage` is implemented as a **static getter** (not a class field). LitElement's `ReactiveElement` inherits it as a getter, and a class-field initializer would throw `setting getter-only property` at class init time. Same trap caught earlier on `mint-dock-manager.element.ts` and `mp-scheduler.ts` in PR #302 — worth keeping in mind for future Lit WCs in this repo.
- Phase 2 (dock manager embeds `<mp-tab-control>` + nested `<mp-splitter>`) is **deferred to a follow-up PR**. The PRD walks through why: ~15 hard-coded DOM-query points in the dock for `.dock-stack` / `.dock-tab` / etc. need careful rewriting against the new shadow trees, the intersection-handle 4-way drag needs adapting to call `setPanelSizes()` on the embedded splitters, and `<mp-splitter>` needs new extension points (`hidden`-panel mode, divider opt-out via `::part`) before the embed can preserve drag-to-detach + intersection handles + snap markers without regression. Doing it on top of the freshly-migrated Lit dock from PR #302, in the same PR as Phase 1, would tangle the regression surface across two large refactors. A separate focused PR keeps bisect clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)