### PR TITLE
Dock: long-press to drag on touch, JS-driven strip scroll

### DIFF
--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.html
@@ -44,7 +44,7 @@
   </bs-dock-manager>
 
   <div class="dock-demo__actions">
-    <button bsButtonType (click)="saveLayout()">Capture layout JSON</button>
+    <button [color]="Color.primary" (click)="saveLayout()">Capture layout JSON</button>
     <div class="dock-demo__snapshots">
       <div class="dock-demo__snapshot">
         <h4 class="dock-demo__snapshot-title">Live layout</h4>

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.ts
@@ -7,12 +7,13 @@ import {
   DockLayoutSnapshot,
 } from '@mintplayer/ng-bootstrap/dock';
 import { Color } from '@mintplayer/ng-bootstrap';
+import { BsButtonTypeDirective } from '@mintplayer/ng-bootstrap/button-type';
 
 @Component({
   selector: 'demo-dock',
   templateUrl: './dock.component.html',
   styleUrls: ['./dock.component.scss'],
-  imports: [CommonModule, BsDockManagerComponent, BsDockPaneComponent, BsBadgeComponent],
+  imports: [CommonModule, BsButtonTypeDirective, BsDockManagerComponent, BsDockPaneComponent, BsBadgeComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DockComponent {

--- a/docs/prd/dock-touch-long-press-drag.md
+++ b/docs/prd/dock-touch-long-press-drag.md
@@ -81,7 +81,7 @@ if (startEvent.pointerType === 'touch') {
 
 Pen is treated as mouse — pen jitter is small and pen users expect direct-manipulation precision. If a future device class needs nuance, it gets its own branch.
 
-### 4.2 Touch arming — long-press timer with movement slop
+### 4.2 Touch arming — long-press timer with JS-driven strip scroll
 
 A new private method `armPaneDragGestureTouch` runs the touch-specific arming:
 
@@ -94,24 +94,31 @@ A new private method `armPaneDragGestureTouch` runs the touch-specific arming:
 - **State machine** (per-gesture, scoped to one pointerdown):
   | State | Entered when | Exit conditions |
   | --- | --- | --- |
-  | `pending` | `pointerdown` on a tab header | timer fires → `armed`; movement >slop → `abandoned`; `pointerup` → `tap`; `pointercancel` → `abandoned` |
+  | `pending` | `pointerdown` on a tab header | timer fires → `armed`; horizontal move >slop on overflowing strip → `scrolling`; any other move >slop → `abandoned`; `pointerup` → `tap`; `pointercancel` → `abandoned` |
   | `armed` | hold timer fires while `pending` | `beginPaneDrag` runs synchronously with the most recent pointer position |
+  | `scrolling` | horizontal move >slop while `pending`, strip is `scrollWidth > clientWidth` | each subsequent `pointermove` does `ul.scrollLeft -= dx`; `pointerup` / `pointercancel` → cleanup |
   | `tap` | `pointerup` arrived first | clear pending metrics; let browser-synthesized click drive `tab-activate` (no `preventDefault`) |
-  | `abandoned` | movement >slop, or `pointercancel`, or visibility change | clear pending metrics; do nothing; native scroll proceeds |
+  | `abandoned` | non-horizontal move >slop, or `pointercancel`, or `pointerup` after a non-tap | clear pending metrics; do nothing |
 
 - **Listeners** (registered on `window` with `capture: true`, mirroring the mouse path):
-  - `pointermove` — track `latestClientX/Y`; if `Math.hypot(dx, dy) > SLOP` while `pending` → cancel timer, transition to `abandoned`, remove listeners.
-  - `pointerup` — if `pending` → cancel timer, transition to `tap`, remove listeners.
-  - `pointercancel` — if `pending` → cancel timer, transition to `abandoned`, remove listeners.
+  - `pointermove` — drives the `pending` → `scrolling` / `abandoned` decision and the `scrolling` scroll updates.
+  - `pointerup` — `cleanup`, no drag.
+  - `pointercancel` — `cleanup`, no drag.
+
+- **`pending` → `scrolling` transition** (the new piece):
+  When the first move past `TOUCH_LONG_PRESS_SLOP_PX` arrives:
+  1. If `Math.abs(dx) > Math.abs(dy)` AND the strip's `<ul>` has `scrollWidth > clientWidth` → enter `scrolling`. Clear the long-press timer and the press-feedback timer, remove the `data-pressing` attribute, set `lastScrollX = clientX`, apply the initial `dx` as `ul.scrollLeft -= dx` so the strip moves on the same frame as the decision. Keep all three window listeners attached.
+  2. Otherwise → `abandoned` (full `cleanup`).
+  In `scrolling`, each subsequent `pointermove` reads `dx = clientX - lastScrollX`, updates `lastScrollX`, and applies `ul.scrollLeft -= dx`. No drag, no momentum — direct 1:1 finger-follows-strip.
 
 - **Timer firing path** (`pending` → `armed`):
-  1. Call `setPointerCapture(pointerId)` on the dock host (`this`). This re-routes subsequent pointer events away from the browser's scroll arbitration to the dock element and is the key handshake that lets us start a drag mid-gesture without `pointercancel` hitting us.
-  2. Synthesise the call to `beginPaneDrag` using the latest tracked `clientX/Y` and the same `pointerId`. `beginPaneDrag` already accepts a `PointerEvent`-shaped argument; we either pass the most recent move event we held a reference to, or construct a minimal `{ clientX, clientY, pointerId, pointerType: 'touch' }` shim — whichever is cleaner at implementation time.
-  3. From here, the existing pipeline takes over: `dragState` is set, `startDragPointerTracking` runs (`:1813`), and the existing reorder-vs-undock 8 px header-bounds threshold (`:1976`) governs subsequent behavior. This is the part of the spec that matches "initially to reorder tabs within the tabstrip without undocking; when the tabstrip is exited by the thumb turn into a floating panel."
+  1. Call `setPointerCapture(pointerId)` on the dock host. With `touch-action: none` on `.dock-tab` the browser never tries to scroll or select to begin with; capture is kept as a safety net so events reach the dock host even if the originating `.dock-tab` is replaced by a re-render.
+  2. Synthesise a `pointermove` event from the latest tracked `clientX/Y` and pass it to `beginPaneDrag`.
+  3. From here, the existing pipeline takes over: `dragState` is set, `startDragPointerTracking` runs, and the reorder-vs-undock 8 px header-bounds threshold governs subsequent behavior.
 
-- **Self-cleanup** matches the mouse path: every exit path runs `cleanup()` which clears the timeout and removes all three window listeners.
+- **Self-cleanup** matches the mouse path: every terminal exit path (`armed`, `tap`, `abandoned`, `scrolling` end) runs `cleanup()` which clears the timeouts and removes all three window listeners.
 
-### 4.3 CSS — let the strip scroll until the long-press fires
+### 4.3 CSS — `touch-action: none` on `.dock-tab`
 
 `mint-dock-manager.element.scss` change to `.dock-tab`:
 
@@ -121,13 +128,13 @@ A new private method `armPaneDragGestureTouch` runs the touch-specific arming:
   padding: 0.5rem 1rem;
   margin: -0.5rem -1rem;
 
-  // Allow horizontal scroll on the tabstrip while the finger is "deciding"
-  // (the long-press hasn't fired yet). The browser claims the gesture for
-  // pan-x and fires pointercancel — armPaneDragGestureTouch interprets that
-  // as "user is scrolling" and leaves the panel docked. Once the long-press
-  // fires we call setPointerCapture on the host and the browser stops
-  // arbitrating, so subsequent moves drive the drag normally.
-  touch-action: pan-x;
+  // touch-action is consulted at touchstart and frozen for the lifetime of
+  // the gesture. `pan-x` cannot be promoted to "anything goes" mid-gesture
+  // even with setPointerCapture (the compositor has already arbitrated the
+  // touch). So we set `none` and own the gesture from frame 1: the browser
+  // never claims it for scroll or selection, and JS drives strip scroll
+  // programmatically during the pending window before the long-press fires.
+  touch-action: none;
 
   // Suppress iOS magnifier loupe / selection on long-press.
   user-select: none;
@@ -136,9 +143,7 @@ A new private method `armPaneDragGestureTouch` runs the touch-specific arming:
 }
 ```
 
-`pan-x` is the right policy because the strip itself is `overflow-x: auto`. If a stack ever ships with a vertical-scroll strip, this becomes `pan-y` — but that's not a current configuration.
-
-The other `touch-action: none` declarations (`.dock-floating__chrome` `:82`, `.dock-floating__resizer` `:121`, `.dock-intersection-handle` `:218`) stay as-is. They guard surfaces that have no competing native gesture.
+The other `touch-action: none` declarations (`.dock-floating__chrome`, `.dock-floating__resizer`, `.dock-intersection-handle`) stay as-is. They guard surfaces that have no competing native gesture.
 
 ### 4.4 Press feedback during the hold
 
@@ -195,6 +200,21 @@ Use Vitest's `vi.useFakeTimers()` for the 600 ms wait; the existing spec already
 
 Bump the touch threshold from 5 px to ~30 px so a "scroll-y" swipe doesn't undock. **Rejected.** The strip is `overflow-x: auto` — a horizontal swipe to scroll *is* the gesture we need to allow. A larger distance threshold delays the drag-undock by a similar amount but doesn't free the strip to scroll.
 
+### 6.1a `touch-action: pan-x` + setPointerCapture mid-gesture
+
+The original draft of this PRD specced `touch-action: pan-x` on `.dock-tab` and called `setPointerCapture` from the long-press timer to "claim" the gesture. **Rejected after measurement.** `touch-action` is consulted by the browser at the *first* touchstart and frozen for the lifetime of that gesture; `setPointerCapture` only retargets event delivery, it does not promote a `pan-x`-arbitrated gesture into a free-form one. Real-touch trace via Chrome DevTools `Input.dispatchTouchEvent`:
+
+```
+t=0     pointerdown   (touch)
+t=600   long-press timer fires → panel undocks, setPointerCapture called
+t=707   pointermove   (first move after long-press)
+t=722   pointercancel ← compositor still enforcing pan-x → 15 ms later
+t=807   touchmove     (delivered to JS, but pointer pipeline is dead)
+t=891   touchend
+```
+
+Result: the panel undocks but is stranded at the original tab location because window-level `pointermove` listeners stop firing after `pointercancel`. On iOS the long-press also triggers the magnifier/selection UI because `pan-x` doesn't suppress that. The only model that holds is `touch-action: none` (so the browser never arbitrates the gesture in the first place) plus JS-implemented strip scroll for the swipe-to-scroll affordance — see §4.2 / §4.3.
+
 ### 6.2 Dedicated drag handle (grip icon)
 
 Add a `<span class="dock-tab__grip">⋮⋮</span>` to each tab header; only the grip arms a drag. **Rejected.** Doubles header width, fights the existing dense `.nav-link` padding, and is contrary to direct-manipulation expectations on touch (no other touch tab UI does this).
@@ -242,8 +262,9 @@ These are explicitly *not* in this PRD's scope. Logged here so we don't lose the
 
 | File | Change |
 | --- | --- |
-| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts` | Add `TOUCH_LONG_PRESS_MS` / `TOUCH_LONG_PRESS_SLOP_PX` constants; add `armPaneDragGestureTouch` private method; branch `armPaneDragGesture` (`:1727`) on `pointerType === 'touch'`; ensure `setPointerCapture` is called on `armed` transition; press-feedback `data-pressing` attribute toggling; navigator.vibrate ping. |
-| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.scss` | `.dock-tab` `touch-action: none` → `touch-action: pan-x`; add `user-select: none`, `-webkit-user-select: none`, `-webkit-touch-callout: none`; add `.dock-tab[data-pressing='true']` press-feedback rule; comment update. |
-| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts` | New `describe('touch long-press arming', …)` block, six cases. |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts` | Add `TOUCH_LONG_PRESS_MS` / `TOUCH_LONG_PRESS_SLOP_PX` / `TOUCH_PRESS_FEEDBACK_DELAY_MS` constants; add `armPaneDragGestureTouch` private method with `pending`/`scrolling`/`armed`/`tap`/`abandoned` state machine; branch `armPaneDragGesture` on `pointerType === 'touch'`; press-feedback `data-pressing` attribute toggling; navigator.vibrate ping. |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.scss` | `.dock-tab` keeps `touch-action: none`; add `user-select: none`, `-webkit-user-select: none`, `-webkit-touch-callout: none`; add `.dock-tab[data-pressing='true']` press-feedback rule; updated comment. |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.template.ts` | Regenerated via `nx run mintplayer-ng-bootstrap:codegen-wc`. (The `unsafeCSS` block embedded in the Lit component must be regenerated whenever `*.element.scss` changes — the SCSS source is not loaded at runtime.) |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts` | New `describe('touch long-press arming', …)` block: tap activates, hold-then-drag undocks, horizontal swipe scrolls strip without undock, vertical swipe abandons. |
 
 No template, demo app, public-API, or `<mp-tab-control>` changes.

--- a/docs/prd/dock-touch-long-press-drag.md
+++ b/docs/prd/dock-touch-long-press-drag.md
@@ -1,0 +1,249 @@
+# PRD: Long-press to drag on touch — keep tabstrip scrollable
+
+**Status:** Proposed.
+**Author:** Pieterjan
+**Date:** 2026-05-05
+**Library:** `@mintplayer/ng-bootstrap/dock`
+**Component:** `<mint-dock-manager>` web component
+**Reproduction:** https://bootstrap.mintplayer.com/advanced/dock on any touchscreen device with a stack containing several panes whose combined headers overflow the strip width.
+**Related prior PRDs:**
+- `docs/prd/dock-tab-drag-android-touch.md` — added `touch-action: none` to drag surfaces so undock works at all on Android.
+- `docs/prd/dock-splitter-tabcontrol-lit-composition.md` — composed the dock from `<mp-tab-control>` + `<mp-splitter>` (where the strip lives today).
+
+---
+
+## 1. Problem
+
+On touch devices, every gesture that begins on a tab header is interpreted as a drag. After PR #305 added `touch-action: none` to `.dock-tab` to stop Android from arbitrating the gesture as a page scroll, the dock now reliably undocks panels — but it undocks them **always**. The user has no way to scroll the tabstrip with their thumb when the headers overflow the strip width: every contact on a tab pulls the panel out of its dock.
+
+Concretely, on a stack with five panes whose combined header widths exceed the strip:
+
+1. User wants to scroll the strip horizontally to reach a hidden tab.
+2. Thumb lands on a visible tab header.
+3. Thumb moves >5 px sideways.
+4. The panel undocks into a floating window. The strip never scrolled.
+
+On desktop (mouse + trackpad), the current 5 px-distance arming is correct and not in question — the user can scroll the strip with the mousewheel or by clicking the (separate) scroll affordance, and a click-drag on a header is unambiguously a drag intent. The issue is exclusive to direct-manipulation touch input.
+
+## 2. Background — what the code does today
+
+Pointer-only architecture lives in `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts`:
+
+1. **Tab header creation** (`:1514–1538`). For each pane, the dock creates a `<span class="dock-tab" slot="${tabId}-header">` and projects it into `<mp-tab-control>`. A single `pointerdown` listener on that span (`:1529`) calls `captureTabDragMetrics` + `armPaneDragGesture` and `event.stopPropagation()`. Comment at `:1533–1537` records that `preventDefault()` is *not* called, on purpose — it would suppress the synthesized click that `<mp-tab-control>` uses to fire `tab-activate`.
+
+2. **Gesture arming** (`armPaneDragGesture`, `:1721–1761`). Registers window-capture `pointermove` / `pointerup` / `pointercancel` listeners scoped to the originating `pointerId`. Cross 5 px of distance from the start point → `beginPaneDrag` (`:1763`). Release first → `clearPendingTabDragMetrics`. The only pointerType-aware branch is `if (startEvent.pointerType === 'mouse' && startEvent.button !== 0) return;` (`:1727`), which rejects right/middle-click on mouse but treats touch identically to a left-click.
+
+3. **CSS** (`mint-dock-manager.element.scss:277–292`):
+   ```scss
+   .dock-tab {
+     cursor: grab;
+     padding: 0.5rem 1rem;
+     margin: -0.5rem -1rem;
+     touch-action: none;   // ← blocks browser scroll arbitration on the tab itself
+   }
+   ```
+   The `<ul class="nav nav-tabs flex-nowrap overflow-x-auto">` *inside* `<mp-tab-control>`'s shadow (`tab-control.styles.scss:34, 157`) is horizontally scrollable on overflow — but only when the touch lands on the gaps between tabs, because every tab carries `touch-action: none`.
+
+4. **No timer / hold logic exists.** The 5 px distance threshold and the 8 px header-bounds threshold (reorder → floating, `:1976`) are the only gesture gates today.
+
+## 3. Goals / non-goals
+
+**Goals**
+
+- A tap-and-hold on a tab header (touch input only) for ~600 ms, then drag, behaves exactly like a desktop click-drag does today: reorder while inside the strip, undock to floating once the finger leaves header bounds.
+- A horizontal swipe on a tab header (touch input only), without the hold, scrolls the strip natively. The panel does not undock.
+- A short tap (touch input, <600 ms, no significant movement) activates the tab — same as today.
+- Mouse and pen behavior is unchanged. 5 px-distance arming, immediate.
+- All existing pointer-architecture properties survive: window-capture listeners, `pointercancel` cleanup, no HTML5 dnd, the `dock-pane-activated` event.
+- No public API change to `<mint-dock-manager>`.
+- One PR, one ship — gesture mechanics + supporting CSS + visual press-feedback + tests all together.
+
+**Non-goals**
+
+- A configurable hold duration via attribute. Hard-code one constant; we can revisit if data comes back asking for it.
+- Long-press on the floating window chrome (`.dock-floating__chrome`). Floating-pane chrome already implies "I am floating, drag me" — there's no scroll competing with it. Keep it on immediate arming.
+- Long-press on splitter dividers / intersection handles / floating-resizers. Same rationale.
+- Generalising long-press to other components (accordion, navbar, etc).
+
+## 4. Design
+
+### 4.1 Branch arming by `pointerType`
+
+`armPaneDragGesture` (`mint-dock-manager.element.ts:1721`) gets a single new branch at the top:
+
+```ts
+if (startEvent.pointerType === 'touch') {
+  this.armPaneDragGestureTouch(startEvent, path, pane, stackEl);
+  return;
+}
+// existing mouse / pen path follows unchanged
+```
+
+Pen is treated as mouse — pen jitter is small and pen users expect direct-manipulation precision. If a future device class needs nuance, it gets its own branch.
+
+### 4.2 Touch arming — long-press timer with movement slop
+
+A new private method `armPaneDragGestureTouch` runs the touch-specific arming:
+
+- **Constants** (top of file, near other class fields):
+  ```ts
+  private static readonly TOUCH_LONG_PRESS_MS = 600;
+  private static readonly TOUCH_LONG_PRESS_SLOP_PX = 10;
+  ```
+
+- **State machine** (per-gesture, scoped to one pointerdown):
+  | State | Entered when | Exit conditions |
+  | --- | --- | --- |
+  | `pending` | `pointerdown` on a tab header | timer fires → `armed`; movement >slop → `abandoned`; `pointerup` → `tap`; `pointercancel` → `abandoned` |
+  | `armed` | hold timer fires while `pending` | `beginPaneDrag` runs synchronously with the most recent pointer position |
+  | `tap` | `pointerup` arrived first | clear pending metrics; let browser-synthesized click drive `tab-activate` (no `preventDefault`) |
+  | `abandoned` | movement >slop, or `pointercancel`, or visibility change | clear pending metrics; do nothing; native scroll proceeds |
+
+- **Listeners** (registered on `window` with `capture: true`, mirroring the mouse path):
+  - `pointermove` — track `latestClientX/Y`; if `Math.hypot(dx, dy) > SLOP` while `pending` → cancel timer, transition to `abandoned`, remove listeners.
+  - `pointerup` — if `pending` → cancel timer, transition to `tap`, remove listeners.
+  - `pointercancel` — if `pending` → cancel timer, transition to `abandoned`, remove listeners.
+
+- **Timer firing path** (`pending` → `armed`):
+  1. Call `setPointerCapture(pointerId)` on the dock host (`this`). This re-routes subsequent pointer events away from the browser's scroll arbitration to the dock element and is the key handshake that lets us start a drag mid-gesture without `pointercancel` hitting us.
+  2. Synthesise the call to `beginPaneDrag` using the latest tracked `clientX/Y` and the same `pointerId`. `beginPaneDrag` already accepts a `PointerEvent`-shaped argument; we either pass the most recent move event we held a reference to, or construct a minimal `{ clientX, clientY, pointerId, pointerType: 'touch' }` shim — whichever is cleaner at implementation time.
+  3. From here, the existing pipeline takes over: `dragState` is set, `startDragPointerTracking` runs (`:1813`), and the existing reorder-vs-undock 8 px header-bounds threshold (`:1976`) governs subsequent behavior. This is the part of the spec that matches "initially to reorder tabs within the tabstrip without undocking; when the tabstrip is exited by the thumb turn into a floating panel."
+
+- **Self-cleanup** matches the mouse path: every exit path runs `cleanup()` which clears the timeout and removes all three window listeners.
+
+### 4.3 CSS — let the strip scroll until the long-press fires
+
+`mint-dock-manager.element.scss` change to `.dock-tab`:
+
+```scss
+.dock-tab {
+  cursor: grab;
+  padding: 0.5rem 1rem;
+  margin: -0.5rem -1rem;
+
+  // Allow horizontal scroll on the tabstrip while the finger is "deciding"
+  // (the long-press hasn't fired yet). The browser claims the gesture for
+  // pan-x and fires pointercancel — armPaneDragGestureTouch interprets that
+  // as "user is scrolling" and leaves the panel docked. Once the long-press
+  // fires we call setPointerCapture on the host and the browser stops
+  // arbitrating, so subsequent moves drive the drag normally.
+  touch-action: pan-x;
+
+  // Suppress iOS magnifier loupe / selection on long-press.
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+```
+
+`pan-x` is the right policy because the strip itself is `overflow-x: auto`. If a stack ever ships with a vertical-scroll strip, this becomes `pan-y` — but that's not a current configuration.
+
+The other `touch-action: none` declarations (`.dock-floating__chrome` `:82`, `.dock-floating__resizer` `:121`, `.dock-intersection-handle` `:218`) stay as-is. They guard surfaces that have no competing native gesture.
+
+### 4.4 Press feedback during the hold
+
+The user has no cursor on touch, so the only signal that "I'm being held" is visual. Without it, a 600 ms wait feels broken.
+
+Add a `.dock-tab[data-pressing="true"]` class applied 150 ms into the hold and removed on any state transition out of `pending`:
+
+```scss
+.dock-tab[data-pressing='true'] {
+  background-color: var(--bs-secondary-bg-subtle, rgba(0, 0, 0, 0.05));
+  transform: scale(1.02);
+  transition: background-color 100ms ease-out, transform 100ms ease-out;
+}
+```
+
+The 150 ms delay before applying the class hides the effect for transient taps. The transform amount is small enough not to clip in the strip but large enough to be perceptible.
+
+When the long-press fires (transition `pending` → `armed`), the dock fires a navigator vibration if available:
+
+```ts
+if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+  navigator.vibrate(10);
+}
+```
+
+This matches iOS/Android native long-press conventions. It is a no-op on desktop and on devices without the vibration API.
+
+### 4.5 Spec test — drive both code paths
+
+The existing `mint-dock-manager.element.spec.ts` has tests for `pointerType: 'mouse'`. Add a parallel suite that:
+
+1. Dispatches `PointerEvent('pointerdown', { pointerType: 'touch', clientX, clientY, pointerId, isPrimary: true })` on a tab header.
+2. Asserts `dragState === null` immediately after, and after a `pointermove` 3 px away.
+3. Advances fake timers by 600 ms.
+4. Asserts `dragState !== null` and the pane has been removed from its source stack only after the 600 ms tick.
+5. Separate test: dispatch `pointerdown` (touch) → `pointermove` 30 px → assert no drag was armed even after 600 ms.
+6. Separate test: dispatch `pointerdown` (touch) → `pointerup` after 200 ms → assert `tab-activate` fires and no drag.
+
+Use Vitest's `vi.useFakeTimers()` for the 600 ms wait; the existing spec already runs in jsdom with synthetic events.
+
+## 5. Edge cases
+
+- **Two-finger gestures.** `armPaneDragGestureTouch` keys all listeners on `pointerId`. A second finger landing on a different tab gets its own pointerdown and its own arming state; they do not interact. The pinch-zoom case is handled by the browser at the document level since `.dock-tab` is `pan-x`, not `none`.
+- **Pointer leaves the tab during the hold.** Movement >slop transitions to `abandoned`. The thumb sliding off the tab onto the strip background is identical to "user is scrolling."
+- **Pointer leaves the window during the hold.** `pointercancel` fires, transition to `abandoned`. No drag, nothing leaks.
+- **Page becomes hidden during the hold** (tab switch, OS notification full-screen). Add a `visibilitychange` listener for the duration of `pending`; on hidden, `abandoned`. (Matches how `armPaneDragGesture` survives DOM teardown via window-level listeners — same pattern.)
+- **Concurrent floating-pane drag and tab long-press.** They use different `pointerId`s and different state objects (`floatingDragState` vs `dragState`). No interaction.
+- **Spec assertion re: tab-activate semantics.** Releasing during the hold must not call `event.preventDefault()` on the original `pointerdown`. The current code (`:1533`) already abstains; the new touch path keeps that abstention for the `tap` exit and adds it nowhere else. The synthesized click on `<button class="nav-link">` continues to drive `<mp-tab-control>`'s `tab-activate`.
+- **Hold fires, but the original `.dock-tab` span has been removed by a re-render.** This is the same hazard that exists today (see `dock-tab-drag-android-touch.md` §3.2). Window-capture pointermove/pointerup listeners survive any DOM rebuild; `setPointerCapture` is on the dock host, which is stable. No regression.
+
+## 6. Alternatives considered
+
+### 6.1 Distance threshold only, no timer
+
+Bump the touch threshold from 5 px to ~30 px so a "scroll-y" swipe doesn't undock. **Rejected.** The strip is `overflow-x: auto` — a horizontal swipe to scroll *is* the gesture we need to allow. A larger distance threshold delays the drag-undock by a similar amount but doesn't free the strip to scroll.
+
+### 6.2 Dedicated drag handle (grip icon)
+
+Add a `<span class="dock-tab__grip">⋮⋮</span>` to each tab header; only the grip arms a drag. **Rejected.** Doubles header width, fights the existing dense `.nav-link` padding, and is contrary to direct-manipulation expectations on touch (no other touch tab UI does this).
+
+### 6.3 Direction-based arbitration (vertical move = drag, horizontal = scroll)
+
+Inspect the first move's angle: vertical → arm drag, horizontal → release to scroll. **Rejected.** Tab strips are horizontal, so an undock-to-floating gesture *also* starts horizontal in many cases. Direction is not a clean signal here.
+
+### 6.4 `touch-action: manipulation` instead of `pan-x`
+
+`manipulation` allows pan + pinch but disables double-tap-to-zoom. **Rejected.** `pan-x` is the precise statement: this surface scrolls horizontally only. `manipulation` admits vertical pan, which we don't want from a horizontal strip.
+
+## 7. Out-of-scope follow-ups
+
+These are explicitly *not* in this PRD's scope. Logged here so we don't lose them.
+
+- **Pen on hybrid touchscreens with no mouse fallback.** If a Surface/iPad-Pencil user reports the immediate-arm path feels too sensitive, revisit the pointerType branching to send pen down the touch path.
+- **Long-press on splitter dividers** to expose a snap-to-grid mode. Distinct feature, not a gesture-mechanics question.
+- **Drag affordance on hover** for desktop discoverability. Cosmetic, separate.
+
+## 8. Test plan
+
+**Manual matrix** (run on https://bootstrap.mintplayer.com/advanced/dock, configure layout to overflow the strip):
+
+| Device | Gesture | Expected |
+| --- | --- | --- |
+| Android Chrome | Quick horizontal swipe on a tab header | Strip scrolls horizontally; no undock |
+| Android Chrome | Hold tab ≥600 ms, then drag down | Pane undocks to floating, follows finger |
+| Android Chrome | Hold tab ≥600 ms, then drag sideways within strip | Reorders tabs (existing behavior) |
+| Android Chrome | Tap tab (release <600 ms) | Tab activates, no drag |
+| iOS Safari | All four cases above | Same as Android |
+| iOS Safari | Hold tab ≥600 ms | No magnifier loupe / text selection appears |
+| Desktop Chrome (mouse) | Drag tab header | Immediate arm at 5 px (unchanged) |
+| Desktop Chrome (mouse) | Click tab header | Tab activates (unchanged) |
+| Surface w/ pen | Pen tap-and-drag tab header | Immediate arm at 5 px (treated as mouse) |
+
+**Automated** (`mint-dock-manager.element.spec.ts`):
+
+- New `describe('touch long-press arming', …)` block with the six cases listed in §4.5.
+- Existing mouse tests continue to pass unchanged.
+
+**Visual regression** — capture before/after screenshot of the tab strip on a desktop browser to confirm no layout shift from the new CSS (`pan-x` instead of `none` is invisible until interacted with; `user-select: none` is invisible).
+
+## 9. Files touched
+
+| File | Change |
+| --- | --- |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts` | Add `TOUCH_LONG_PRESS_MS` / `TOUCH_LONG_PRESS_SLOP_PX` constants; add `armPaneDragGestureTouch` private method; branch `armPaneDragGesture` (`:1727`) on `pointerType === 'touch'`; ensure `setPointerCapture` is called on `armed` transition; press-feedback `data-pressing` attribute toggling; navigator.vibrate ping. |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.scss` | `.dock-tab` `touch-action: none` → `touch-action: pan-x`; add `user-select: none`, `-webkit-user-select: none`, `-webkit-touch-callout: none`; add `.dock-tab[data-pressing='true']` press-feedback rule; comment update. |
+| `libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts` | New `describe('touch long-press arming', …)` block, six cases. |
+
+No template, demo app, public-API, or `<mp-tab-control>` changes.

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.scss
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.scss
@@ -279,16 +279,14 @@
   display: block;
   padding: 0.5rem 1rem;
   margin: -0.5rem -1rem;
-  // Allow horizontal scroll on the tabstrip while the long-press timer is
-  // running. The browser may claim the gesture for pan-x and fire
-  // pointercancel — armPaneDragGestureTouch interprets that as "user is
-  // scrolling" and leaves the panel docked. Once the long-press fires we
-  // call setPointerCapture on the host so subsequent moves drive the drag
-  // without further arbitration. Mouse / pen are unaffected because they
-  // don't go through the touch-action gesture path.
-  // See docs/prd/dock-touch-long-press-drag.md and
-  // docs/prd/dock-tab-drag-android-touch.md.
-  touch-action: pan-x;
+  // touch-action is consulted at touchstart and frozen for the lifetime of
+  // the gesture — `pan-x` cannot be promoted to "anything goes" mid-gesture
+  // even with setPointerCapture (the compositor has already arbitrated the
+  // touch). So we set `none` and own the gesture from frame 1: the browser
+  // never claims it for scroll or selection, and JS drives strip scroll
+  // programmatically during the pending window before the long-press fires.
+  // See docs/prd/dock-touch-long-press-drag.md.
+  touch-action: none;
   // Suppress iOS magnifier loupe / text selection on long-press.
   user-select: none;
   -webkit-user-select: none;

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.scss
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.scss
@@ -279,16 +279,36 @@
   display: block;
   padding: 0.5rem 1rem;
   margin: -0.5rem -1rem;
-  // Block the browser's touch-gesture arbitration. On Android Chrome, without
-  // this the first pointermove still fires (so the tab undocks once the 5px
-  // threshold is crossed), but immediately after the browser claims the
-  // gesture for page scroll, fires pointercancel, and the floating pane is
-  // stranded. See docs/prd/dock-tab-drag-android-touch.md.
-  touch-action: none;
+  // Allow horizontal scroll on the tabstrip while the long-press timer is
+  // running. The browser may claim the gesture for pan-x and fire
+  // pointercancel — armPaneDragGestureTouch interprets that as "user is
+  // scrolling" and leaves the panel docked. Once the long-press fires we
+  // call setPointerCapture on the host so subsequent moves drive the drag
+  // without further arbitration. Mouse / pen are unaffected because they
+  // don't go through the touch-action gesture path.
+  // See docs/prd/dock-touch-long-press-drag.md and
+  // docs/prd/dock-tab-drag-android-touch.md.
+  touch-action: pan-x;
+  // Suppress iOS magnifier loupe / text selection on long-press.
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .dock-tab:active {
   cursor: grabbing;
+}
+
+// Visual feedback during the touch long-press hold. Applied 150 ms into the
+// hold (after the initial settle), removed on any state transition out of
+// pending. The transform is small enough not to clip in the strip but large
+// enough to read as "I see your press."
+.dock-tab[data-pressing='true'] {
+  background-color: var(--bs-secondary-bg-subtle, rgba(0, 0, 0, 0.05));
+  transform: scale(1.02);
+  transition:
+    background-color 100ms ease-out,
+    transform 100ms ease-out;
 }
 
 // `.dock-stack__pane` is the slotted content wrapper. The WC projects it

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
@@ -267,3 +267,111 @@ describe('mint-dock-manager — touch long-press arming', () => {
     expect(getFloatingWrapper()).toBeTruthy();
   });
 });
+
+describe('mint-dock-manager — touch swipe scrolls the tabstrip', () => {
+  let dock: MintDockManagerElement;
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+    dock = document.createElement('mint-dock-manager') as MintDockManagerElement;
+    document.body.appendChild(dock);
+    dock.getBoundingClientRect = () => makeRect(HOST_LEFT, HOST_TOP, HOST_WIDTH, HOST_HEIGHT);
+
+    // Multi-pane stack so the strip has several tabs and can overflow.
+    dock.layout = {
+      root: { kind: 'stack', panes: ['A', 'B', 'C', 'D', 'E'], activePane: 'A' },
+      titles: { A: 'Alpha', B: 'Bravo', C: 'Charlie', D: 'Delta', E: 'Echo' },
+      floating: [],
+    } as never;
+
+    await (dock as unknown as { updateComplete: Promise<void> }).updateComplete;
+    await nextRaf();
+
+    if (dock.shadowRoot) {
+      (dock.shadowRoot as unknown as { elementsFromPoint: (x: number, y: number) => Element[] }).elementsFromPoint =
+        () => [];
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    dock.remove();
+  });
+
+  function getStripUl(): HTMLElement {
+    const stack = dock.shadowRoot!.querySelector('mp-tab-control');
+    if (!stack) throw new Error('mp-tab-control not rendered');
+    const ul = stack.shadowRoot?.querySelector<HTMLElement>('ul.nav.nav-tabs');
+    if (!ul) throw new Error('strip <ul> not rendered');
+    // jsdom returns 0 for scrollWidth/clientWidth; mock to force overflow.
+    Object.defineProperty(ul, 'scrollWidth', { configurable: true, value: 600 });
+    Object.defineProperty(ul, 'clientWidth', { configurable: true, value: 200 });
+    return ul;
+  }
+
+  function getHeaderSpan(pane: string): HTMLElement {
+    const headerSpan = dock.shadowRoot!.querySelector<HTMLElement>(`.dock-tab[data-pane="${pane}"]`);
+    if (!headerSpan) throw new Error(`header span for ${pane} not rendered`);
+    headerSpan.getBoundingClientRect = () => makeRect(TAB_LEFT, TAB_TOP, TAB_WIDTH, TAB_HEIGHT);
+    return headerSpan;
+  }
+
+  it('horizontal swipe before the long-press fires drives ul.scrollLeft and does not undock', async () => {
+    const ul = getStripUl();
+    const headerSpan = getHeaderSpan('A');
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    // First move: 30 px left, past the 10 px slop. Enters `scrolling`,
+    // applies the initial delta to scrollLeft.
+    window.dispatchEvent(makePointerEvent('pointermove', { clientX: startX - 30, clientY: startY, pointerType: 'touch' }));
+    expect(ul.scrollLeft).toBe(30);
+    // Subsequent moves continue to scroll directly.
+    window.dispatchEvent(makePointerEvent('pointermove', { clientX: startX - 60, clientY: startY, pointerType: 'touch' }));
+    expect(ul.scrollLeft).toBe(60);
+
+    // Long-press timer would fire here in real time — but since we entered
+    // `scrolling`, the timer was cleared. No undock.
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(dock.shadowRoot!.querySelector('.dock-floating-layer .dock-floating')).toBeNull();
+  });
+
+  it('vertical swipe past slop abandons — no scroll and no drag', async () => {
+    const ul = getStripUl();
+    const headerSpan = getHeaderSpan('A');
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    // 30 px vertical move, well past slop, but |dy| > |dx| → abandoned.
+    window.dispatchEvent(makePointerEvent('pointermove', { clientX: startX, clientY: startY + 30, pointerType: 'touch' }));
+    expect(ul.scrollLeft).toBe(0);
+
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(dock.shadowRoot!.querySelector('.dock-floating-layer .dock-floating')).toBeNull();
+  });
+
+  it('horizontal swipe on a non-overflowing strip abandons — does not pretend to scroll', async () => {
+    const stack = dock.shadowRoot!.querySelector('mp-tab-control')!;
+    const ul = stack.shadowRoot!.querySelector<HTMLElement>('ul.nav.nav-tabs')!;
+    // Override the helper's overflow mock — clientWidth >= scrollWidth.
+    Object.defineProperty(ul, 'scrollWidth', { configurable: true, value: 200 });
+    Object.defineProperty(ul, 'clientWidth', { configurable: true, value: 600 });
+
+    const headerSpan = getHeaderSpan('A');
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    window.dispatchEvent(makePointerEvent('pointermove', { clientX: startX - 30, clientY: startY, pointerType: 'touch' }));
+    expect(ul.scrollLeft).toBe(0);
+
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(dock.shadowRoot!.querySelector('.dock-floating-layer .dock-floating')).toBeNull();
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
@@ -375,3 +375,82 @@ describe('mint-dock-manager — touch swipe scrolls the tabstrip', () => {
     expect(dock.shadowRoot!.querySelector('.dock-floating-layer .dock-floating')).toBeNull();
   });
 });
+
+describe('mint-dock-manager — computeHeaderInsertIndex excludes the dragged tab', () => {
+  // mp-tab-control's strip refreshes on a microtask after data-hidden is set.
+  // beginPaneDrag calls updateDraggedFloatingPositionFromPoint synchronously
+  // right after preparePaneDragSource, so computeHeaderInsertIndex runs before
+  // that refresh — the dragged button is still in the strip's shadow. Without
+  // the explicit exclusion, the loop counts the dragged tab as a real target
+  // and the placeholder gets appended past the live tabs (visible on touch
+  // long-press, where the finger doesn't move and the user sees the
+  // mis-positioned placeholder for the duration of the hold).
+  let dock: MintDockManagerElement;
+
+  beforeEach(async () => {
+    dock = document.createElement('mint-dock-manager') as MintDockManagerElement;
+    document.body.appendChild(dock);
+    dock.getBoundingClientRect = () => makeRect(HOST_LEFT, HOST_TOP, HOST_WIDTH, HOST_HEIGHT);
+
+    dock.layout = {
+      root: { kind: 'stack', panes: ['A', 'B', 'C'], activePane: 'A' },
+      titles: { A: 'Alpha', B: 'Bravo', C: 'Charlie' },
+      floating: [],
+    } as never;
+
+    await (dock as unknown as { updateComplete: Promise<void> }).updateComplete;
+    await nextRaf();
+  });
+
+  afterEach(() => {
+    dock.remove();
+  });
+
+  it('returns the dragged tab\'s original index, not the appended end', () => {
+    const stack = dock.shadowRoot!.querySelector('mp-tab-control') as HTMLElement;
+    const draggedPane = 'B';
+    const draggedHeader = stack.querySelector<HTMLElement>(
+      `.dock-tab[data-pane="${draggedPane}"]`,
+    )!;
+    const draggedContent = stack.querySelector<HTMLElement>(
+      `.dock-stack__pane[data-pane="${draggedPane}"]`,
+    )!;
+
+    // Reproduce the synchronous state ensureHeaderDragPlaceholder leaves
+    // behind right before mp-tab-control's MutationObserver gets a chance to
+    // refresh its strip: dragged content has data-hidden, placeholder span
+    // is in light DOM before the dragged header, but shadow buttons are
+    // still [A, B, C].
+    draggedContent.setAttribute('data-hidden', '');
+    const phHeader = document.createElement('span');
+    phHeader.setAttribute('slot', '__dock-placeholder__-header');
+    phHeader.classList.add('dock-tab');
+    phHeader.dataset['placeholder'] = 'true';
+    phHeader.dataset['tabId'] = '__dock-placeholder__';
+    stack.insertBefore(phHeader, draggedHeader);
+
+    // Set dragState so the function knows which pane is being dragged.
+    (dock as unknown as { dragState: unknown }).dragState = { pane: draggedPane };
+
+    // Stub each strip button's geometry. A:[0,60), B:[60,120), C:[120,180).
+    const buttons = Array.from(
+      stack.shadowRoot!.querySelectorAll<HTMLButtonElement>('button.nav-link'),
+    );
+    expect(buttons.length).toBe(3);
+    buttons[0].getBoundingClientRect = () => makeRect(0, 0, 60, 32);
+    buttons[1].getBoundingClientRect = () => makeRect(60, 0, 60, 32);
+    buttons[2].getBoundingClientRect = () => makeRect(120, 0, 60, 32);
+
+    // clientX = 90 → center of B. Pre-fix the loop would count B as a real
+    // target and return 2 (index past B), which clamps to length-2 of
+    // [A, C] in updateHeaderDragPlaceholderPosition → null ref → APPEND.
+    // Post-fix targets = [A, C], the loop returns 1 (insert before C),
+    // which lands the placeholder between A and C — i.e. B's old spot.
+    const idx = (
+      dock as unknown as {
+        computeHeaderInsertIndex(stack: HTMLElement, clientX: number): number;
+      }
+    ).computeHeaderInsertIndex(stack, 90);
+    expect(idx).toBe(1);
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import './mint-dock-manager.element';
 import type { MintDockManagerElement } from './mint-dock-manager.element';
 
@@ -28,14 +28,23 @@ function makeRect(left: number, top: number, width: number, height: number): DOM
 
 function makePointerEvent(
   type: string,
-  init: { clientX: number; clientY: number; pointerId?: number; offsetX?: number; offsetY?: number; button?: number; buttons?: number },
+  init: {
+    clientX: number;
+    clientY: number;
+    pointerId?: number;
+    offsetX?: number;
+    offsetY?: number;
+    button?: number;
+    buttons?: number;
+    pointerType?: 'mouse' | 'touch' | 'pen';
+  },
 ): PointerEvent {
   return new PointerEvent(type, {
     bubbles: true,
     composed: true,
     cancelable: true,
     pointerId: init.pointerId ?? 1,
-    pointerType: 'mouse',
+    pointerType: init.pointerType ?? 'mouse',
     isPrimary: true,
     button: init.button ?? 0,
     buttons: init.buttons ?? 1,
@@ -126,5 +135,135 @@ describe('mint-dock-manager — drag-to-detach follows the cursor mid-gesture', 
     // The wrapper must have moved in the same direction and magnitude as the cursor.
     expect(movedLeft - initialLeft).toBeCloseTo(moveDX, 0);
     expect(movedTop - initialTop).toBeCloseTo(moveDY, 0);
+  });
+});
+
+describe('mint-dock-manager — touch long-press arming', () => {
+  let dock: MintDockManagerElement;
+
+  beforeEach(async () => {
+    // Fake setTimeout / clearTimeout only — leave requestAnimationFrame real
+    // so Lit can flush re-renders normally between assertions.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+    dock = document.createElement('mint-dock-manager') as MintDockManagerElement;
+    document.body.appendChild(dock);
+
+    dock.getBoundingClientRect = () => makeRect(HOST_LEFT, HOST_TOP, HOST_WIDTH, HOST_HEIGHT);
+
+    dock.layout = {
+      root: { kind: 'stack', panes: ['Panel4'], activePane: 'Panel4' },
+      titles: { Panel4: 'Panel 4' },
+      floating: [],
+    } as never;
+
+    await (dock as unknown as { updateComplete: Promise<void> }).updateComplete;
+    await nextRaf();
+
+    if (dock.shadowRoot) {
+      (dock.shadowRoot as unknown as { elementsFromPoint: (x: number, y: number) => Element[] }).elementsFromPoint =
+        () => [];
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    dock.remove();
+  });
+
+  function getHeaderSpan(): HTMLElement {
+    const headerSpan = dock.shadowRoot!.querySelector<HTMLElement>('.dock-tab[data-pane="Panel4"]');
+    if (!headerSpan) throw new Error('header span not rendered');
+    headerSpan.getBoundingClientRect = () => makeRect(TAB_LEFT, TAB_TOP, TAB_WIDTH, TAB_HEIGHT);
+    return headerSpan;
+  }
+
+  function getFloatingWrapper(): HTMLElement | null {
+    return dock.shadowRoot!.querySelector<HTMLElement>('.dock-floating-layer .dock-floating');
+  }
+
+  it('does not arm a drag immediately on touch pointerdown', () => {
+    const headerSpan = getHeaderSpan();
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    // Advance just enough for the press-feedback timer (150 ms) but not the
+    // 600 ms long-press timer.
+    vi.advanceTimersByTime(200);
+    expect(getFloatingWrapper()).toBeNull();
+    expect(headerSpan.getAttribute('data-pressing')).toBe('true');
+  });
+
+  it('arms the drag after the long-press hold elapses', async () => {
+    const headerSpan = getHeaderSpan();
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(getFloatingWrapper()).toBeTruthy();
+    // Press-feedback class must be cleared once the drag is armed.
+    expect(headerSpan.getAttribute('data-pressing')).toBeNull();
+  });
+
+  it('abandons the gesture if the finger moves past slop before the hold elapses', async () => {
+    const headerSpan = getHeaderSpan();
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    // 30 px move — well past the 10 px slop.
+    window.dispatchEvent(makePointerEvent('pointermove', { clientX: startX + 30, clientY: startY, pointerType: 'touch' }));
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(getFloatingWrapper()).toBeNull();
+    expect(headerSpan.getAttribute('data-pressing')).toBeNull();
+  });
+
+  it('keeps waiting if the finger trembles within slop', async () => {
+    const headerSpan = getHeaderSpan();
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    // 5 px move — within the 10 px slop.
+    window.dispatchEvent(makePointerEvent('pointermove', { clientX: startX + 5, clientY: startY, pointerType: 'touch' }));
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(getFloatingWrapper()).toBeTruthy();
+  });
+
+  it('treats a release before the hold elapses as a tap (no drag)', async () => {
+    const headerSpan = getHeaderSpan();
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    vi.advanceTimersByTime(200);
+    window.dispatchEvent(makePointerEvent('pointerup', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(getFloatingWrapper()).toBeNull();
+    expect(headerSpan.getAttribute('data-pressing')).toBeNull();
+  });
+
+  it('abandons the gesture on pointercancel before the hold elapses', async () => {
+    const headerSpan = getHeaderSpan();
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    vi.advanceTimersByTime(200);
+    window.dispatchEvent(makePointerEvent('pointercancel', { clientX: startX, clientY: startY, pointerType: 'touch' }));
+    vi.advanceTimersByTime(700);
+    await nextRaf();
+    expect(getFloatingWrapper()).toBeNull();
+    expect(headerSpan.getAttribute('data-pressing')).toBeNull();
+  });
+
+  it('treats pen as mouse — immediate 5 px arming, no hold required', async () => {
+    const headerSpan = getHeaderSpan();
+    const startX = TAB_LEFT + 20;
+    const startY = TAB_TOP + 16;
+    headerSpan.dispatchEvent(makePointerEvent('pointerdown', { clientX: startX, clientY: startY, pointerType: 'pen' }));
+    window.dispatchEvent(makePointerEvent('pointermove', { clientX: startX + 10, clientY: startY + 10, pointerType: 'pen' }));
+    await nextRaf();
+    expect(getFloatingWrapper()).toBeTruthy();
   });
 });

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
@@ -2602,7 +2602,37 @@ export class MintDockManagerElement extends LitElement {
       ? allTabButtons.find((b) => b.id === `${placeholderTabId}-header-button`) ?? null
       : null;
 
-    const targets = allTabButtons.filter((b) => b !== placeholderButton);
+    // The dragged pane's content is `data-hidden`, but mp-tab-control's strip
+    // re-render is async (its MutationObserver schedules a Lit microtask). When
+    // beginPaneDrag calls updateDraggedFloatingPositionFromPoint synchronously
+    // right after preparePaneDragSource, this runs before that re-render — so
+    // the dragged button is still in the strip's shadow. We must exclude it
+    // explicitly, otherwise the loop counts it as a real target and the
+    // placeholder gets appended past the live tabs (visible on touch
+    // long-press, where the finger doesn't move and the user sees the
+    // mis-positioned placeholder for the duration of the hold).
+    const draggedPane = this.dragState?.pane ?? null;
+    let draggedTabId: string | null = null;
+    if (draggedPane) {
+      for (const child of Array.from(stack.children)) {
+        if (
+          child instanceof HTMLElement &&
+          child.classList.contains('dock-tab') &&
+          !child.hasAttribute('data-placeholder') &&
+          child.dataset['pane'] === draggedPane
+        ) {
+          draggedTabId = child.dataset['tabId'] ?? null;
+          break;
+        }
+      }
+    }
+    const draggedButton = draggedTabId
+      ? allTabButtons.find((b) => b.id === `${draggedTabId}-header-button`) ?? null
+      : null;
+
+    const targets = allTabButtons.filter(
+      (b) => b !== placeholderButton && b !== draggedButton,
+    );
     if (targets.length === 0) {
       return 0;
     }

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
@@ -56,6 +56,14 @@ export class MintDockManagerElement extends LitElement {
 
   private static instanceCounter = 0;
 
+  // Touch tab-drag gesture: a finger that lands on a tab header must be able
+  // to scroll the tabstrip natively. We require a stationary hold before
+  // arming the drag, so a horizontal swipe scrolls instead of undocking.
+  // See docs/prd/dock-touch-long-press-drag.md.
+  private static readonly TOUCH_LONG_PRESS_MS = 600;
+  private static readonly TOUCH_LONG_PRESS_SLOP_PX = 10;
+  private static readonly TOUCH_PRESS_FEEDBACK_DELAY_MS = 150;
+
   private documentRef!: Document;
   private windowRef!: (Window & typeof globalThis) | null;
   private rootEl!: HTMLElement;
@@ -1712,11 +1720,12 @@ export class MintDockManagerElement extends LitElement {
   }
 
   /**
-   * Pointerdown handler arms a "may become a drag" gesture. Once the pointer
-   * moves past `threshold` pixels we promote it to an actual pane drag via
-   * {@link beginPaneDrag}; if the user releases first we just clear the
-   * pending tab metrics. All listeners self-clean on resolve so the gesture
-   * stays scoped to a single pointerdown.
+   * Pointerdown handler arms a "may become a drag" gesture. Mouse / pen use a
+   * 5 px distance threshold and arm immediately; touch dispatches to
+   * {@link armPaneDragGestureTouch} which requires a 600 ms stationary hold
+   * (so the user can scroll the tabstrip natively without undocking).
+   * Once armed, both paths converge on {@link beginPaneDrag}. All listeners
+   * self-clean on resolve so the gesture stays scoped to a single pointerdown.
    */
   private armPaneDragGesture(
     startEvent: PointerEvent,
@@ -1724,6 +1733,10 @@ export class MintDockManagerElement extends LitElement {
     pane: string,
     stackEl: HTMLElement | null,
   ): void {
+    if (startEvent.pointerType === 'touch') {
+      this.armPaneDragGestureTouch(startEvent, path, pane, stackEl);
+      return;
+    }
     if (startEvent.pointerType === 'mouse' && startEvent.button !== 0) return;
     const win = this.windowRef;
     if (!win) return;
@@ -1758,6 +1771,122 @@ export class MintDockManagerElement extends LitElement {
     win.addEventListener('pointermove', onMove, true);
     win.addEventListener('pointerup', onRelease, true);
     win.addEventListener('pointercancel', onRelease, true);
+  }
+
+  /**
+   * Touch-specific gesture arming. Waits {@link TOUCH_LONG_PRESS_MS} for a
+   * stationary hold (within {@link TOUCH_LONG_PRESS_SLOP_PX} of the start
+   * point); on success, claims the gesture via setPointerCapture and runs
+   * {@link beginPaneDrag} with the latest pointer position. Movement past
+   * slop, pointerup, or pointercancel before the timer fires aborts cleanly
+   * — letting the browser scroll the tabstrip natively or fire the
+   * synthesized click that drives `tab-activate`.
+   *
+   * `.dock-tab` is `touch-action: pan-x` (not `none`), so the browser claims
+   * the gesture for horizontal scroll and fires `pointercancel` while the
+   * finger is "deciding". That pointercancel transitions us to abandoned and
+   * leaves the panel docked. After the long-press fires, setPointerCapture
+   * on the host stops the browser from arbitrating subsequent moves.
+   */
+  private armPaneDragGestureTouch(
+    startEvent: PointerEvent,
+    path: DockPath,
+    pane: string,
+    stackEl: HTMLElement | null,
+  ): void {
+    const win = this.windowRef;
+    if (!win) return;
+    const startX = startEvent.clientX;
+    const startY = startEvent.clientY;
+    const pointerId = startEvent.pointerId;
+    let latestX = startX;
+    let latestY = startY;
+    let resolved = false;
+    let pressFeedbackApplied = false;
+
+    const tabSpan: HTMLElement | null =
+      startEvent.currentTarget instanceof HTMLElement
+        ? startEvent.currentTarget
+        : startEvent.target instanceof HTMLElement
+        ? startEvent.target.closest('.dock-tab')
+        : null;
+
+    const cleanup = (): void => {
+      if (resolved) return;
+      resolved = true;
+      win.clearTimeout(longPressTimeout);
+      win.clearTimeout(pressFeedbackTimeout);
+      win.removeEventListener('pointermove', onMove, true);
+      win.removeEventListener('pointerup', onRelease, true);
+      win.removeEventListener('pointercancel', onCancel, true);
+      if (pressFeedbackApplied && tabSpan) {
+        tabSpan.removeAttribute('data-pressing');
+      }
+    };
+
+    const onMove = (event: PointerEvent): void => {
+      if (resolved || event.pointerId !== pointerId) return;
+      latestX = event.clientX;
+      latestY = event.clientY;
+      const dx = event.clientX - startX;
+      const dy = event.clientY - startY;
+      if (Math.hypot(dx, dy) > MintDockManagerElement.TOUCH_LONG_PRESS_SLOP_PX) {
+        cleanup();
+        this.clearPendingTabDragMetrics();
+      }
+    };
+
+    const onRelease = (event: PointerEvent): void => {
+      if (resolved || event.pointerId !== pointerId) return;
+      cleanup();
+      this.clearPendingTabDragMetrics();
+    };
+
+    const onCancel = (event: PointerEvent): void => {
+      if (resolved || event.pointerId !== pointerId) return;
+      cleanup();
+      this.clearPendingTabDragMetrics();
+    };
+
+    const longPressTimeout = win.setTimeout(() => {
+      if (resolved) return;
+      cleanup();
+      // Claim the gesture before the browser can arbitrate a late scroll.
+      try {
+        this.setPointerCapture(pointerId);
+      } catch {
+        // setPointerCapture throws if the pointer is no longer active
+        // (e.g. timer raced a pointerup we didn't see). Drag will abort
+        // naturally on the next event.
+      }
+      if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+        try {
+          navigator.vibrate(10);
+        } catch {
+          // ignore
+        }
+      }
+      const synthEvent = new PointerEvent('pointermove', {
+        pointerId,
+        pointerType: 'touch',
+        isPrimary: true,
+        clientX: latestX,
+        clientY: latestY,
+        bubbles: false,
+        cancelable: false,
+      });
+      this.beginPaneDrag(synthEvent, path, pane, stackEl);
+    }, MintDockManagerElement.TOUCH_LONG_PRESS_MS);
+
+    const pressFeedbackTimeout = win.setTimeout(() => {
+      if (resolved || !tabSpan) return;
+      pressFeedbackApplied = true;
+      tabSpan.setAttribute('data-pressing', 'true');
+    }, MintDockManagerElement.TOUCH_PRESS_FEEDBACK_DELAY_MS);
+
+    win.addEventListener('pointermove', onMove, true);
+    win.addEventListener('pointerup', onRelease, true);
+    win.addEventListener('pointercancel', onCancel, true);
   }
 
   private beginPaneDrag(

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
@@ -1774,19 +1774,25 @@ export class MintDockManagerElement extends LitElement {
   }
 
   /**
-   * Touch-specific gesture arming. Waits {@link TOUCH_LONG_PRESS_MS} for a
-   * stationary hold (within {@link TOUCH_LONG_PRESS_SLOP_PX} of the start
-   * point); on success, claims the gesture via setPointerCapture and runs
-   * {@link beginPaneDrag} with the latest pointer position. Movement past
-   * slop, pointerup, or pointercancel before the timer fires aborts cleanly
-   * — letting the browser scroll the tabstrip natively or fire the
-   * synthesized click that drives `tab-activate`.
+   * Touch-specific gesture arming. With `.dock-tab` set to `touch-action:
+   * none`, the browser never arbitrates the gesture itself, so JS owns it
+   * from frame 1. Three outcomes from the pending state:
    *
-   * `.dock-tab` is `touch-action: pan-x` (not `none`), so the browser claims
-   * the gesture for horizontal scroll and fires `pointercancel` while the
-   * finger is "deciding". That pointercancel transitions us to abandoned and
-   * leaves the panel docked. After the long-press fires, setPointerCapture
-   * on the host stops the browser from arbitrating subsequent moves.
+   *  - User holds within {@link TOUCH_LONG_PRESS_SLOP_PX} for
+   *    {@link TOUCH_LONG_PRESS_MS} → timer fires → drag arms via
+   *    {@link beginPaneDrag}.
+   *  - User moves past slop and the move is mostly horizontal, and the
+   *    strip's `<ul>` is scrollable → enter `scrolling` mode and drive
+   *    `ul.scrollLeft` from JS for the rest of the gesture (no drag, no
+   *    momentum — direct 1:1 finger follow).
+   *  - User moves past slop in any other direction, releases, or
+   *    pointercancel fires → abandoned, no drag, no scroll. Releases
+   *    under slop fire the synthesized click that drives `tab-activate`.
+   *
+   * `touch-action: pan-x` was the original PRD design but doesn't work:
+   * the policy is frozen at touchstart and `setPointerCapture` doesn't
+   * promote it, so first move after a long-press fires pointercancel and
+   * strands the panel. JS-driven scroll is the only model that holds.
    */
   private armPaneDragGestureTouch(
     startEvent: PointerEvent,
@@ -1801,7 +1807,9 @@ export class MintDockManagerElement extends LitElement {
     const pointerId = startEvent.pointerId;
     let latestX = startX;
     let latestY = startY;
+    let lastScrollX = startX;
     let resolved = false;
+    let scrolling = false;
     let pressFeedbackApplied = false;
 
     const tabSpan: HTMLElement | null =
@@ -1810,6 +1818,12 @@ export class MintDockManagerElement extends LitElement {
         : startEvent.target instanceof HTMLElement
         ? startEvent.target.closest('.dock-tab')
         : null;
+
+    const stripUl: HTMLElement | null = stackEl
+      ? this.getStackStripEl(stackEl)?.querySelector<HTMLElement>(
+          'ul.nav.nav-tabs',
+        ) ?? null
+      : null;
 
     const cleanup = (): void => {
       if (resolved) return;
@@ -1826,14 +1840,44 @@ export class MintDockManagerElement extends LitElement {
 
     const onMove = (event: PointerEvent): void => {
       if (resolved || event.pointerId !== pointerId) return;
+
+      if (scrolling) {
+        const dx = event.clientX - lastScrollX;
+        lastScrollX = event.clientX;
+        if (stripUl) stripUl.scrollLeft -= dx;
+        return;
+      }
+
       latestX = event.clientX;
       latestY = event.clientY;
       const dx = event.clientX - startX;
       const dy = event.clientY - startY;
-      if (Math.hypot(dx, dy) > MintDockManagerElement.TOUCH_LONG_PRESS_SLOP_PX) {
-        cleanup();
-        this.clearPendingTabDragMetrics();
+      if (Math.hypot(dx, dy) <= MintDockManagerElement.TOUCH_LONG_PRESS_SLOP_PX) {
+        return;
       }
+
+      // Slop crossed before the long-press fired. If the move is mostly
+      // horizontal and the strip can scroll, take over scroll in JS;
+      // otherwise abandon (no drag — browser native UI is fully suppressed
+      // by `touch-action: none` so no fallback is needed).
+      const stripScrollable =
+        !!stripUl && stripUl.scrollWidth > stripUl.clientWidth;
+      if (Math.abs(dx) > Math.abs(dy) && stripScrollable) {
+        win.clearTimeout(longPressTimeout);
+        win.clearTimeout(pressFeedbackTimeout);
+        if (pressFeedbackApplied && tabSpan) {
+          tabSpan.removeAttribute('data-pressing');
+          pressFeedbackApplied = false;
+        }
+        scrolling = true;
+        lastScrollX = event.clientX;
+        stripUl!.scrollLeft -= dx;
+        this.clearPendingTabDragMetrics();
+        return;
+      }
+
+      cleanup();
+      this.clearPendingTabDragMetrics();
     };
 
     const onRelease = (event: PointerEvent): void => {
@@ -1851,7 +1895,6 @@ export class MintDockManagerElement extends LitElement {
     const longPressTimeout = win.setTimeout(() => {
       if (resolved) return;
       cleanup();
-      // Claim the gesture before the browser can arbitrate a late scroll.
       try {
         this.setPointerCapture(pointerId);
       } catch {

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.24.0",
+  "version": "21.25.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
## Summary

- On touch, a tap-and-hold (600 ms) on a tab header arms a drag; a horizontal swipe before the hold scrolls the strip natively (1:1, JS-driven).
- `.dock-tab` is `touch-action: none` — JS owns the gesture from frame 1, so iOS doesn't show the loupe and Android doesn't claim a `pan-x` scroll mid-gesture (which `setPointerCapture` cannot override — `touch-action` is frozen at touchstart).
- Mouse and pen behavior unchanged (immediate 5 px arming).
- Fixed a synchronous timing bug in `computeHeaderInsertIndex` where the dragged tab's button was still in the strip's shadow when called from `beginPaneDrag`, causing the placeholder to be appended past the live tabs (visible on touch long-press as the held tab "jumping to the right" of the strip).

## Test plan

- [x] Vitest: 7 existing touch long-press cases + 3 new strip-scroll cases + 1 new dragged-tab-exclusion case all pass (319/319 in `mintplayer-ng-bootstrap`).
- [x] Real-touch via Chrome DevTools `Input.dispatchTouchEvent`: horizontal swipe on overflowing strip → `ul.scrollLeft` increases, no undock; long-press → undock + drag follows finger, no `pointercancel`; long-press on a tab in a multi-tab stack → placeholder lands at the held tab's original position.
- [ ] Manual on Android Chrome / iOS Safari: confirm the four cases in the PRD §8 matrix and that no magnifier loupe appears on long-press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)