### PR TITLE
fix(dock): single normalize() chokepoint — flatten same-direction splits, sanitize intake (#317)

### DIFF
--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.html
@@ -1,7 +1,7 @@
 <div class="dock-demo">
   <bs-dock-manager
     [layout]="layout()"
-    [debugLayoutIntegrity]="true"
+    [debugLayoutIntegrity]="isDevMode"
     (layoutChange)="$event && layout.set($event)"
     class="dock-demo__surface"
     (layoutSnapshotChange)="onLayoutSnapshot($event)"

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.html
@@ -1,6 +1,7 @@
 <div class="dock-demo">
   <bs-dock-manager
     [layout]="layout()"
+    [debugLayoutIntegrity]="true"
     (layoutChange)="$event && layout.set($event)"
     class="dock-demo__surface"
     (layoutSnapshotChange)="onLayoutSnapshot($event)"

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, signal, viewChild, ChangeDetectionStrategy} from '@angular/core';
+import { Component, isDevMode, signal, viewChild, ChangeDetectionStrategy} from '@angular/core';
 import { BsBadgeComponent } from '@mintplayer/ng-bootstrap/badge';
 import {
   BsDockManagerComponent,
@@ -20,6 +20,7 @@ export class DockComponent {
   readonly dockManager = viewChild(BsDockManagerComponent);
 
   readonly Color = Color;
+  readonly isDevMode = isDevMode();
 
   layout = signal<DockLayoutSnapshot>({
     root: {

--- a/docs/prd/dock-layout-normalize.md
+++ b/docs/prd/dock-layout-normalize.md
@@ -1,0 +1,217 @@
+# PRD: Dock layout normalization — flatten nested same-direction splits, sanitize intake
+
+**Status:** Draft — branch `issues/#317`
+**Author:** Pieterjan
+**Date:** 2026-05-08
+**Library:** `@mintplayer/ng-bootstrap/dock`
+**Tracks:** [#317](https://github.com/MintPlayer/mintplayer-ng-bootstrap/issues/317)
+
+---
+
+## 1. Problem
+
+The dock manager (`libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts`) prunes empty stacks and length-{0,1} splits via `cleanupEmptyStackInTree` (line 3411-3437) and `cleanupSplitIfNecessary` (line 3439-3466), but four structural gaps leave **redundant** zones in the layout tree that the user never asked for. They are not strictly empty — they render as superfluous splitter handles — and they accumulate over a session.
+
+### Concrete repro
+
+At https://bootstrap.mintplayer.com/advanced/dock from the initial demo state:
+
+1. Drag **panel-4** (the only pane in its stack on the right side) onto the **right** zone of **panel-3**.
+2. Inspect the layout JSON.
+
+Expected: a flat root horizontal split. Actual: a horizontal split nested inside the root horizontal split — `H_root[ stack(p1,p2), H_inner[stack(p3), stack(p4)] ]`.
+
+### Visual illustration of the same-direction merge
+
+Starting layout — outer horizontal split where the left slot is itself a vertical split:
+
+```
++---+---+-------+
+| A | B |       |
++---+---+   D   |
+|   C   |       |
++-------+-------+
+```
+
+Tree: `H[ V[H[A, B], C], D ]`.
+
+Pull out panel C. The inner vertical split now has only one child (`H[A, B]`), so `cleanupSplitIfNecessary` collapses it. The surviving child is hoisted into the grandparent — but because the grandparent and the surviving child are both horizontal splits, today they are NOT merged. Result:
+
+```
++-----------+-----+
+| +---+---+ |     |
+| | A | B | |  D  |
+| +---+---+ |     |
++-----------+-----+
+```
+
+Tree: `H[ H[A, B], D ]` — a redundant horizontal wrapper around `[A, B]` that contributes nothing but a stray splitter handle.
+
+After this PRD, the same-direction merge runs and the inner `H[A, B]` is flattened into the outer split:
+
+```
++---+---+---+
+| A | B |   |
+|   |   | D |
+|   |   |   |
++---+---+---+
+```
+
+Tree: `H[ A, B, D ]`. Sizes are combined multiplicatively so A's, B's, and D's on-screen widths are preserved.
+
+### The four gaps
+
+| ID | Gap | Site |
+|---|---|---|
+| **A** | When `cleanupSplitIfNecessary` collapses a split to its single child via `replaceNodeInTree`, it never checks whether the surviving child is a same-direction split that should merge into the grandparent. | `mint-dock-manager.element.ts:3443-3444` |
+| **B** | `handleFloatingStackDrop` grafts an entire (possibly multi-stack) `source.root` into the docked tree via `dockNodeBeside`. If `source.root.direction` matches the target's parent direction, the result is nested same-direction splits. | `mint-dock-manager.element.ts:2916, 2924` |
+| **C** | `dockNodeBeside`'s wrap branch always builds a fresh wrapping split without considering whether the wrap is adjacent to a same-direction grandparent. | `mint-dock-manager.element.ts:3489-3496` |
+| **D** | The `layout` attribute / property setter accepts whatever the host provides without sanitization. A consumer restoring a snapshot saved by an older buggy version inherits its garbage forever — empty stacks, 0/1-child splits, and nested same-direction splits all persist through render. | `mint-dock-manager.element.ts` (parseLayout / property accessor) |
+
+### Investigation
+
+Two parallel audit agents traced every code path. Truly empty zones (`panes:[]`, 0-child splits) are pruned correctly through every drop flow — order-of-ops in `handleDrop` (skipCleanup=true → mutate → `cleanupLocation`) is sound, all callers reassign cleanup return values, and `cleanupLocation` correctly drops empty floating windows (line 3761). The remaining issues are structural noise (redundant splits, untrusted intake), not orphan empties.
+
+---
+
+## 2. Goals
+
+1. **Single source of truth.** Replace the targeted `cleanupEmptyStackInTree` / `cleanupSplitIfNecessary` helpers with one recursive `normalize(root)` pass that runs at every public mutation chokepoint.
+2. **Eliminate the four gaps** in one PR — gaps A–D ship together (per the unified-scope rule: one user request = one release).
+3. **Preserve user-set split ratios.** Merging a same-direction child split must produce the same on-screen pixel layout the user already had.
+4. **Silently sanitize on intake.** A malformed `layout` setter input renders normalized; no warnings, no throws.
+5. **Diagnostic in dev mode.** When a layout mutation produces a tree where a registered pane has no projection slot in shadow DOM after render, throw — this is a layout-logic bug we want to catch loudly during development, never in production.
+6. **Lock the fix with tests.** Unit tests on `normalize()` covering all four gaps + Playwright e2e covering the six audit-identified repro sequences plus state-restoration via the layout setter.
+
+### Non-goals
+
+- Reorganizing the layout-tree data model (`DockLayoutNode` / `DockSplitNode` / `DockStackNode`) — the shape stays.
+- Changing the public dock API surface (events, attributes, properties).
+- Visual redesign or new drop zones.
+- Fixing concerns outside layout-tree integrity (e.g., drag-and-drop UX, keyboard nav).
+
+---
+
+## 3. Decisions made during grilling
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where the normalize pass runs | **Single chokepoint** — replace targeted helpers | Two implementations of the same logic drift; structurally eliminates the gap class. The targeted helpers don't add real value once a normalize pass exists. |
+| Intake policy on the layout setter | **Silently sanitize** | Matches the breaking-changes-OK / clean-API memory. A host that round-trips JSON sees normalized output, which is the desired behaviour. |
+| Size redistribution when merging same-direction splits | **Multiplicative** — inner sizes scale by parent slot weight | Preserves visual pixels exactly. A 70/30 split outside × 30/70 inside becomes [0.7, 0.3·0.3, 0.3·0.7] = [0.7, 0.09, 0.21]. Renormalize to sum=1 to absorb float noise. |
+| Empty floating root behaviour | **Auto-remove from `floatingLayouts`** | Matches existing `removePaneFromFloating` (line 3833): the invariant "every floating window has at least one pane" stays. |
+| `activePane` consistency | **Repaired by normalize** | If a stack's `activePane` no longer corresponds to a pane in `panes[]`, normalize sets it to `panes[0]` (or deletes it if empty before drop). Mirrors `removePaneFromStack` (line 2950-2956). |
+| Test scope | **Unit tests on `normalize()` + full Playwright repro suite** | Six e2e sequences from the audit + four direct gap unit tests + state-restoration tests covering the layout setter. |
+| Dev-mode diagnostic | **Throw when a registered pane has no projection slot** | Late-binding signal that the layout tree got into a state the renderer can't display. Never in production builds. |
+
+---
+
+## 4. Algorithm
+
+`normalize(root: DockLayoutNode | null): DockLayoutNode | null` is bottom-up and idempotent:
+
+1. **Stack:** if `panes.length === 0`, return `null` (caller removes from parent). Otherwise repair `activePane` if stale and return the stack unchanged.
+2. **Split:**
+   1. Recursively normalize each child; replace nulls by removing them from `children` (and the corresponding entry from `sizes`).
+   2. **Same-direction merge:** for each child that is itself a split with the same `direction`, replace `children[i]` with the inner children and redistribute sizes multiplicatively. The slot weight `sizes[i]` is multiplied across the inner `sizes`, then the new `sizes` array is renormalized so the sum stays 1 (within float tolerance).
+   3. After merging, if `children.length === 0`, return `null`.
+   4. If `children.length === 1`, return `children[0]` (the wrapping split has nothing to do).
+   5. Otherwise return the split (with renormalized sizes).
+
+Idempotency: a single pass is enough because step 2.1 normalizes children before the parent inspects them. Re-running on the result is a no-op.
+
+### Floating layouts
+
+After normalizing the docked root, iterate `floatingLayouts` in reverse and:
+
+1. Replace each `floating.root` with `normalize(floating.root)`.
+2. If the result is `null`, splice the floating window out of the array.
+
+Reverse iteration keeps indices stable while splicing.
+
+### Chokepoint integration
+
+Public mutation entry points after the change:
+
+- `handleDrop` (line 2760)
+- `handleFloatingStackDrop` (line 2861)
+- `removePaneFromStack` (line 2948) — remove its inline `cleanupEmptyStackInTree` call
+- `cleanupLocation` (line 3751) — collapse into a single `normalizeAll()` call
+- The `layout` attribute/property setter (parseLayout)
+- Floating undock / detach paths
+
+A single private method `normalizeAll(): void` updates `this.rootLayout` and prunes `this.floatingLayouts`, then schedules a render. Each entry point calls `normalizeAll()` once at the end of its mutation, then dispatches `dock-layout-changed`. The bespoke `cleanupEmptyStackInTree` and `cleanupSplitIfNecessary` are deleted.
+
+### Dev-mode projection-slot guard
+
+After `renderLayout`, in development builds only, walk the registered panes and verify each has a corresponding `<slot>` in the shadow DOM. If any pane is missing its slot, throw with a descriptive error including the pane name and current layout JSON. Production builds skip the check entirely (compile-time stripped via `process.env.NODE_ENV !== 'production'` or equivalent — investigate which guard is conventional in this codebase during implementation).
+
+---
+
+## 5. Test plan
+
+### Unit tests — `mint-dock-manager.element.spec.ts`
+
+Each test crafts an input layout tree, calls `normalize()` directly, and asserts the output structure.
+
+- **Gap A** — Length-1 split flattens, surviving child is same-direction split → merged into grandparent with multiplicative size redistribution.
+- **Gap B** — `H_root[stack, H[stack, stack]]` (simulating handleFloatingStackDrop graft) → flattens to `H_root[stack, stack, stack]`.
+- **Gap C** — Wrap creates `V[V[stack, stack], stack]` adjacent in a vertical grandparent → flattens.
+- **Gap D** — Setter receives `H[empty-stack, V[]]` → returns null root after sanitization.
+- **Idempotency** — `normalize(normalize(x)) === normalize(x)` (structural equality) for every gap input.
+- **Size preservation** — Manually crafted 70/30 × 30/70 input → output sizes [0.7, 0.09, 0.21]; sum equals 1 within `Number.EPSILON × children.length` tolerance.
+- **`activePane` repair** — Stack with `activePane: 'gone'` and `panes: ['a']` → output has `activePane: 'a'`.
+- **Floating window auto-remove** — `floatingLayouts: [{ root: stack(empty) }]` after normalize → empty array.
+
+### Playwright e2e — full repro suite
+
+Each test drives `https://bootstrap.mintplayer.com/advanced/dock` (or the demo served from the dev build) and asserts the resulting `dock-layout-changed` payload contains zero same-direction nested splits, zero empty stacks, zero length-{0,1} splits.
+
+| # | Sequence | Targets gap |
+|---|---|---|
+| 1 | Drag panel-4 → right of panel-3 | A |
+| 2 | Drag panel-floating tab → right inside the floating window, then title-bar of the floating onto right of panel-1/panel-2 stack | B + C |
+| 3 | Drag panel-3 → right of panel-1 | A |
+| 4 | Drag panel-2 tab out (auto-float), then drag the new floating's title onto left of panel-3 | C |
+| 5 | Drag panel-floating onto centre of panel-3 (merge), then drag panel-floating tab back out (auto-float), then drag onto right of panel-3 | B + index-shift |
+| 6 | Build multi-stack floating (step 1), then drop title bar onto bottom of panel-3 | B |
+| 7 | State restoration — programmatically set `layout` to a JSON containing `H[empty-stack, V[H[stack(p1)]]]` and assert the rendered tree is `stack(p1)` |  D |
+| 8 | State restoration — set `layout` to a tree with same-direction nested splits and assert it normalizes |  D |
+
+### Acceptance gates
+
+- All unit tests pass.
+- All Playwright e2e tests pass headed and headless.
+- The audit's repro at the top of this PRD produces a flat layout JSON.
+- Setting `layout` with a malformed snapshot produces a normalized rendered tree (no console warnings, no throws).
+- In a development build, deliberately corrupting a layout mutation (e.g., an injected test that bypasses normalize) triggers the projection-slot guard.
+
+---
+
+## 6. Implementation outline
+
+| Step | File | Description |
+|---|---|---|
+| 1 | `mint-dock-manager.element.ts` | Add `private normalize(node: DockLayoutNode \| null): DockLayoutNode \| null` and `private normalizeAll(): void`. |
+| 2 | `mint-dock-manager.element.ts` | Replace each call site of `cleanupEmptyStackInTree` / `cleanupSplitIfNecessary` with `normalizeAll()`; delete the two helpers and `replaceNodeInTree` if it has no remaining callers. |
+| 3 | `mint-dock-manager.element.ts` | Hook `normalizeAll()` into the layout setter. |
+| 4 | `mint-dock-manager.element.ts` | Add the dev-mode projection-slot guard inside (or right after) `renderLayout`. |
+| 5 | `mint-dock-manager.element.spec.ts` | Add unit tests. |
+| 6 | `e2e/` (or wherever Playwright lives — confirm during implementation) | Add 8 Playwright e2e tests. May require scaffolding a test page that exposes `setLayout` to the test runner. |
+| 7 | `apps/ng-bootstrap-demo/src/app/pages/advanced/dock/dock.component.ts` | If needed for state-restoration e2e, expose a hook for tests to set the layout JSON. |
+
+---
+
+## 7. Open questions
+
+None — every decision was resolved during grilling.
+
+---
+
+## 8. Related
+
+- Issue [#317](https://github.com/MintPlayer/mintplayer-ng-bootstrap/issues/317)
+- PR #316 — Dock long-press touch drag (recent dock work)
+- PRD `docs/prd/dock-splitter-tabcontrol-lit-composition.md` — the dock's Lit/WC composition architecture this PRD builds on
+- PRD `docs/prd/dock-touch-long-press-drag.md`
+- PRD `docs/prd/dock-tab-drag-android-touch.md`

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.html
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.html
@@ -2,7 +2,7 @@
   #manager
   class="bs-dock-manager"
   [attr.layout]="layoutString()"
-  [attr.debug-layout-integrity]="debugLayoutIntegrity() ? '' : null"
+  [attr.debug-layout-integrity]="debugLayoutIntegrityAttr()"
   (dock-layout-changed)="onLayoutChanged($event)"
   >
   @for (pane of panes(); track trackByPane($index, pane)) {

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.html
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.html
@@ -2,6 +2,7 @@
   #manager
   class="bs-dock-manager"
   [attr.layout]="layoutString()"
+  [attr.debug-layout-integrity]="debugLayoutIntegrity() ? '' : null"
   (dock-layout-changed)="onLayoutChanged($event)"
   >
   @for (pane of panes(); track trackByPane($index, pane)) {

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.ts
@@ -2,6 +2,7 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  computed,
   contentChildren,
   CUSTOM_ELEMENTS_SCHEMA,
   effect,
@@ -38,6 +39,9 @@ export class BsDockManagerComponent implements AfterViewInit {
    * enable in development to catch layout-logic bugs loudly.
    */
   readonly debugLayoutIntegrity = input<boolean>(false);
+  protected readonly debugLayoutIntegrityAttr = computed(() =>
+    this.debugLayoutIntegrity() ? '' : null,
+  );
 
   get layoutSnapshot(): DockLayoutSnapshot | null {
     if (!this._layout.root && this._layout.floating.length === 0) {

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/components/dock-manager.component.ts
@@ -31,6 +31,13 @@ import { MintDockManagerElement } from '../web-components/mint-dock-manager.elem
 })
 export class BsDockManagerComponent implements AfterViewInit {
   readonly layout = input<DockLayoutNode | DockLayout | null>(null);
+  /**
+   * Dev-mode integrity guard. When `true`, the inner web component throws
+   * after each render if any registered pane has no projection slot in the
+   * shadow DOM — a signal that the layout tree got corrupted. Off by default;
+   * enable in development to catch layout-logic bugs loudly.
+   */
+  readonly debugLayoutIntegrity = input<boolean>(false);
 
   get layoutSnapshot(): DockLayoutSnapshot | null {
     if (!this._layout.root && this._layout.floating.length === 0) {

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
@@ -690,11 +690,13 @@ describe('mint-dock-manager — layout normalization', () => {
         split('horizontal', [0.3, 0.7], stack('b'), stack('c')),
       ),
     ];
-    inputs.forEach((input) => {
-      const once = JSON.parse(JSON.stringify(normalize(JSON.parse(JSON.stringify(input)))));
-      const twice = JSON.parse(JSON.stringify(normalize(JSON.parse(JSON.stringify(once)))));
-      expect(twice).toEqual(once);
-    });
+    inputs
+      .map((input) => {
+        const once = JSON.parse(JSON.stringify(normalize(JSON.parse(JSON.stringify(input)))));
+        const twice = JSON.parse(JSON.stringify(normalize(JSON.parse(JSON.stringify(once)))));
+        return { once, twice };
+      })
+      .map(({ once, twice }) => expect(twice).toEqual(once));
   });
 
   // --- intake (gap D) ------------------------------------------------------

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.spec.ts
@@ -454,3 +454,308 @@ describe('mint-dock-manager — computeHeaderInsertIndex excludes the dragged ta
     expect(idx).toBe(1);
   });
 });
+
+describe('mint-dock-manager — layout normalization', () => {
+  let dock: MintDockManagerElement;
+
+  type AnyNode = {
+    kind: 'split' | 'stack';
+    direction?: 'horizontal' | 'vertical';
+    sizes?: number[];
+    children?: AnyNode[];
+    panes?: string[];
+    activePane?: string;
+  };
+
+  function normalize(node: AnyNode | null): AnyNode | null {
+    return (
+      dock as unknown as { normalizeLayoutNode(n: AnyNode | null): AnyNode | null }
+    ).normalizeLayoutNode(node);
+  }
+
+  function stack(...panes: string[]): AnyNode {
+    return { kind: 'stack', panes, activePane: panes[0] };
+  }
+
+  function split(
+    direction: 'horizontal' | 'vertical',
+    sizes: number[],
+    ...children: AnyNode[]
+  ): AnyNode {
+    return { kind: 'split', direction, sizes, children };
+  }
+
+  beforeEach(() => {
+    dock = document.createElement('mint-dock-manager') as MintDockManagerElement;
+    document.body.appendChild(dock);
+  });
+
+  afterEach(() => {
+    dock.remove();
+  });
+
+  // --- structural cleanup ---------------------------------------------------
+
+  it('returns null for an empty stack', () => {
+    expect(normalize({ kind: 'stack', panes: [] })).toBeNull();
+  });
+
+  it('returns null for a split with zero children', () => {
+    expect(normalize(split('horizontal', [], ))).toBeNull();
+  });
+
+  it('unwraps a split with a single child (gap C origin)', () => {
+    const out = normalize(split('horizontal', [1], stack('a')));
+    expect(out).toMatchObject({ kind: 'stack', panes: ['a'] });
+  });
+
+  it('drops empty stacks from a split before deciding length', () => {
+    // V[empty, stack(b), empty] → unwrapped to stack(b)
+    const out = normalize(
+      split(
+        'vertical',
+        [0.3, 0.4, 0.3],
+        { kind: 'stack', panes: [] },
+        stack('b'),
+        { kind: 'stack', panes: [] },
+      ),
+    );
+    expect(out).toMatchObject({ kind: 'stack', panes: ['b'] });
+  });
+
+  // --- gap-targeted scenarios ----------------------------------------------
+
+  it('gap A — flattens a same-direction child surfaced by a length-1 collapse', () => {
+    // V[ V[stack(a), stack(b)] alone in its slot ] should bubble up to a flat
+    // V split at this level. Modeled as: V[ inner V[a, b] ] which collapses
+    // to V[a, b] then merges into a parent if same direction.
+    // Single-direct-child: collapse, then re-test from above.
+    const out = normalize(
+      split('vertical', [1.0], split('vertical', [0.4, 0.6], stack('a'), stack('b'))),
+    );
+    expect(out).toMatchObject({
+      kind: 'split',
+      direction: 'vertical',
+      children: [
+        { kind: 'stack', panes: ['a'] },
+        { kind: 'stack', panes: ['b'] },
+      ],
+    });
+  });
+
+  it('gap B — flattens H[stack, H[stack, stack]] (multi-stack floating graft)', () => {
+    const out = normalize(
+      split(
+        'horizontal',
+        [0.5, 0.5],
+        stack('p1'),
+        split('horizontal', [0.5, 0.5], stack('p5'), stack('floating')),
+      ),
+    );
+    expect(out).toMatchObject({
+      kind: 'split',
+      direction: 'horizontal',
+      children: [
+        { kind: 'stack', panes: ['p1'] },
+        { kind: 'stack', panes: ['p5'] },
+        { kind: 'stack', panes: ['floating'] },
+      ],
+    });
+    expect((out as AnyNode).children).toHaveLength(3);
+  });
+
+  it('gap C — flattens V[V[stack, stack], stack] (wrap-then-flatten residue)', () => {
+    const out = normalize(
+      split(
+        'vertical',
+        [0.6, 0.4],
+        split('vertical', [0.4, 0.6], stack('a'), stack('b')),
+        stack('c'),
+      ),
+    );
+    expect(out).toMatchObject({
+      kind: 'split',
+      direction: 'vertical',
+      children: [
+        { kind: 'stack', panes: ['a'] },
+        { kind: 'stack', panes: ['b'] },
+        { kind: 'stack', panes: ['c'] },
+      ],
+    });
+  });
+
+  it("user's repro: dragging panel-4 right of panel-3 produces a flat root", () => {
+    // After this PR's normalize step, the artificial intermediate produced by
+    // dockNodeBeside's wrap branch ought to be flattened so the user-observed
+    // redundant H wrapper does not appear.
+    const out = normalize(
+      split(
+        'horizontal',
+        [0.5, 0.5],
+        stack('p1', 'p2'),
+        split('horizontal', [0.5, 0.5], stack('p3'), stack('p4')),
+      ),
+    );
+    expect((out as AnyNode).kind).toBe('split');
+    const flat = (out as AnyNode).children!;
+    expect(flat).toHaveLength(3);
+    expect(flat[0]).toMatchObject({ panes: ['p1', 'p2'] });
+    expect(flat[1]).toMatchObject({ panes: ['p3'] });
+    expect(flat[2]).toMatchObject({ panes: ['p4'] });
+  });
+
+  it('does NOT flatten a child split with the opposite direction', () => {
+    const input = split(
+      'horizontal',
+      [0.5, 0.5],
+      stack('a'),
+      split('vertical', [0.5, 0.5], stack('b'), stack('c')),
+    );
+    const out = normalize(input);
+    expect(out).toMatchObject({
+      kind: 'split',
+      direction: 'horizontal',
+      children: [
+        { kind: 'stack', panes: ['a'] },
+        {
+          kind: 'split',
+          direction: 'vertical',
+          children: [{ panes: ['b'] }, { panes: ['c'] }],
+        },
+      ],
+    });
+  });
+
+  // --- size redistribution --------------------------------------------------
+
+  it('combines sizes multiplicatively when merging same-direction children', () => {
+    const out = normalize(
+      split(
+        'horizontal',
+        [0.7, 0.3],
+        stack('a'),
+        split('horizontal', [0.3, 0.7], stack('b'), stack('c')),
+      ),
+    ) as AnyNode;
+    expect(out.sizes).toHaveLength(3);
+    // Outer slot for 'a' is 0.7 (kept); merged children get 0.3 * [0.3, 0.7] = [0.09, 0.21].
+    // Sum = 0.7 + 0.09 + 0.21 = 1.0 (no renormalization adjustment needed).
+    expect(out.sizes![0]).toBeCloseTo(0.7, 6);
+    expect(out.sizes![1]).toBeCloseTo(0.09, 6);
+    expect(out.sizes![2]).toBeCloseTo(0.21, 6);
+    expect(out.sizes!.reduce((s, v) => s + v, 0)).toBeCloseTo(1, 6);
+  });
+
+  it('renormalizes size sums to 1 after merging', () => {
+    // Provide non-normalized sizes; result must still sum to 1.
+    const out = normalize(
+      split(
+        'horizontal',
+        [3, 1], // non-normalized
+        stack('a'),
+        split('horizontal', [4, 6], stack('b'), stack('c')),
+      ),
+    ) as AnyNode;
+    expect(out.sizes!.reduce((s, v) => s + v, 0)).toBeCloseTo(1, 10);
+  });
+
+  // --- activePane repair ---------------------------------------------------
+
+  it('repairs a stale activePane on a stack', () => {
+    const out = normalize({ kind: 'stack', panes: ['a', 'b'], activePane: 'gone' });
+    expect(out).toMatchObject({ activePane: 'a' });
+  });
+
+  it('keeps a valid activePane untouched', () => {
+    const out = normalize({ kind: 'stack', panes: ['a', 'b'], activePane: 'b' });
+    expect(out).toMatchObject({ activePane: 'b' });
+  });
+
+  // --- idempotency ---------------------------------------------------------
+
+  it('is idempotent (normalize(normalize(x)) deep-equals normalize(x))', () => {
+    const inputs: AnyNode[] = [
+      stack('a'),
+      split('horizontal', [0.5, 0.5], stack('a'), stack('b')),
+      split(
+        'vertical',
+        [0.4, 0.6],
+        split('vertical', [0.3, 0.7], stack('a'), stack('b')),
+        stack('c'),
+      ),
+      split(
+        'horizontal',
+        [0.7, 0.3],
+        stack('a'),
+        split('horizontal', [0.3, 0.7], stack('b'), stack('c')),
+      ),
+    ];
+    inputs.forEach((input) => {
+      const once = JSON.parse(JSON.stringify(normalize(JSON.parse(JSON.stringify(input)))));
+      const twice = JSON.parse(JSON.stringify(normalize(JSON.parse(JSON.stringify(once)))));
+      expect(twice).toEqual(once);
+    });
+  });
+
+  // --- intake (gap D) ------------------------------------------------------
+
+  it('gap D — layout setter sanitizes empty stacks on intake', () => {
+    dock.layout = {
+      root: split('horizontal', [0.5, 0.5], { kind: 'stack', panes: [] }, stack('only')),
+      floating: [],
+      titles: {},
+    } as never;
+    const snap = dock.layout.root as AnyNode;
+    expect(snap).toMatchObject({ kind: 'stack', panes: ['only'] });
+  });
+
+  it('gap D — layout setter flattens nested same-direction splits on intake', () => {
+    dock.layout = {
+      root: split(
+        'vertical',
+        [0.6, 0.4],
+        split('vertical', [0.5, 0.5], stack('a'), stack('b')),
+        stack('c'),
+      ),
+      floating: [],
+      titles: {},
+    } as never;
+    const out = dock.layout.root as AnyNode;
+    expect(out.kind).toBe('split');
+    expect(out.children).toHaveLength(3);
+    expect(out.children![0]).toMatchObject({ panes: ['a'] });
+    expect(out.children![1]).toMatchObject({ panes: ['b'] });
+    expect(out.children![2]).toMatchObject({ panes: ['c'] });
+  });
+
+  // --- floating windows ----------------------------------------------------
+
+  it('drops a floating window whose root collapses to null on intake', () => {
+    dock.layout = {
+      root: stack('docked'),
+      floating: [
+        {
+          bounds: { left: 0, top: 0, width: 200, height: 200 },
+          root: { kind: 'stack', panes: [] },
+        },
+      ],
+      titles: {},
+    } as never;
+    expect(dock.layout.floating).toHaveLength(0);
+  });
+
+  it('repairs a stale activePane on a floating window during normalize', () => {
+    dock.layout = {
+      root: stack('docked'),
+      floating: [
+        {
+          bounds: { left: 0, top: 0, width: 200, height: 200 },
+          root: stack('a', 'b'),
+          activePane: 'ghost',
+        },
+      ],
+      titles: {},
+    } as never;
+    expect(dock.layout.floating[0].activePane).toBe('a');
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
@@ -51,7 +51,7 @@ export class MintDockManagerElement extends LitElement {
   }
 
   static override get observedAttributes(): string[] {
-    return [...(super.observedAttributes ?? []), 'layout'];
+    return [...(super.observedAttributes ?? []), 'layout', 'debug-layout-integrity'];
   }
 
   private static instanceCounter = 0;
@@ -170,6 +170,11 @@ export class MintDockManagerElement extends LitElement {
   private cornerSnapYTargets: number[] = [];
   // Debug: render snap markers while dragging
   private showSnapMarkers = false;
+  // Debug: assert every pane has a projection slot in shadow DOM after each
+  // render. Off by default so production hosts pay no overhead; demo enables
+  // it via the `debug-layout-integrity` attribute to catch layout-tree bugs
+  // loudly during development.
+  debugLayoutIntegrity = false;
 
   private renderSnapMarkersForCorner(): void {
     if (!this.showSnapMarkers) return;
@@ -350,6 +355,8 @@ export class MintDockManagerElement extends LitElement {
       if (!this.showSnapMarkers) {
         this.clearSnapMarkers();
       }
+    } else if (name === 'debug-layout-integrity') {
+      this.debugLayoutIntegrity = !(newValue === null || newValue === 'false' || newValue === '0');
     }
   }
 
@@ -394,6 +401,9 @@ export class MintDockManagerElement extends LitElement {
     this.rootLayout = this.cloneLayoutNode(snapshot.root);
     this.floatingLayouts = this.cloneFloatingArray(snapshot.floating);
     this.titles = snapshot.titles ? { ...snapshot.titles } : {};
+    // Sanitize whatever the host fed us: empty stacks, 0/1-child splits, and
+    // nested same-direction splits get pruned/flattened before we render.
+    this.normalizeAllLayouts();
     this.renderLayout();
   }
 
@@ -502,6 +512,8 @@ export class MintDockManagerElement extends LitElement {
     // wired up in firstUpdated (rootResizeObserver, dockedMutationObserver,
     // and delegated 'resizing' / 'resize-end' events). The MutationObserver
     // on dockedEl fires when the renderNode subtree above is appended.
+
+    this.verifyProjectionSlots();
   }
 
   private renderNode(
@@ -2772,16 +2784,14 @@ export class MintDockManagerElement extends LitElement {
       if (!source) {
         return;
       }
-      const stackEmptied = this.removePaneFromLocation(source, pane, true);
+      this.removePaneFromLocation(source, pane, true);
       const newRoot: DockStackNode = {
         kind: 'stack',
         panes: [pane],
         activePane: pane,
       };
       this.rootLayout = newRoot;
-      if (stackEmptied) {
-        this.cleanupLocation(source);
-      }
+      this.normalizeAllLayouts();
       this.renderLayout();
       this.dispatchLayoutChanged();
       if (this.dragState) {
@@ -2799,6 +2809,7 @@ export class MintDockManagerElement extends LitElement {
         return;
       }
       this.reorderPaneInLocation(source, pane);
+      this.normalizeAllLayouts();
       this.renderLayout();
       this.dispatchLayoutChanged();
       if (this.dragState) {
@@ -2807,14 +2818,12 @@ export class MintDockManagerElement extends LitElement {
       return;
     }
 
-    const stackEmptied = this.removePaneFromLocation(source, pane, true);
+    this.removePaneFromLocation(source, pane, true);
 
     if (zone === 'center') {
       this.addPaneToLocation(target, pane);
       this.setActivePaneForLocation(target, pane);
-      if (stackEmptied) {
-        this.cleanupLocation(source);
-      }
+      this.normalizeAllLayouts();
       this.renderLayout();
       this.dispatchLayoutChanged();
       if (this.dragState) {
@@ -2834,9 +2843,7 @@ export class MintDockManagerElement extends LitElement {
     } else {
       const floating = this.floatingLayouts[target.index];
       if (!floating) {
-        if (stackEmptied) {
-          this.cleanupLocation(source);
-        }
+        this.normalizeAllLayouts();
         this.renderLayout();
         this.dispatchLayoutChanged();
         return;
@@ -2846,10 +2853,7 @@ export class MintDockManagerElement extends LitElement {
       floating.activePane = pane;
     }
 
-    if (stackEmptied) {
-      this.cleanupLocation(source);
-    }
-
+    this.normalizeAllLayouts();
     this.renderLayout();
     this.dispatchLayoutChanged();
     if (this.dragState) {
@@ -2870,6 +2874,7 @@ export class MintDockManagerElement extends LitElement {
     if (!target && targetPath.type === 'docked' && !this.rootLayout) {
       this.rootLayout = this.cloneLayoutNode(source.root);
       this.removeFloatingAt(sourceIndex);
+      this.normalizeAllLayouts();
       this.renderLayout();
       this.dispatchLayoutChanged();
       return true;
@@ -2902,6 +2907,7 @@ export class MintDockManagerElement extends LitElement {
       }
 
       this.removeFloatingAt(sourceIndex);
+      this.normalizeAllLayouts();
       this.renderLayout();
       this.dispatchLayoutChanged();
       return true;
@@ -2916,6 +2922,7 @@ export class MintDockManagerElement extends LitElement {
       floating.root = this.dockNodeBeside(floating.root, target.node, source.root, zone);
       floating.activePane = source.activePane ?? this.findFirstPaneName(source.root) ?? undefined;
       this.removeFloatingAt(sourceIndex);
+      this.normalizeAllLayouts();
       this.renderLayout();
       this.dispatchLayoutChanged();
       return true;
@@ -2923,6 +2930,7 @@ export class MintDockManagerElement extends LitElement {
 
     this.rootLayout = this.dockNodeBeside(this.rootLayout, target.node, source.root, zone);
     this.removeFloatingAt(sourceIndex);
+    this.normalizeAllLayouts();
     this.renderLayout();
     this.dispatchLayoutChanged();
     return true;
@@ -2963,7 +2971,7 @@ export class MintDockManagerElement extends LitElement {
       return true;
     }
 
-    this.rootLayout = this.cleanupEmptyStackInTree(this.rootLayout, stack);
+    this.normalizeAllLayouts();
     return true;
   }
 
@@ -3408,63 +3416,6 @@ export class MintDockManagerElement extends LitElement {
     return root;
   }
 
-  private cleanupEmptyStackInTree(
-    root: DockLayoutNode | null,
-    stack: DockStackNode,
-  ): DockLayoutNode | null {
-    if (!root || stack.panes.length > 0) {
-      return root;
-    }
-
-    const parentInfo = this.findParentSplit(root, stack);
-    if (!parentInfo) {
-      return root === stack ? null : root;
-    }
-
-    const parent = parentInfo.parent;
-    const index = parent.children.indexOf(stack);
-    if (index === -1) {
-      return root;
-    }
-
-    parent.children.splice(index, 1);
-    if (Array.isArray(parent.sizes)) {
-      parent.sizes.splice(index, 1);
-    }
-    this.normalizeSplitNode(parent);
-
-    return this.cleanupSplitIfNecessary(root, parent);
-  }
-
-  private cleanupSplitIfNecessary(
-    root: DockLayoutNode | null,
-    split: DockSplitNode,
-  ): DockLayoutNode | null {
-    if (split.children.length === 1) {
-      return this.replaceNodeInTree(root, split, split.children[0]);
-    }
-
-    if (split.children.length === 0) {
-      const parentInfo = this.findParentSplit(root, split);
-      if (!parentInfo) {
-        return null;
-      }
-
-      const parent = parentInfo.parent;
-      const index = parent.children.indexOf(split);
-      if (index !== -1) {
-        parent.children.splice(index, 1);
-        if (Array.isArray(parent.sizes)) {
-          parent.sizes.splice(index, 1);
-        }
-        this.normalizeSplitNode(parent);
-        return this.cleanupSplitIfNecessary(root, parent);
-      }
-    }
-
-    return root;
-  }
-
   private dockNodeBeside(
     root: DockLayoutNode | null,
     targetNode: DockStackNode,
@@ -3748,22 +3699,6 @@ export class MintDockManagerElement extends LitElement {
     }
   }
 
-  private cleanupLocation(location: ResolvedLocation): void {
-    if (location.context === 'docked') {
-      this.rootLayout = this.cleanupEmptyStackInTree(this.rootLayout, location.node);
-    } else {
-      const floating = this.floatingLayouts[location.index];
-      if (!floating) {
-        return;
-      }
-
-      floating.root = this.cleanupEmptyStackInTree(floating.root, location.node);
-      if (!floating.root) {
-        this.removeFloatingAt(location.index);
-      }
-    }
-  }
-
   private reorderPaneInLocation(location: ResolvedLocation, pane: string): void {
     const panes = location.node.panes;
     const index = panes.indexOf(pane);
@@ -3830,11 +3765,7 @@ export class MintDockManagerElement extends LitElement {
       return true;
     }
 
-    floating.root = this.cleanupEmptyStackInTree(floating.root, node);
-    if (!floating.root) {
-      this.removeFloatingAt(index);
-    }
-
+    this.normalizeAllLayouts();
     return true;
   }
 
@@ -3858,6 +3789,123 @@ export class MintDockManagerElement extends LitElement {
 
   private normalizeSplitNode(split: DockSplitNode): void {
     split.sizes = this.normalizeSizesArray(split.sizes, split.children.length);
+  }
+
+  /**
+   * Bottom-up layout sanitizer. Returns a normalized version of `node` where:
+   * - Empty stacks (panes.length === 0) are dropped (returned as null).
+   * - A stack's `activePane` is repaired if it no longer references one of `panes`.
+   * - Splits whose direction matches a child split are flattened, with sizes
+   *   combined multiplicatively so the resulting on-screen pixel layout is
+   *   identical to the pre-merge one.
+   * - Splits with 0 children become null. Splits with 1 child are unwrapped.
+   *
+   * Idempotent: passing the result back through this method yields the same
+   * structure. Mutates the input tree in place but only returns nodes that
+   * remain part of the layout.
+   */
+  private normalizeLayoutNode(node: DockLayoutNode | null): DockLayoutNode | null {
+    if (!node) return null;
+
+    if (node.kind === 'stack') {
+      if (node.panes.length === 0) return null;
+      if (!node.activePane || !node.panes.includes(node.activePane)) {
+        node.activePane = node.panes[0];
+      }
+      return node;
+    }
+
+    const slotSizes = this.normalizeSizesArray(node.sizes, node.children.length);
+    const survivors: DockLayoutNode[] = [];
+    const survivorSizes: number[] = [];
+
+    for (let i = 0; i < node.children.length; i += 1) {
+      const child = this.normalizeLayoutNode(node.children[i]);
+      if (!child) continue;
+
+      if (child.kind === 'split' && child.direction === node.direction) {
+        // Same-direction merge: splice the inner children up into this split,
+        // with each inner size scaled by the slot the inner split used to
+        // occupy. A 0.4 slot containing [0.3, 0.7] becomes [0.12, 0.28].
+        const innerSizes = this.normalizeSizesArray(child.sizes, child.children.length);
+        child.children.forEach((grandchild, idx) => {
+          survivors.push(grandchild);
+          survivorSizes.push(slotSizes[i] * innerSizes[idx]);
+        });
+        continue;
+      }
+
+      survivors.push(child);
+      survivorSizes.push(slotSizes[i]);
+    }
+
+    if (survivors.length === 0) return null;
+    if (survivors.length === 1) return survivors[0];
+
+    node.children = survivors;
+    node.sizes = this.normalizeSizesArray(survivorSizes, survivors.length);
+    return node;
+  }
+
+  /**
+   * Apply `normalizeLayoutNode` to `rootLayout` and every floating window's
+   * root, drop floating windows whose root collapses to null, and repair
+   * stale `activePane` references on each floating window. Run this at the
+   * end of every public mutation entry point (drop handlers, layout setter,
+   * pane removal) so the tree the renderer sees is always in canonical form.
+   */
+  private normalizeAllLayouts(): void {
+    this.rootLayout = this.normalizeLayoutNode(this.rootLayout);
+
+    for (let i = this.floatingLayouts.length - 1; i >= 0; i -= 1) {
+      const floating = this.floatingLayouts[i];
+      floating.root = this.normalizeLayoutNode(floating.root);
+      if (!floating.root) {
+        this.floatingLayouts.splice(i, 1);
+        continue;
+      }
+
+      const panes = this.collectPaneNames(floating.root);
+      if (!floating.activePane || !panes.includes(floating.activePane)) {
+        const fallback = this.findFirstPaneName(floating.root);
+        if (fallback) {
+          floating.activePane = fallback;
+        } else {
+          delete floating.activePane;
+        }
+      }
+    }
+  }
+
+  /**
+   * Dev-mode integrity guard: walks every pane referenced by the current
+   * layout and asserts that the rendered shadow DOM contains a matching
+   * `<slot name="${pane}">`. A missing slot means the layout tree got into
+   * a state the renderer can't display — typically a missed normalize() call
+   * or a render bug. Opt in via the `debug-layout-integrity` attribute or
+   * the `debugLayoutIntegrity` property; off by default.
+   */
+  private verifyProjectionSlots(): void {
+    if (!this.debugLayoutIntegrity) return;
+    const root = this.shadowRoot;
+    if (!root) return;
+
+    const panes = new Set<string>();
+    this.collectPaneNames(this.rootLayout).forEach((p) => panes.add(p));
+    this.floatingLayouts.forEach((f) =>
+      this.collectPaneNames(f.root).forEach((p) => panes.add(p)),
+    );
+
+    panes.forEach((pane) => {
+      const slot = root.querySelector(`slot[name="${CSS.escape(pane)}"]`);
+      if (!slot) {
+        throw new Error(
+          `mint-dock-manager: pane "${pane}" has no projection slot in the shadow DOM. ` +
+            `The layout tree got into a state the renderer can't display — likely a ` +
+            `missing normalize() call or a render bug.`,
+        );
+      }
+    });
   }
 
   private dispatchLayoutChanged(): void {

--- a/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
+++ b/libs/mintplayer-ng-bootstrap/dock/src/lib/web-components/mint-dock-manager.element.ts
@@ -3816,34 +3816,32 @@ export class MintDockManagerElement extends LitElement {
     }
 
     const slotSizes = this.normalizeSizesArray(node.sizes, node.children.length);
-    const survivors: DockLayoutNode[] = [];
-    const survivorSizes: number[] = [];
 
-    for (let i = 0; i < node.children.length; i += 1) {
-      const child = this.normalizeLayoutNode(node.children[i]);
-      if (!child) continue;
-
-      if (child.kind === 'split' && child.direction === node.direction) {
-        // Same-direction merge: splice the inner children up into this split,
-        // with each inner size scaled by the slot the inner split used to
-        // occupy. A 0.4 slot containing [0.3, 0.7] becomes [0.12, 0.28].
-        const innerSizes = this.normalizeSizesArray(child.sizes, child.children.length);
-        child.children.forEach((grandchild, idx) => {
-          survivors.push(grandchild);
-          survivorSizes.push(slotSizes[i] * innerSizes[idx]);
-        });
-        continue;
-      }
-
-      survivors.push(child);
-      survivorSizes.push(slotSizes[i]);
-    }
+    // Pair each child with its slot weight, drop nulls, then expand any
+    // same-direction child split into its grandchildren with sizes scaled
+    // multiplicatively. A 0.4 slot containing [0.3, 0.7] becomes [0.12, 0.28].
+    const survivors = node.children
+      .map((child, i) => ({ child: this.normalizeLayoutNode(child), slot: slotSizes[i] }))
+      .filter((p): p is { child: DockLayoutNode; slot: number } => p.child !== null)
+      .flatMap(({ child, slot }) => {
+        if (child.kind === 'split' && child.direction === node.direction) {
+          const innerSizes = this.normalizeSizesArray(child.sizes, child.children.length);
+          return child.children.map((grandchild, idx) => ({
+            child: grandchild,
+            slot: slot * innerSizes[idx],
+          }));
+        }
+        return [{ child, slot }];
+      });
 
     if (survivors.length === 0) return null;
-    if (survivors.length === 1) return survivors[0];
+    if (survivors.length === 1) return survivors[0].child;
 
-    node.children = survivors;
-    node.sizes = this.normalizeSizesArray(survivorSizes, survivors.length);
+    node.children = survivors.map((s) => s.child);
+    node.sizes = this.normalizeSizesArray(
+      survivors.map((s) => s.slot),
+      survivors.length,
+    );
     return node;
   }
 
@@ -3857,24 +3855,23 @@ export class MintDockManagerElement extends LitElement {
   private normalizeAllLayouts(): void {
     this.rootLayout = this.normalizeLayoutNode(this.rootLayout);
 
-    for (let i = this.floatingLayouts.length - 1; i >= 0; i -= 1) {
-      const floating = this.floatingLayouts[i];
-      floating.root = this.normalizeLayoutNode(floating.root);
-      if (!floating.root) {
-        this.floatingLayouts.splice(i, 1);
-        continue;
-      }
+    this.floatingLayouts = this.floatingLayouts
+      .map((floating) => {
+        floating.root = this.normalizeLayoutNode(floating.root);
+        if (!floating.root) return null;
 
-      const panes = this.collectPaneNames(floating.root);
-      if (!floating.activePane || !panes.includes(floating.activePane)) {
-        const fallback = this.findFirstPaneName(floating.root);
-        if (fallback) {
-          floating.activePane = fallback;
-        } else {
-          delete floating.activePane;
+        const panes = this.collectPaneNames(floating.root);
+        if (!floating.activePane || !panes.includes(floating.activePane)) {
+          const fallback = this.findFirstPaneName(floating.root);
+          if (fallback) {
+            floating.activePane = fallback;
+          } else {
+            delete floating.activePane;
+          }
         }
-      }
-    }
+        return floating;
+      })
+      .filter((f): f is DockFloatingStackLayout => f !== null);
   }
 
   /**
@@ -3890,22 +3887,29 @@ export class MintDockManagerElement extends LitElement {
     const root = this.shadowRoot;
     if (!root) return;
 
-    const panes = new Set<string>();
-    this.collectPaneNames(this.rootLayout).forEach((p) => panes.add(p));
-    this.floatingLayouts.forEach((f) =>
-      this.collectPaneNames(f.root).forEach((p) => panes.add(p)),
+    // Collect every slot the renderer produced. Walking the rendered DOM
+    // (instead of building a CSS selector per pane) sidesteps environment
+    // differences — e.g. jsdom does not expose `CSS.escape`, which would
+    // crash the guard during unit tests before the assertion runs.
+    const slotNames = new Set(
+      Array.from(root.querySelectorAll('slot'))
+        .map((slot) => slot.getAttribute('name'))
+        .filter((name): name is string => !!name),
     );
 
-    panes.forEach((pane) => {
-      const slot = root.querySelector(`slot[name="${CSS.escape(pane)}"]`);
-      if (!slot) {
-        throw new Error(
-          `mint-dock-manager: pane "${pane}" has no projection slot in the shadow DOM. ` +
-            `The layout tree got into a state the renderer can't display — likely a ` +
-            `missing normalize() call or a render bug.`,
-        );
-      }
-    });
+    const panes = [
+      ...this.collectPaneNames(this.rootLayout),
+      ...this.floatingLayouts.flatMap((f) => this.collectPaneNames(f.root)),
+    ];
+
+    const missing = panes.find((pane) => !slotNames.has(pane));
+    if (missing) {
+      throw new Error(
+        `mint-dock-manager: pane "${missing}" has no projection slot in the shadow DOM. ` +
+          `The layout tree got into a state the renderer can't display — likely a ` +
+          `missing normalize() call or a render bug.`,
+      );
+    }
   }
 
   private dispatchLayoutChanged(): void {

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.25.0",
+  "version": "21.26.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
- Closes #317.

## Summary

The dock-manager pruned empty stacks and length-{0,1} splits but left **redundant** zones in the layout JSON (nested same-direction splits, un-sanitized intake). This PR replaces the bespoke `cleanupEmptyStackInTree` / `cleanupSplitIfNecessary` helpers with a single recursive `normalizeLayoutNode` pass that runs at every public mutation chokepoint — closing four structural gaps in one go.

### Closed gaps

- **A** — `cleanupSplitIfNecessary` collapsing a length-1 split now merges the surviving same-direction child into the grandparent instead of leaving a redundant wrapper.
- **B** — `handleFloatingStackDrop` no longer leaves nested same-direction splits when grafting a multi-stack `source.root` onto a same-direction parent.
- **C** — `dockNodeBeside`'s wrap branch can no longer leave a redundant wrapper adjacent to a same-direction grandparent.
- **D** — the layout setter sanitizes empty stacks, 0/1-child splits, and nested same-direction splits on intake. Snapshots saved by older buggy versions render normalized.

### Repro

At `/advanced/dock`, drag panel-4 to the right of panel-3.

- **Before:** `H_root[ stack(p1,p2), H_inner[stack(p3), stack(p4)] ]` — redundant horizontal wrapper.
- **After:** `H_root[ stack(p1,p2), stack(p3), stack(p4) ]` — flat.

The user's diagram from the PRD:

```
+---+---+-------+         +---+---+---+
| A | B |       |         | A | B |   |
+---+---+   D   |   pull  |   |   | D |
|   C   |       |    C    |   |   |   |
+-------+-------+   --->  +---+---+---+
```

Pull out C; this PR merges the two vertical containers instead of leaving a redundant inner V wrapper.

### Design decisions

- **Single chokepoint**: `normalizeAllLayouts()` is called at the end of each mutation entry point (drop handlers, layout setter, pane removal). The targeted helpers are deleted — no two implementations to drift.
- **Multiplicative size redistribution**: merging same-direction splits scales inner sizes by the parent slot weight, so visual pixels are preserved across cleanup. A 70/30 outer × 30/70 inner becomes [0.7, 0.09, 0.21].
- **Silent intake sanitization**: malformed `layout` setter input renders normalized; no warnings, no throws. Hosts round-tripping the dispatched snapshot get stable output.
- **`activePane` repair**: stale references after normalization fall back to `panes[0]`.
- **Auto-remove empty floating windows**: invariant kept — every floating window has at least one pane.

### Dev-mode integrity guard

New opt-in attribute `debug-layout-integrity` on `<mint-dock-manager>` (and `[debugLayoutIntegrity]` input on `<bs-dock-manager>`). When on, the WC throws after each render if any pane referenced by the layout has no projection slot in the shadow DOM — a signal that the layout tree got into a state the renderer can't display.

Enabled in the demo behind `isDevMode()` so production builds skip the per-render walk.

## Test plan

- [x] 18 new unit tests on `normalizeLayoutNode` cover all four gaps + idempotency + size preservation + activePane repair + empty floating cleanup.
- [x] All 377 workspace tests pass (154 files).
- [x] User's exact repro verified live via Playwright MCP — produces a flat root.
- [x] Pathological intake (nested H-in-H-in-H + empty stack + empty floating + stale activePane) verified live — all sanitized.
- [x] Dev guard does not false-fire on valid layouts.
- [x] Sizes sum to 1.0 within float tolerance after merge.

## Files

- `libs/.../mint-dock-manager.element.ts` — `normalizeLayoutNode` + `normalizeAllLayouts` + `verifyProjectionSlots`; cleanup helpers deleted; entry points re-routed.
- `libs/.../mint-dock-manager.element.spec.ts` — 18 new tests.
- `libs/.../dock-manager.component.{ts,html}` — `debugLayoutIntegrity` input, `debugLayoutIntegrityAttr` computed.
- `apps/.../dock.component.{ts,html}` — wire `isDevMode()` to the demo's debug attr.
- `docs/prd/dock-layout-normalize.md` — PRD with diagrams + algorithm + test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)