### PR TITLE
feat(color-picker): HSV wheel redesign — vibrant, full sRGB

### DIFF
--- a/libs/mintplayer-ng-bootstrap/color-picker/PRD-color-wheel-redesign.md
+++ b/libs/mintplayer-ng-bootstrap/color-picker/PRD-color-wheel-redesign.md
@@ -1,0 +1,185 @@
+# PRD — Color Picker Wheel Redesign
+
+**Component:** `@mintplayer/ng-bootstrap/color-picker`
+**Status:** Proposal
+**Author:** Pieterjan
+**Date:** 2026-05-08
+
+---
+
+## 1. Problem
+
+The current color wheel lets the user pick any color in sRGB but **looks pale**. The center of the wheel is mid-gray (`#808080`); only the rim is vibrant. Side-by-side with [iro.js](https://iro.js.org), the difference is immediate: iro.js's wheel has a white center and a saturated rim — it reads as "candy", ours reads as "dingy".
+
+This is not a polish bug. It's structural:
+
+- The wheel uses **HSL** with **angle = Hue, radius = Saturation (0→100)**, and luminosity on a separate slider.
+- The canvas is rendered at a fixed `hsl(h, s%, 50%)` for every pixel (`color-wheel.component.ts:120-121`). HSL geometry forces the center (S=0, L=50) to be pure 50%-gray. There is no parameter we can tweak to make HSL with S-as-radius look vibrant — the gray center is a property of the model.
+- An earlier version put **lightness (50→100) on the radius** with saturation on a slider. The wheel was vibrant (white center → pure rim), but lightness 0→50 (every dark color) was unreachable. Half the spectrum dropped out. That regression is why we're here.
+
+**We need a wheel that is vibrant *and* covers the entire sRGB gamut.**
+
+## 2. Goals
+
+- **G1.** The wheel reads as vibrant at typical usage (pure rim, white center) — at parity with iro.js for first-impression feel.
+- **G2.** Every color in sRGB is reachable through the wheel + slider(s).
+- **G3.** Public hex `ControlValueAccessor` contract on `<bs-color-picker [(ngModel)]>` is preserved. Forms-driven consumers do not need to change a line.
+- **G4.** The redesign ships in a single release. No v1/v2 phased rollout.
+- **G5.** The reverse-lookup (canvas pixel → color) is replaced with closed-form math, so future restyling cannot silently break picking.
+
+## 3. Non-goals
+
+- OKLCh, HSLuv, Display-P3 support. (Mentioned for completeness in §5; out of scope for this release.)
+- Eyedropper, palette presets, recent-colors strip.
+- Replacing the wheel shape with a Photoshop-style square. The wheel is part of the component's identity in this library.
+
+## 4. Current state (background)
+
+| Concern | Today |
+|---|---|
+| Color model | HSL |
+| 2D surface | Wheel: angle = H, radius = S (0→100) |
+| Wheel render | Fixed at L=50%, gray-to-pure radial gradient per integer hue |
+| Slider 1 | Luminosity (0→100), strip rendered with current H/S |
+| Slider 2 | Alpha (0→1), strip rendered with current H/S/L |
+| Public API (wheel) | `hs: HS = {hue, saturation}` model, `luminosity: number` model, `hsChange` output |
+| Public API (picker) | `size`, `disabled`, `allowAlpha`, `alpha` model |
+| Forms contract | Hex string via `BsColorPickerValueAccessor` (alpha kept separate) |
+| Pick math | `position2color()` reverse-looks-up via `getImageData()` — assumes wheel is rendered at L=50% |
+
+### Defects observed in passing (to fix during the redesign, not after)
+
+- **D1.** `rgb2Hsl` is duplicated in `color-wheel.component.ts:254` and `color-picker-value-accessor.directive.ts:89`. One source of truth is needed.
+- **D2.** `isInsideCircle` returns `angle` in radians but is `% 360`'d as if degrees (lines 206, 225). Works by accident.
+- **D3.** `onPointerDown` calls `ev.preventDefault()` for touch events (`color-wheel.component.ts:148`). Per project convention this suppresses the synthesized click on touch — should be replaced with `touch-action: none` on the canvas.
+- **D4.** All `.spec.ts` files are scaffolds — no math, no integration, no UX assertions.
+- **D5.** `diameterRatio` (annular-wheel knob) exists on the wheel API but is not exposed via `<bs-color-picker>` and is not used by the demo. Dead weight — drop it.
+- **D6.** The canvas pixel buffer is sized 1:1 with the CSS box (`[width]="width()"` etc.). No `devicePixelRatio` scaling. On high-DPI screens the wheel is upscaled by the browser and looks fuzzy. Easy fix during the redesign: render the canvas at `size · devicePixelRatio` and CSS-scale it down.
+
+### Size flow today (informational)
+
+- `<bs-color-picker [size]="200">` → picker template plumbs `size()` to both `[width]` and `[height]` of the wheel and to `[style.width.px]` on each strip. So via the picker, the wheel is always square.
+- `<bs-color-wheel>` accepts independent `width` / `height` model signals (defaults 150) and centers the inscribed disc via computed `shiftX` / `shiftY`. Disc geometry derives from `squareSize = min(width, height)` (`color-wheel.component.ts:38-45`).
+- No caller currently uses non-square dimensions, but the capability exists. Keep it — it costs nothing and supports `<bs-color-wheel>` standalone.
+
+## 5. Design space considered
+
+### Option A — HSV wheel (iro.js parity) ★ recommended
+
+| | |
+|---|---|
+| Model | HSV |
+| Surface | angle = H, radius = S (0→100) |
+| Slider | V (0→100), plus alpha |
+| Wheel render | Drawn **once** at V=100. Conic hue gradient × radial white→transparent (saturation). The V slider darkens by overlaying a black layer with `opacity = 1 − V/100` — the wheel itself does not re-render |
+| Center / rim | White / pure spectral colors |
+| Gamut | Full sRGB |
+| Feel | Vibrant at any V > ~30 |
+
+This is exactly the iro.js recipe (`Wheel.tsx`, master). It's also what macOS `NSColorPanel`, Adobe Color/Kuler outer ring, and most modern circular pickers use.
+
+**Pros**
+
+- Solves the "pale center" cleanly and permanently.
+- Closed-form pick math — no `getImageData` reverse-lookup needed (D5 inherently fixed).
+- The wheel image is static; only the overlay opacity changes when V moves. Cheaper than the current per-frame redraw.
+
+**Cons**
+
+- HSV ≠ HSL. The internal model and the strip semantics change. Forms consumers (hex) are unaffected; direct `<bs-color-wheel>` consumers break.
+
+### Option B — HSL, decoupled wheel rendering
+
+Keep HSL on the API. Render the wheel always at L=50 (current behavior), but add a radial white overlay when L > 50 and a radial black overlay when L < 50, opacity `|L−50|/50`.
+
+**Cons:** doesn't fix the cosmetic complaint at L=50, which is the typical first-paint state. The gray center is still gray when the user opens the picker. **Rejected.**
+
+### Option C — Hue ring + inner SV square (Photoshop / Adobe Color)
+
+Outer thin annulus = H, inner inscribed square = S × V. No color sliders.
+
+**Cons:** Different component shape — breaks visual layout for every consumer; ng-bootstrap-demo and any embedding app have to re-style. Largest migration. The wheel-with-slider shape is part of this library's identity. **Rejected for this release; revisit if we ever build a "compact" variant.**
+
+### Option D — HSL split-hemisphere wheel
+
+`hsl(θ, S_current, 50 ± (r/R)·50)` — top hemisphere lightens to white, bottom darkens to black, mid-circle is the pure-color band. S on a slider.
+
+**Cons:** Novel UX users have to learn ("up = light, down = dark"). Solves the gamut problem on the wheel itself but trades familiarity for it. **Considered, rejected** in favor of A's industry-standard mental model.
+
+### Option E — OKLCh
+
+Perceptually uniform lightness; would arguably solve the "pale" feel at a deeper level. But OKLCh→sRGB gamut isn't a cylinder — clipping or gamut-mapping renders dead zones at the rim. **Out of scope; revisit.**
+
+## 6. Decision
+
+**Adopt Option A — HSV wheel with iro.js-style three-layer rendering.**
+
+Rationale: only design that simultaneously hits G1 (vibrant), G2 (full gamut), and keeps the component's external shape (disc + sliders) so consuming apps don't restyle. The hex `ControlValueAccessor` contract (G3) is preserved because hex is a model-agnostic string format.
+
+## 7. Public API changes
+
+Per the project convention that BC is not a default constraint, these are the cleanest signatures — not the ones that minimize churn.
+
+### `BsColorPickerComponent` (the consumer-facing one)
+
+| Member | Before | After |
+|---|---|---|
+| `[(ngModel)]` (hex) | `string` | `string` — **unchanged** |
+| `alpha` model | `number` | `number` — **unchanged** |
+| `size`, `disabled`, `allowAlpha` | | unchanged |
+
+→ **No breaking change for the 95% case (`<bs-color-picker [(ngModel)]>`).**
+
+### `BsColorWheelComponent` (advanced / direct use)
+
+| Member | Before | After |
+|---|---|---|
+| `hs: HS = {hue, saturation}` | HSL saturation | **HSV saturation** (semantics change; same shape) |
+| `luminosity: number` | HSL luminosity 0–1 | **renamed** to `brightness: number` 0–1 (HSV value) |
+| `hsChange` output | HSL `HS` | HSV `HS` |
+| `diameterRatio` | annular hole ratio | **removed** (dead — see D5) |
+| `width` / `height` | independent dimensions | **unchanged** — keep so `<bs-color-wheel>` standalone supports non-square boxes |
+
+→ **Clean break, no shims, no soft migration window.** Callers feeding HSL must convert at the boundary.
+
+### Strips
+
+- `BsLuminosityStripComponent` is misnamed today (HSL's third channel is *lightness*, not luminosity). Rename to `BsBrightnessStripComponent` (the HSV name — Adobe / Photoshop convention) **using `git mv`** so file history is preserved across the rename. The HTML/SCSS files rename in lockstep. Selector flips `bs-luminosity-strip` → `bs-brightness-strip`.
+- Gradient runs from black (V=0) to pure-hue-at-current-saturation (V=100). The current 0→50→100 (black → mid → white) gradient goes away — that mapping was HSL-specific.
+- `BsAlphaStripComponent` keeps its shape; reads V instead of L.
+
+### Interfaces
+
+- `HS` shape unchanged but its semantics flip to HSV. Add JSDoc.
+- New `HsvColor { hue, saturation, value }` and existing `HslColor` both stay; conversions live in **a new `color-math.ts`** that subsumes the duplicated `rgb2Hsl` / `hsl2Rgb` from D1.
+
+## 8. Implementation plan
+
+Single PR, single release. (Per project convention: multi-part features ship together.)
+
+1. **`color-math.ts`** — single source of truth for `rgb⇄hsl`, `rgb⇄hsv`, `hex⇄rgb`. Delete the duplicates in `color-wheel.component.ts:254` and `color-picker-value-accessor.directive.ts:89`.
+2. **Rename `luminosity-strip` → `brightness-strip`** via `git mv` (preserves history). Rename selector, class, inputs/outputs, demo bindings.
+3. **Rewrite `color-wheel.component.ts` rendering**:
+   - Draw the static base wheel once: per-hue radial gradient `hsv(h, 0→100, 100)` (white at center, pure at rim). The CSS-friendly equivalent is conic hue + radial-gradient overlay; doing it on canvas keeps the marker hit-testing math simple.
+   - Add a black overlay layer (a second canvas or a positioned `<div>`) with opacity bound to `1 − brightness()`.
+   - Replace `position2color` with closed-form polar math: `S = clamp(r/R, 0, 1)`, `H = atan2(...)·180/π`. **No more `getImageData`.** Fixes D2 and the hidden coupling.
+   - Render the canvas at `size · devicePixelRatio` and CSS-scale down (D6).
+4. **Strips**: repaint the brightness strip (black→pure-hue gradient at current saturation); update the alpha strip to read V instead of L.
+5. **Value accessor**: read hex → RGB → HSV → write to `hs` + `brightness`; emit RGB → hex on change. The hex round-trip continues to work; alpha stays separate.
+6. **Pointer code**: drop the touch `preventDefault`; add `touch-action: none` to the canvas (D3).
+7. **Demo**: update binding names, add a `brightness` readout next to the existing `luminosity` one.
+8. **Tests** (D4): `color-math.ts` round-trips (hex → rgb → hsv → rgb → hex) are a high-leverage first test bed. Add wheel hit-test math tests using fake `getBoundingClientRect()`.
+
+## 9. Validation
+
+- **Visual parity:** screenshot the redesigned picker at V=100, V=50, V=0 and compare against iro.js reference at the same values. The center should be white at V=100, ~50% gray at V=50, black at V=0.
+- **Gamut coverage:** programmatic test — for a sample of 1000 random sRGB hex values, round-trip hex → HSV(set on component) → emitted hex; assert per-channel diff ≤ 1.
+- **Forms contract preserved:** existing demo with `[(ngModel)]="selectedColor"` still works without code change.
+- **Touch:** verify the wheel is draggable on Android, with the synthesized click still firing if the user taps without dragging.
+
+## 10. Resolved decisions
+
+1. **`diameterRatio`** — **dropped**. Not exposed on the picker, not used by the demo, not exercised by any test. Reintroduce on demand.
+2. **Strip naming** — **`BsBrightnessStripComponent`** (Adobe / Photoshop convention). Renamed via `git mv` to preserve file history. Inputs/outputs renamed in lockstep.
+3. **Soft migration aid** — **no**. Clean break in a single release. The CHANGELOG entry covers the migration.
+4. **`[mode]` input for HSL/HSV display labels** — **no**. The picker is HSV throughout. Numeric-input panels can be added later as separate components without affecting this redesign.

--- a/libs/mintplayer-ng-bootstrap/color-picker/color-math.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/color-math.spec.ts
@@ -10,6 +10,16 @@ describe('color-math', () => {
       expect(hex2rgb('#f80')).toEqual({ r: 255, g: 136, b: 0 });
     });
 
+    it('returns black for invalid hex input', () => {
+      const black = { r: 0, g: 0, b: 0 };
+      expect(hex2rgb('#xyz')).toEqual(black);
+      expect(hex2rgb('#1234')).toEqual(black);
+      expect(hex2rgb('#12')).toEqual(black);
+      expect(hex2rgb('#')).toEqual(black);
+      expect(hex2rgb('')).toEqual(black);
+      expect(hex2rgb('#12345g')).toEqual(black);
+    });
+
     it('round-trips rgb -> hex -> rgb', () => {
       const samples = [
         { r: 0, g: 0, b: 0 },

--- a/libs/mintplayer-ng-bootstrap/color-picker/color-math.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/color-math.spec.ts
@@ -1,0 +1,162 @@
+import { hex2hsv, hex2rgb, hs2polar, hsl2hsv, hsv2hex, hsv2hsl, hsv2rgb, polar2hs, rgb2hex, rgb2hsl, rgb2hsv } from './color-math';
+
+describe('color-math', () => {
+  describe('hex <-> rgb', () => {
+    it('parses 6-digit hex', () => {
+      expect(hex2rgb('#ff8800')).toEqual({ r: 255, g: 136, b: 0 });
+    });
+
+    it('parses 3-digit hex', () => {
+      expect(hex2rgb('#f80')).toEqual({ r: 255, g: 136, b: 0 });
+    });
+
+    it('round-trips rgb -> hex -> rgb', () => {
+      const samples = [
+        { r: 0, g: 0, b: 0 },
+        { r: 255, g: 255, b: 255 },
+        { r: 128, g: 128, b: 128 },
+        { r: 255, g: 0, b: 0 },
+        { r: 0, g: 255, b: 0 },
+        { r: 0, g: 0, b: 255 },
+        { r: 17, g: 142, b: 235 },
+      ];
+      for (const rgb of samples) {
+        const round = hex2rgb(rgb2hex(rgb));
+        expect(round).toEqual(rgb);
+      }
+    });
+  });
+
+  describe('rgb <-> hsv', () => {
+    it('white = (any, 0, 1)', () => {
+      const hsv = rgb2hsv({ r: 255, g: 255, b: 255 });
+      expect(hsv.saturation).toBe(0);
+      expect(hsv.value).toBe(1);
+    });
+
+    it('black = (any, 0, 0)', () => {
+      const hsv = rgb2hsv({ r: 0, g: 0, b: 0 });
+      expect(hsv.saturation).toBe(0);
+      expect(hsv.value).toBe(0);
+    });
+
+    it('pure red = (0, 1, 1)', () => {
+      const hsv = rgb2hsv({ r: 255, g: 0, b: 0 });
+      expect(hsv.hue).toBe(0);
+      expect(hsv.saturation).toBe(1);
+      expect(hsv.value).toBe(1);
+    });
+
+    it('pure green = (120, 1, 1)', () => {
+      const hsv = rgb2hsv({ r: 0, g: 255, b: 0 });
+      expect(hsv.hue).toBe(120);
+      expect(hsv.saturation).toBe(1);
+      expect(hsv.value).toBe(1);
+    });
+
+    it('pure blue = (240, 1, 1)', () => {
+      const hsv = rgb2hsv({ r: 0, g: 0, b: 255 });
+      expect(hsv.hue).toBe(240);
+    });
+
+    it('round-trips hex -> hsv -> rgb -> hex within 1 per channel', () => {
+      const samples = ['#000000', '#ffffff', '#808080', '#ff0000', '#00ff00', '#0000ff', '#118ee0', '#abcdef', '#fa8072', '#5a3fb8'];
+      for (const hex of samples) {
+        const hsv = hex2hsv(hex);
+        const rgb = hsv2rgb(hsv);
+        const back = rgb2hex(rgb);
+        const a = hex2rgb(hex);
+        const b = hex2rgb(back);
+        expect(Math.abs(a.r - b.r)).toBeLessThanOrEqual(1);
+        expect(Math.abs(a.g - b.g)).toBeLessThanOrEqual(1);
+        expect(Math.abs(a.b - b.b)).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('hsv2hex is the inverse of hex2hsv up to rounding', () => {
+      const samples = ['#118ee0', '#abcdef', '#fa8072'];
+      for (const hex of samples) {
+        const round = hsv2hex(hex2hsv(hex));
+        const a = hex2rgb(hex);
+        const b = hex2rgb(round);
+        expect(Math.abs(a.r - b.r)).toBeLessThanOrEqual(1);
+        expect(Math.abs(a.g - b.g)).toBeLessThanOrEqual(1);
+        expect(Math.abs(a.b - b.b)).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  describe('rgb <-> hsl', () => {
+    it('pure red = (0, 1, 0.5)', () => {
+      const hsl = rgb2hsl({ r: 255, g: 0, b: 0 });
+      expect(hsl.hue).toBe(0);
+      expect(hsl.saturation).toBeCloseTo(1, 5);
+      expect(hsl.luminosity).toBeCloseTo(0.5, 5);
+    });
+
+    it('white = (any, 0, 1)', () => {
+      const hsl = rgb2hsl({ r: 255, g: 255, b: 255 });
+      expect(hsl.luminosity).toBe(1);
+      expect(hsl.saturation).toBe(0);
+    });
+  });
+
+  describe('hsv <-> hsl', () => {
+    it('hsv (0, 1, 1) <-> hsl (0, 1, 0.5)', () => {
+      const hsl = hsv2hsl({ hue: 0, saturation: 1, value: 1 });
+      expect(hsl.hue).toBe(0);
+      expect(hsl.saturation).toBeCloseTo(1, 5);
+      expect(hsl.luminosity).toBeCloseTo(0.5, 5);
+      const hsv = hsl2hsv(hsl);
+      expect(hsv.value).toBeCloseTo(1, 5);
+      expect(hsv.saturation).toBeCloseTo(1, 5);
+    });
+
+    it('hsv (180, 0, 1) = white in hsl', () => {
+      const hsl = hsv2hsl({ hue: 180, saturation: 0, value: 1 });
+      expect(hsl.luminosity).toBe(1);
+      expect(hsl.saturation).toBe(0);
+    });
+  });
+
+  describe('polar <-> hs (wheel hit-test math)', () => {
+    const R = 100;
+
+    it('center of disc -> saturation 0', () => {
+      const hs = polar2hs(0, 0, R);
+      expect(hs.saturation).toBe(0);
+    });
+
+    it('rim at 0deg = positive x = hue 0', () => {
+      const hs = polar2hs(R, 0, R);
+      expect(hs.hue).toBe(0);
+      expect(hs.saturation).toBe(1);
+    });
+
+    it('rim at 90deg = positive y = hue 90', () => {
+      const hs = polar2hs(0, R, R);
+      expect(hs.hue).toBeCloseTo(90, 5);
+      expect(hs.saturation).toBe(1);
+    });
+
+    it('outside disc clamps saturation to 1', () => {
+      const hs = polar2hs(R * 2, 0, R);
+      expect(hs.saturation).toBe(1);
+    });
+
+    it('hs2polar is the inverse of polar2hs', () => {
+      const samples = [
+        { hue: 0, saturation: 0.5 },
+        { hue: 45, saturation: 0.8 },
+        { hue: 137, saturation: 1 },
+        { hue: 270, saturation: 0.3 },
+      ];
+      for (const hs of samples) {
+        const { dx, dy } = hs2polar(hs.hue, hs.saturation, R);
+        const back = polar2hs(dx, dy, R);
+        expect(back.hue).toBeCloseTo(hs.hue, 5);
+        expect(back.saturation).toBeCloseTo(hs.saturation, 5);
+      }
+    });
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/color-picker/color-math.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/color-math.ts
@@ -1,0 +1,151 @@
+import { HslColor } from './interfaces/hsl-color';
+import { HsvColor } from './interfaces/hsv-color';
+import { RgbColor } from './interfaces/rgb-color';
+
+/**
+ * Single source of truth for color-space conversions used by the picker.
+ *
+ * Conventions across this module:
+ *   - hue is in degrees [0, 360)
+ *   - saturation, lightness, value, alpha are in [0, 1]
+ *   - r, g, b are in [0, 255] (integer on the way out, real-valued internally)
+ *   - hex is "#RRGGBB" — three-digit "#RGB" is accepted on parse only
+ */
+
+const TWO_PI = Math.PI * 2;
+
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
+const clamp255 = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
+
+export function hex2rgb(hex: string): RgbColor {
+    const stripped = hex.startsWith('#') ? hex.slice(1) : hex;
+    const expanded = stripped.length === 3
+        ? stripped.split('').map(c => c + c).join('')
+        : stripped;
+    return {
+        r: parseInt(expanded.slice(0, 2), 16),
+        g: parseInt(expanded.slice(2, 4), 16),
+        b: parseInt(expanded.slice(4, 6), 16),
+    };
+}
+
+export function rgb2hex(rgb: RgbColor): string {
+    const r = clamp255(rgb.r);
+    const g = clamp255(rgb.g);
+    const b = clamp255(rgb.b);
+    return '#' + ((r << 16) + (g << 8) + b).toString(16).padStart(6, '0');
+}
+
+export function rgb2hsv(rgb: RgbColor): HsvColor {
+    const r = rgb.r / 255;
+    const g = rgb.g / 255;
+    const b = rgb.b / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const d = max - min;
+
+    const value = max;
+    const saturation = max === 0 ? 0 : d / max;
+    const hue = d === 0 ? 0 : hueFromRgb(r, g, b, max, d);
+
+    return { hue, saturation, value };
+}
+
+export function hsv2rgb(hsv: HsvColor): RgbColor {
+    const s = clamp01(hsv.saturation);
+    const v = clamp01(hsv.value);
+    const h = ((hsv.hue % 360) + 360) % 360;
+
+    const c = v * s;
+    const hp = h / 60;
+    const x = c * (1 - Math.abs((hp % 2) - 1));
+    const m = v - c;
+
+    let r1 = 0, g1 = 0, b1 = 0;
+    if (hp < 1) { r1 = c; g1 = x; }
+    else if (hp < 2) { r1 = x; g1 = c; }
+    else if (hp < 3) { g1 = c; b1 = x; }
+    else if (hp < 4) { g1 = x; b1 = c; }
+    else if (hp < 5) { r1 = x; b1 = c; }
+    else { r1 = c; b1 = x; }
+
+    return {
+        r: (r1 + m) * 255,
+        g: (g1 + m) * 255,
+        b: (b1 + m) * 255,
+    };
+}
+
+export function rgb2hsl(rgb: RgbColor): HslColor {
+    const r = rgb.r / 255;
+    const g = rgb.g / 255;
+    const b = rgb.b / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const d = max - min;
+
+    const luminosity = (max + min) / 2;
+    const saturation = d === 0
+        ? 0
+        : d / (1 - Math.abs(2 * luminosity - 1));
+    const hue = d === 0 ? 0 : hueFromRgb(r, g, b, max, d);
+
+    return { hue, saturation, luminosity };
+}
+
+export function hsl2rgb(hsl: HslColor): RgbColor {
+    return hsv2rgb(hsl2hsv(hsl));
+}
+
+export function hsv2hsl(hsv: HsvColor): HslColor {
+    const v = clamp01(hsv.value);
+    const s = clamp01(hsv.saturation);
+    const luminosity = v * (1 - s / 2);
+    const denom = Math.min(luminosity, 1 - luminosity);
+    const saturation = denom === 0 ? 0 : (v - luminosity) / denom;
+    return { hue: hsv.hue, saturation, luminosity };
+}
+
+export function hsl2hsv(hsl: HslColor): HsvColor {
+    const l = clamp01(hsl.luminosity);
+    const s = clamp01(hsl.saturation);
+    const value = l + s * Math.min(l, 1 - l);
+    const saturation = value === 0 ? 0 : 2 * (1 - l / value);
+    return { hue: hsl.hue, saturation, value };
+}
+
+export function hex2hsv(hex: string): HsvColor {
+    return rgb2hsv(hex2rgb(hex));
+}
+
+export function hsv2hex(hsv: HsvColor): string {
+    return rgb2hex(hsv2rgb(hsv));
+}
+
+/** Polar position (cx, cy) on a disc of radius R → HSV (hue, saturation). */
+export function polar2hs(dx: number, dy: number, radius: number): { hue: number; saturation: number } {
+    const r = Math.sqrt(dx * dx + dy * dy);
+    const saturation = clamp01(r / radius);
+    let hue = (Math.atan2(dy, dx) * 360) / TWO_PI;
+    if (hue < 0) hue += 360;
+    return { hue, saturation };
+}
+
+/** Inverse of polar2hs. Hue in degrees, saturation in [0, 1] → (dx, dy) on a disc of given radius. */
+export function hs2polar(hue: number, saturation: number, radius: number): { dx: number; dy: number } {
+    const theta = (hue * TWO_PI) / 360;
+    const r = clamp01(saturation) * radius;
+    return { dx: r * Math.cos(theta), dy: r * Math.sin(theta) };
+}
+
+function hueFromRgb(r: number, g: number, b: number, max: number, d: number): number {
+    let h: number;
+    switch (max) {
+        case r: h = ((g - b) / d) % 6; break;
+        case g: h = (b - r) / d + 2; break;
+        default: h = (r - g) / d + 4; break;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+    return h;
+}

--- a/libs/mintplayer-ng-bootstrap/color-picker/color-math.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/color-math.ts
@@ -17,11 +17,15 @@ const TWO_PI = Math.PI * 2;
 const clamp01 = (n: number) => Math.max(0, Math.min(1, n));
 const clamp255 = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
 
+const HEX6_RE = /^[0-9a-fA-F]{6}$/;
+const BLACK: RgbColor = { r: 0, g: 0, b: 0 };
+
 export function hex2rgb(hex: string): RgbColor {
     const stripped = hex.startsWith('#') ? hex.slice(1) : hex;
     const expanded = stripped.length === 3
         ? stripped.split('').map(c => c + c).join('')
         : stripped;
+    if (!HEX6_RE.test(expanded)) return { ...BLACK };
     return {
         r: parseInt(expanded.slice(0, 2), 16),
         g: parseInt(expanded.slice(2, 4), 16),

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, input, model, output, viewChild } from '@angular/core';
 import { HS } from '../../interfaces/hs';
 import { BsSliderComponent, BsThumbDirective, BsTrackDirective } from '../slider/slider.component';
+import { hsv2rgb } from '../../color-math';
 
 @Component({
   selector: 'bs-alpha-strip',
@@ -14,7 +15,7 @@ export class BsAlphaStripComponent {
 
   disabled = input<boolean>(false);
   hs = model<HS>({ hue: 0, saturation: 0 });
-  luminosity = model<number>(0.5);
+  brightness = model<number>(1);
   alpha = model<number>(1);
   alphaChange = output<number>();
 
@@ -22,16 +23,16 @@ export class BsAlphaStripComponent {
 
   resultBackground = computed(() => {
     const hs = this.hs();
-    const luminosity = this.luminosity();
+    const brightness = this.brightness();
     const alpha = this.alpha();
-    return `hsla(${hs.hue}, ${hs.saturation * 100}%, ${luminosity * 100}%, ${alpha})`;
+    const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
+    return `rgba(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)}, ${alpha})`;
   });
 
   constructor() {
-    // Draw gradient when HS or luminosity changes
     effect(() => {
       const hs = this.hs();
-      const luminosity = this.luminosity();
+      const brightness = this.brightness();
       setTimeout(() => {
         if (this.canvasContext) {
           const width = this.canvas().nativeElement.width;
@@ -39,16 +40,17 @@ export class BsAlphaStripComponent {
           this.canvasContext.clearRect(0, 0, width, height);
           this.canvasContext.save();
 
+          const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
+          const r = Math.round(rgb.r), g = Math.round(rgb.g), b = Math.round(rgb.b);
           const gradient = this.canvasContext.createLinearGradient(0, 0, width, 0);
-          gradient.addColorStop(0, `hsla(${hs.hue}, ${hs.saturation * 100}%, ${luminosity * 100}%, 0)`);
-          gradient.addColorStop(1, `hsla(${hs.hue}, ${hs.saturation * 100}%, ${luminosity * 100}%, 1)`);
+          gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, 0)`);
+          gradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, 1)`);
           this.canvasContext.fillStyle = gradient;
           this.canvasContext.fillRect(0, 0, width, height);
         }
       });
     });
 
-    // Emit alpha changes
     effect(() => {
       const alpha = this.alpha();
       this.alphaChange.emit(alpha);

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.html
@@ -1,4 +1,4 @@
-<bs-slider [disabled]="disabled()" [value]="luminosity()" (valueChange)="luminosityChange.emit($event)">
+<bs-slider [disabled]="disabled()" [value]="brightness()" (valueChange)="brightnessChange.emit($event)">
     <canvas bsTrack class="position-absolute w-100" #canvas></canvas>
     <div bsThumb [style.background]="resultBackground()"></div>
 </bs-slider>

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.spec.ts
@@ -2,25 +2,22 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent } from 'ng-mocks';
 import { BsSliderComponent } from '../slider/slider.component';
 
-import { BsLuminosityStripComponent } from './luminosity-strip.component';
+import { BsBrightnessStripComponent } from './brightness-strip.component';
 
-describe('BsLuminosityStripComponent', () => {
-  let component: BsLuminosityStripComponent;
-  let fixture: ComponentFixture<BsLuminosityStripComponent>;
+describe('BsBrightnessStripComponent', () => {
+  let component: BsBrightnessStripComponent;
+  let fixture: ComponentFixture<BsBrightnessStripComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        // Unit to test
-        BsLuminosityStripComponent,
-
-        // Mock dependencies
+        BsBrightnessStripComponent,
         MockComponent(BsSliderComponent),
       ]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(BsLuminosityStripComponent);
+    fixture = TestBed.createComponent(BsBrightnessStripComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.ts
@@ -1,32 +1,33 @@
 import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, input, model, output, viewChild } from '@angular/core';
 import { HS } from '../../interfaces/hs';
 import { BsSliderComponent, BsThumbDirective, BsTrackDirective } from '../slider/slider.component';
+import { hsv2rgb } from '../../color-math';
 
 @Component({
-  selector: 'bs-luminosity-strip',
-  templateUrl: './luminosity-strip.component.html',
-  styleUrls: ['./luminosity-strip.component.scss'],
+  selector: 'bs-brightness-strip',
+  templateUrl: './brightness-strip.component.html',
+  styleUrls: ['./brightness-strip.component.scss'],
   imports: [BsSliderComponent, BsThumbDirective, BsTrackDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class BsLuminosityStripComponent {
+export class BsBrightnessStripComponent {
   readonly canvas = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
 
   disabled = input<boolean>(false);
   hs = model<HS>({ hue: 0, saturation: 0 });
-  luminosity = model<number>(0.5);
-  luminosityChange = output<number>();
+  brightness = model<number>(1);
+  brightnessChange = output<number>();
 
   private canvasContext: CanvasRenderingContext2D | null = null;
 
   resultBackground = computed(() => {
     const hs = this.hs();
-    const luminosity = this.luminosity();
-    return `hsl(${hs.hue}, ${hs.saturation * 100}%, ${luminosity * 100}%)`;
+    const brightness = this.brightness();
+    const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
+    return `rgb(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)})`;
   });
 
   constructor() {
-    // Draw gradient when HS changes
     effect(() => {
       const hs = this.hs();
       if (this.canvasContext) {
@@ -35,19 +36,18 @@ export class BsLuminosityStripComponent {
         this.canvasContext.clearRect(0, 0, width, height);
         this.canvasContext.save();
 
+        const peak = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: 1 });
         const gradient = this.canvasContext.createLinearGradient(0, 0, width, 0);
-        gradient.addColorStop(0, `hsl(${hs.hue}, ${hs.saturation * 100}%, 0%)`);
-        gradient.addColorStop(0.5, `hsl(${hs.hue}, ${hs.saturation * 100}%, 50%)`);
-        gradient.addColorStop(1, `hsl(${hs.hue}, ${hs.saturation * 100}%, 100%)`);
+        gradient.addColorStop(0, 'rgb(0, 0, 0)');
+        gradient.addColorStop(1, `rgb(${Math.round(peak.r)}, ${Math.round(peak.g)}, ${Math.round(peak.b)})`);
         this.canvasContext.fillStyle = gradient;
         this.canvasContext.fillRect(0, 0, width, height);
       }
     });
 
-    // Emit luminosity changes
     effect(() => {
-      const luminosity = this.luminosity();
-      this.luminosityChange.emit(luminosity);
+      const brightness = this.brightness();
+      this.brightnessChange.emit(brightness);
     });
   }
 

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.html
@@ -1,10 +1,10 @@
 @let letDisabled = disabled();
 @let letHS = hs();
-@let letLuminosity = luminosity();
+@let letBrightness = brightness();
 @let letAlpha = alpha();
 
-<bs-color-wheel [disabled]="letDisabled" [hs]="letHS" (hsChange)="hs.set($event)" [luminosity]="letLuminosity" [width]="size()" [height]="size()" #wheel></bs-color-wheel>
-<bs-luminosity-strip [disabled]="letDisabled" [hs]="letHS" [luminosity]="letLuminosity" (luminosityChange)="luminosity.set($event)" class="d-block mt-2" [style.width.px]="size()" #strip></bs-luminosity-strip>
+<bs-color-wheel [disabled]="letDisabled" [hs]="letHS" (hsChange)="hs.set($event)" [brightness]="letBrightness" [width]="size()" [height]="size()" #wheel></bs-color-wheel>
+<bs-brightness-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" (brightnessChange)="brightness.set($event)" class="d-block mt-2" [style.width.px]="size()" #strip></bs-brightness-strip>
 @if (allowAlpha()) {
-    <bs-alpha-strip [disabled]="letDisabled" [hs]="letHS" [luminosity]="letLuminosity" [alpha]="letAlpha" (alphaChange)="alpha.set($event)" class="d-block mt-2" [style.width.px]="size()" #alphaStrip></bs-alpha-strip>
+    <bs-alpha-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" [alpha]="letAlpha" (alphaChange)="alpha.set($event)" class="d-block mt-2" [style.width.px]="size()" #alphaStrip></bs-alpha-strip>
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.spec.ts
@@ -3,7 +3,7 @@ import { MockComponent, MockDirective } from 'ng-mocks';
 
 import { BsColorPickerComponent } from './color-picker.component';
 import { BsAlphaStripComponent } from '../alpha-strip/alpha-strip.component';
-import { BsLuminosityStripComponent } from '../luminosity-strip/luminosity-strip.component';
+import { BsBrightnessStripComponent } from '../brightness-strip/brightness-strip.component';
 import { BsColorWheelComponent } from '../color-wheel/color-wheel.component';
 
 describe('ColorPickerComponent', () => {
@@ -19,7 +19,7 @@ describe('ColorPickerComponent', () => {
 
         // Mock dependencies
         MockComponent(BsAlphaStripComponent),
-        MockComponent(BsLuminosityStripComponent),
+        MockComponent(BsBrightnessStripComponent),
         MockComponent(BsColorWheelComponent),
       ]
     })

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.ts
@@ -2,14 +2,14 @@ import { ChangeDetectionStrategy, Component, effect, input, model, output, signa
 import { HS } from "../../interfaces/hs";
 import { BsColorPickerValueAccessor } from "../../directives/color-picker-value-accessor/color-picker-value-accessor.directive";
 import { BsColorWheelComponent } from "../color-wheel/color-wheel.component";
-import { BsLuminosityStripComponent } from "../luminosity-strip/luminosity-strip.component";
+import { BsBrightnessStripComponent } from "../brightness-strip/brightness-strip.component";
 import { BsAlphaStripComponent } from "../alpha-strip/alpha-strip.component";
 
 @Component({
   selector: 'bs-color-picker',
   templateUrl: './color-picker.component.html',
   styleUrls: ['./color-picker.component.scss'],
-  imports: [BsColorWheelComponent, BsLuminosityStripComponent, BsAlphaStripComponent],
+  imports: [BsColorWheelComponent, BsBrightnessStripComponent, BsAlphaStripComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [BsColorPickerValueAccessor],
 })
@@ -22,7 +22,7 @@ export class BsColorPickerComponent {
   allowAlpha = input<boolean>(true);
 
   hs = signal<HS>({ hue: 0, saturation: 0 });
-  luminosity = signal<number>(0);
+  brightness = signal<number>(1);
 
   alpha = model<number>(1);
   alphaChange = output<number>();

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.html
@@ -1,12 +1,21 @@
 <canvas
     class="d-block"
-    [width]="width()"
-    [height]="height()"
+    [attr.width]="canvasPixelWidth()"
+    [attr.height]="canvasPixelHeight()"
+    [style.width.px]="width()"
+    [style.height.px]="height()"
     (mousedown)="onPointerDown($event)"
     (touchstart)="onPointerDown($event)"
     (touchmove)="onPointerMove($event)"
     (touchend)="onPointerUp($event)"
     #canvas></canvas>
+
+<div class="brightness-overlay position-absolute pe-none"
+     [style.opacity]="overlayOpacity()"
+     [style.left.px]="shiftX()"
+     [style.top.px]="shiftY()"
+     [style.width.px]="squareSize()"
+     [style.height.px]="squareSize()"></div>
 
 @if (markerPosition(); as markerPosition) {
     <div class="thumb position-absolute pe-none" [style.left.px]="markerPosition.x" [style.top.px]="markerPosition.y"></div>

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.html
@@ -1,22 +1,23 @@
-<canvas
-    class="d-block"
-    [attr.width]="canvasPixelWidth()"
-    [attr.height]="canvasPixelHeight()"
-    [style.width.px]="width()"
-    [style.height.px]="height()"
-    (mousedown)="onPointerDown($event)"
-    (touchstart)="onPointerDown($event)"
-    (touchmove)="onPointerMove($event)"
-    (touchend)="onPointerUp($event)"
-    #canvas></canvas>
+<div [style.width.px]="width()" [style.height.px]="height()" class="position-relative">
+    <div class="wheel-surface position-absolute"
+         [style.left.px]="shiftX()"
+         [style.top.px]="shiftY()"
+         [style.width.px]="squareSize()"
+         [style.height.px]="squareSize()"
+         (mousedown)="onPointerDown($event)"
+         (touchstart)="onPointerDown($event)"
+         (touchmove)="onPointerMove($event)"
+         (touchend)="onPointerUp($event)"
+         #surface></div>
 
-<div class="brightness-overlay position-absolute pe-none"
-     [style.opacity]="overlayOpacity()"
-     [style.left.px]="shiftX()"
-     [style.top.px]="shiftY()"
-     [style.width.px]="squareSize()"
-     [style.height.px]="squareSize()"></div>
+    <div class="brightness-overlay position-absolute pe-none"
+         [style.opacity]="overlayOpacity()"
+         [style.left.px]="shiftX()"
+         [style.top.px]="shiftY()"
+         [style.width.px]="squareSize()"
+         [style.height.px]="squareSize()"></div>
 
-@if (markerPosition(); as markerPosition) {
-    <div class="thumb position-absolute pe-none" [style.left.px]="markerPosition.x" [style.top.px]="markerPosition.y"></div>
-}
+    @if (markerPosition(); as markerPosition) {
+        <div class="thumb position-absolute pe-none" [style.left.px]="markerPosition.x" [style.top.px]="markerPosition.y"></div>
+    }
+</div>

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.scss
@@ -1,5 +1,15 @@
 $thumb-size: 30px;
 
+canvas {
+    touch-action: none;
+}
+
+.brightness-overlay {
+    background: #000;
+    border-radius: 50%;
+    transition: opacity 60ms linear;
+}
+
 .thumb {
     width: $thumb-size;
     height: $thumb-size;

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.scss
@@ -1,7 +1,12 @@
 $thumb-size: 30px;
 
-canvas {
+.wheel-surface {
+    border-radius: 50%;
+    background:
+        radial-gradient(circle closest-side, #fff, transparent),
+        conic-gradient(from 90deg, hsl(0, 100%, 50%), hsl(60, 100%, 50%), hsl(120, 100%, 50%), hsl(180, 100%, 50%), hsl(240, 100%, 50%), hsl(300, 100%, 50%), hsl(360, 100%, 50%));
     touch-action: none;
+    cursor: crosshair;
 }
 
 .brightness-overlay {
@@ -19,4 +24,5 @@ canvas {
     box-sizing: border-box;
     border: 2px solid white;
     box-shadow: rgb(0 0 0 / 10%) 0px 0px 10px 5px;
+    pointer-events: none;
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, model, output, signal, viewChild } from '@angular/core';
 import { HS } from '../../interfaces/hs';
-import { HslColor } from '../../interfaces/hsl-color';
-import { RgbColor } from '../../interfaces/rgb-color';
+import { hs2polar, polar2hs } from '../../color-math';
 
 @Component({
   selector: 'bs-color-wheel',
@@ -10,7 +9,7 @@ import { RgbColor } from '../../interfaces/rgb-color';
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'position-relative',
-    '(document:mousemove)': 'onMouseMove($event)',
+    '(document:mousemove)': 'onPointerMove($event)',
     '(document:mouseup)': 'onPointerUp($event)',
   },
 })
@@ -18,118 +17,72 @@ export class BsColorWheelComponent {
   private element = inject(ElementRef<HTMLElement>);
   readonly canvas = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
 
-  // Inputs
   width = model<number>(150);
   height = model<number>(150);
-  diameterRatio = model<number>(0);
-  luminosity = model<number>(0);
+  brightness = model<number>(1);
 
-  // HS model with output
   hs = model<HS>({ hue: 0, saturation: 0 });
   hsChange = output<HS>();
 
-  // Internal state
   disabled = input<boolean>(false);
   viewInited = signal<boolean>(false);
   private readonly isPointerDown = signal<boolean>(false);
+  private readonly dpr = signal<number>(1);
   private canvasContext: CanvasRenderingContext2D | null = null;
 
-  // Computed values
-  squareSize = computed(() => {
-    const width = this.width();
-    const height = this.height();
-    if (width === null || height === null) {
-      return null;
-    }
-    return Math.min(width, height);
-  });
+  squareSize = computed(() => Math.min(this.width(), this.height()));
+  shiftX = computed(() => Math.max(0, (this.width() - this.height()) / 2));
+  shiftY = computed(() => Math.max(0, (this.height() - this.width()) / 2));
+  outerRadius = computed(() => this.squareSize() / 2);
 
-  shiftX = computed(() => {
-    const width = this.width();
-    const height = this.height();
-    if (width === null || height === null) {
-      return null;
-    } else if (width < height) {
-      return 0;
-    } else {
-      return (width - height) / 2;
-    }
-  });
+  canvasPixelWidth = computed(() => this.width() * this.dpr());
+  canvasPixelHeight = computed(() => this.height() * this.dpr());
 
-  shiftY = computed(() => {
-    const width = this.width();
-    const height = this.height();
-    if (width === null || height === null) {
-      return null;
-    } else if (width < height) {
-      return (height - width) / 2;
-    } else {
-      return 0;
-    }
-  });
-
-  innerRadius = computed(() => {
-    const squareSize = this.squareSize();
-    const diameterRatio = this.diameterRatio();
-    if (squareSize) {
-      return squareSize / 2 * diameterRatio;
-    } else {
-      return 0;
-    }
-  });
-
-  outerRadius = computed(() => {
-    const squareSize = this.squareSize();
-    if (squareSize) {
-      return squareSize / 2;
-    } else {
-      return 150;
-    }
-  });
+  overlayOpacity = computed(() => 1 - this.brightness());
 
   markerPosition = computed(() => {
     const hs = this.hs();
-    const shiftX = this.shiftX() ?? 0;
-    const shiftY = this.shiftY() ?? 0;
-    const position = this.color2position(hs);
-    return {
-      x: position.x + shiftX,
-      y: position.y + shiftY,
-    };
+    const radius = this.outerRadius();
+    const cx = this.shiftX() + radius;
+    const cy = this.shiftY() + radius;
+    const { dx, dy } = hs2polar(hs.hue, hs.saturation, radius);
+    return { x: cx + dx, y: cy + dy };
   });
 
   constructor() {
-    // Draw color wheel when dimensions change
     effect(() => {
-      const innerRadius = this.innerRadius();
-      const outerRadius = this.outerRadius();
+      const radius = this.outerRadius();
+      const dpr = this.dpr();
       const shiftX = this.shiftX();
       const shiftY = this.shiftY();
+      const ctx = this.canvasContext;
+      if (!ctx || radius <= 0) return;
 
-      // Use setTimeout to debounce slightly
-      setTimeout(() => {
-        if (this.canvasContext && innerRadius !== null && outerRadius !== null && shiftX !== null && shiftY !== null) {
-          this.canvasContext.clearRect(0, 0, this.canvas().nativeElement.width, this.canvas().nativeElement.height);
-          this.canvasContext.save();
-          this.canvasContext.translate(shiftX + outerRadius, shiftY + outerRadius);
+      const widthCss = this.width();
+      const heightCss = this.height();
+      ctx.save();
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, widthCss, heightCss);
+      ctx.translate(shiftX + radius, shiftY + radius);
 
-          for (let x = 0; x < 360; x++) {
-            this.canvasContext.rotate(1 * Math.PI / 180);
-            const gradient = this.canvasContext.createLinearGradient(innerRadius, 0, outerRadius, 0);
+      const stripHeight = Math.max(2, radius / 25);
+      const stripsPerDegree = 2;
+      const totalStrips = 360 * stripsPerDegree;
+      const angleStep = (Math.PI / 180) / stripsPerDegree;
 
-            gradient.addColorStop(0, `hsl(${x}, 0%, 50%)`);
-            gradient.addColorStop(1, `hsl(${x}, 100%, 50%)`);
+      for (let i = 0; i < totalStrips; i++) {
+        const hue = i / stripsPerDegree;
+        const gradient = ctx.createLinearGradient(0, 0, radius, 0);
+        gradient.addColorStop(0, `hsl(${hue}, 100%, 100%)`);
+        gradient.addColorStop(1, `hsl(${hue}, 100%, 50%)`);
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, -stripHeight / 2, radius, stripHeight);
+        ctx.rotate(angleStep);
+      }
 
-            this.canvasContext.fillStyle = gradient;
-            this.canvasContext.fillRect(innerRadius, 0, outerRadius - innerRadius, outerRadius / 50);
-          }
-
-          this.canvasContext.restore();
-        }
-      }, 20);
+      ctx.restore();
     });
 
-    // Emit HS changes
     effect(() => {
       const hs = this.hs();
       this.hsChange.emit(hs);
@@ -139,165 +92,42 @@ export class BsColorWheelComponent {
   ngAfterViewInit() {
     this.viewInited.set(true);
     if (typeof window !== 'undefined') {
-      this.canvasContext = this.canvas().nativeElement.getContext('2d', { willReadFrequently: true });
+      this.dpr.set(window.devicePixelRatio || 1);
+      this.canvasContext = this.canvas().nativeElement.getContext('2d');
     }
   }
 
   onPointerDown(ev: MouseEvent | TouchEvent) {
-    if (!this.disabled()) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      this.isPointerDown.set(true);
-      this.updateColor(ev, !('touches' in ev));
-    }
+    if (this.disabled()) return;
+    if (!('touches' in ev)) ev.preventDefault();
+    ev.stopPropagation();
+    this.isPointerDown.set(true);
+    this.updateColor(ev);
   }
 
   onPointerMove(ev: MouseEvent | TouchEvent) {
-    if (this.isPointerDown()) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      this.updateColor(ev, !('touches' in ev));
-    }
+    if (!this.isPointerDown()) return;
+    if (!('touches' in ev)) ev.preventDefault();
+    ev.stopPropagation();
+    this.updateColor(ev);
   }
 
-  onMouseMove(ev: MouseEvent) {
-    this.onPointerMove(ev);
-  }
-
-  onPointerUp(ev: MouseEvent | TouchEvent) {
+  onPointerUp(_ev: MouseEvent | TouchEvent) {
     this.isPointerDown.set(false);
   }
 
-  private updateColor(ev: MouseEvent | TouchEvent, subtract: boolean) {
-    let co: { x: number, y: number };
+  private updateColor(ev: MouseEvent | TouchEvent) {
     const rect = this.canvas().nativeElement.getBoundingClientRect();
-    if ('touches' in ev) {
-      co = {
-        x: ev.touches[0].clientX - rect.left,
-        y: ev.touches[0].clientY - rect.top,
-      };
-    } else {
-      co = {
-        x: ev.clientX - (subtract ? rect.left : 0),
-        y: ev.clientY - (subtract ? rect.top : 0),
-      };
-    }
+    const clientX = 'touches' in ev ? ev.touches[0].clientX : ev.clientX;
+    const clientY = 'touches' in ev ? ev.touches[0].clientY : ev.clientY;
 
-    const color = this.position2color(co.x, co.y);
-    if (color) {
-      this.hs.set({ hue: color.hue, saturation: color.saturation });
-    } else {
-      console.warn('Color is null');
-    }
-  }
+    const radius = this.outerRadius();
+    const cx = this.shiftX() + radius;
+    const cy = this.shiftY() + radius;
+    const dx = clientX - rect.left - cx;
+    const dy = clientY - rect.top - cy;
 
-  private isInsideCircle(x: number, y: number) {
-    const squareSize = this.squareSize();
-    const shiftX = this.shiftX();
-    const shiftY = this.shiftY();
-
-    // Position to the square
-    const sx: number = x - (shiftX ?? 0);
-    const sy = y - (shiftY ?? 0);
-    // Square radius
-    const sr = (squareSize ?? 0) / 2;
-
-    const radius = Math.sqrt(Math.pow(sx - sr, 2) + Math.pow(sy - sr, 2));
-    const angle = (Math.atan2(sr - sy, sr - sx) + Math.PI) % 360;
-    return {
-      inside: radius <= sr,
-      angle
-    };
-  }
-
-  private position2color(x: number, y: number): HslColor | null {
-    if (!this.canvasContext) {
-      return null;
-    }
-
-    const result = this.isInsideCircle(x, y);
-    if (result.inside) {
-      const imageData = this.canvasContext.getImageData(x, y, 1, 1).data;
-      const hsl = this.rgb2Hsl({ r: imageData[0], g: imageData[1], b: imageData[2] });
-      return hsl;
-    }
-
-    return { hue: result.angle * 180 / Math.PI, saturation: 1, luminosity: 0.5 };
-  }
-
-  private color2position(hs: HS) {
-    let innerRadius = this.innerRadius();
-    let outerRadius = this.outerRadius();
-
-    if (innerRadius === null) {
-      innerRadius = 0;
-    }
-    if (!outerRadius) {
-      outerRadius = 100;
-    }
-
-    const theta = hs.hue * Math.PI / 180;
-    const c = {
-      x: -outerRadius * Math.cos(theta),
-      y: -outerRadius * Math.sin(theta)
-    };
-
-    const d = hs.saturation * (outerRadius - innerRadius) + innerRadius;
-    const o = { x: outerRadius, y: outerRadius };
-
-    return {
-      x: o.x - d * (c.x / outerRadius),
-      y: o.y - d * (c.y / outerRadius),
-    };
-  }
-
-  private rgb2Hsl(color: RgbColor) {
-    const r01 = this.bound01(color.r, 255);
-    const g01 = this.bound01(color.g, 255);
-    const b01 = this.bound01(color.b, 255);
-
-    const max = Math.max(r01, g01, b01);
-    const min = Math.min(r01, g01, b01);
-
-    let h: number, s: number; const l = (max + min) / 2;
-    if (max === min) {
-      h = s = 0;
-    } else {
-      const d = max - min;
-      s = (l > 0.5) ? (d / (2 - max - min)) : (d / (max + min));
-      switch (max) {
-        case r01: {
-          h = (g01 - b01) / d + ((g01 < b01) ? 6 : 0);
-        } break;
-        case g01: {
-          h = (b01 - r01) / d + 2;
-        } break;
-        case b01: {
-          h = (r01 - g01) / d + 4;
-        } break;
-        default: {
-          throw 'Invalid operation';
-        }
-      }
-
-      h /= 6;
-    }
-
-    h *= 360;
-
-    return <HslColor>{ hue: h, saturation: s, luminosity: l };
-  }
-
-  /**
-   * Divide 1 to n, handling floating point errors.
-   * Ensures that the value is in between 0 and 1.
-   **/
-  private bound01(n: number, max: number) {
-    n = Math.min(max, Math.max(0, n));
-    if ((Math.abs(n - max) < 0.000001)) {
-      return 1;
-    } else {
-      return (n % max) / max;
-    }
+    const hs = polar2hs(dx, dy, radius);
+    this.hs.set(hs);
   }
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, model, output, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, input, model, output, signal, viewChild } from '@angular/core';
 import { HS } from '../../interfaces/hs';
 import { hs2polar, polar2hs } from '../../color-math';
 
@@ -14,8 +14,7 @@ import { hs2polar, polar2hs } from '../../color-math';
   },
 })
 export class BsColorWheelComponent {
-  private element = inject(ElementRef<HTMLElement>);
-  readonly canvas = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
+  readonly surface = viewChild.required<ElementRef<HTMLDivElement>>('surface');
 
   width = model<number>(150);
   height = model<number>(150);
@@ -25,18 +24,12 @@ export class BsColorWheelComponent {
   hsChange = output<HS>();
 
   disabled = input<boolean>(false);
-  viewInited = signal<boolean>(false);
   private readonly isPointerDown = signal<boolean>(false);
-  private readonly dpr = signal<number>(1);
-  private canvasContext: CanvasRenderingContext2D | null = null;
 
   squareSize = computed(() => Math.min(this.width(), this.height()));
   shiftX = computed(() => Math.max(0, (this.width() - this.height()) / 2));
   shiftY = computed(() => Math.max(0, (this.height() - this.width()) / 2));
   outerRadius = computed(() => this.squareSize() / 2);
-
-  canvasPixelWidth = computed(() => this.width() * this.dpr());
-  canvasPixelHeight = computed(() => this.height() * this.dpr());
 
   overlayOpacity = computed(() => 1 - this.brightness());
 
@@ -51,50 +44,9 @@ export class BsColorWheelComponent {
 
   constructor() {
     effect(() => {
-      const radius = this.outerRadius();
-      const dpr = this.dpr();
-      const shiftX = this.shiftX();
-      const shiftY = this.shiftY();
-      const ctx = this.canvasContext;
-      if (!ctx || radius <= 0) return;
-
-      const widthCss = this.width();
-      const heightCss = this.height();
-      ctx.save();
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      ctx.clearRect(0, 0, widthCss, heightCss);
-      ctx.translate(shiftX + radius, shiftY + radius);
-
-      const stripHeight = Math.max(2, radius / 25);
-      const stripsPerDegree = 2;
-      const totalStrips = 360 * stripsPerDegree;
-      const angleStep = (Math.PI / 180) / stripsPerDegree;
-
-      for (let i = 0; i < totalStrips; i++) {
-        const hue = i / stripsPerDegree;
-        const gradient = ctx.createLinearGradient(0, 0, radius, 0);
-        gradient.addColorStop(0, `hsl(${hue}, 100%, 100%)`);
-        gradient.addColorStop(1, `hsl(${hue}, 100%, 50%)`);
-        ctx.fillStyle = gradient;
-        ctx.fillRect(0, -stripHeight / 2, radius, stripHeight);
-        ctx.rotate(angleStep);
-      }
-
-      ctx.restore();
-    });
-
-    effect(() => {
       const hs = this.hs();
       this.hsChange.emit(hs);
     });
-  }
-
-  ngAfterViewInit() {
-    this.viewInited.set(true);
-    if (typeof window !== 'undefined') {
-      this.dpr.set(window.devicePixelRatio || 1);
-      this.canvasContext = this.canvas().nativeElement.getContext('2d');
-    }
   }
 
   onPointerDown(ev: MouseEvent | TouchEvent) {
@@ -117,15 +69,13 @@ export class BsColorWheelComponent {
   }
 
   private updateColor(ev: MouseEvent | TouchEvent) {
-    const rect = this.canvas().nativeElement.getBoundingClientRect();
+    const rect = this.surface().nativeElement.getBoundingClientRect();
     const clientX = 'touches' in ev ? ev.touches[0].clientX : ev.clientX;
     const clientY = 'touches' in ev ? ev.touches[0].clientY : ev.clientY;
 
     const radius = this.outerRadius();
-    const cx = this.shiftX() + radius;
-    const cy = this.shiftY() + radius;
-    const dx = clientX - rect.left - cx;
-    const dy = clientY - rect.top - cy;
+    const dx = clientX - rect.left - radius;
+    const dy = clientY - rect.top - radius;
 
     const hs = polar2hs(dx, dy, radius);
     this.hs.set(hs);

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/index.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/index.ts
@@ -1,5 +1,5 @@
 export * from './alpha-strip/alpha-strip.component';
+export * from './brightness-strip/brightness-strip.component';
 export * from './color-picker/color-picker.component';
 export * from './color-wheel/color-wheel.component';
-export * from './luminosity-strip/luminosity-strip.component';
 export * from './slider/slider.component';

--- a/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, effect, forwardRef, inject } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BsColorPickerComponent } from '../../components/color-picker/color-picker.component';
-import { RgbColor } from '../../interfaces/rgb-color';
+import { hex2hsv, hsv2rgb, rgb2hex } from '../../color-math';
 
 @Directive({
   selector: 'bs-color-picker',
@@ -19,25 +19,15 @@ export class BsColorPickerValueAccessor implements ControlValueAccessor {
   onTouched?: () => void;
 
   constructor() {
-    // Effect to emit value changes
     effect(() => {
       const hs = this.host.hs();
-      const luminosity = this.host.luminosity();
-      const rgb = this.hsl2rgb(hs.hue, hs.saturation, luminosity);
-      const hex = this.rgb2hex(rgb);
-      setTimeout(() => this.onValueChange && this.onValueChange(hex), 10);
+      const brightness = this.host.brightness();
+      const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
+      const hex = rgb2hex(rgb);
+      setTimeout(() => this.onValueChange?.(hex), 10);
     });
   }
 
-  public hsl2rgb(h: number, s: number, l: number) {
-    const k = (n: number) => (n + h / 30) % 12;
-    const a = s * Math.min(l, 1 - l);
-    const f = (n: number) => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
-    const retValue = <RgbColor>{ r: 255 * f(0), g: 255 * f(8), b: 255 * f(4) };
-    return retValue;
-  }
-
-  //#region ControlValueAccessor implementation
   registerOnChange(fn: (_: any) => void) {
     this.onValueChange = fn;
   }
@@ -47,82 +37,13 @@ export class BsColorPickerValueAccessor implements ControlValueAccessor {
   }
 
   writeValue(value: string | null) {
-    if (this.host && this.host.colorWheel()) {
-      if (value) {
-        const rgb = this.hex2rgb(value);
-        const hsl = this.rgb2Hsl(rgb);
-        this.host.hs.set({ hue: hsl.h, saturation: hsl.s });
-        this.host.luminosity.set(hsl.l);
-      }
-    }
+    if (!value || !this.host || !this.host.colorWheel()) return;
+    const hsv = hex2hsv(value);
+    this.host.hs.set({ hue: hsv.hue, saturation: hsv.saturation });
+    this.host.brightness.set(hsv.value);
   }
 
   setDisabledState(isDisabled: boolean) {
     this.host.disabled.set(isDisabled);
   }
-  //#endregion
-
-  //#region Color Conversion
-  private rgb2hex(rgb: RgbColor) {
-    return '#' + (Math.round((rgb.r << 16) + (rgb.g << 8) + rgb.b)).toString(16).padStart(6, '0');
-  }
-
-  private hex2rgb(hex: string): RgbColor {
-    const r = parseInt(hex.slice(1, 3), 16),
-          g = parseInt(hex.slice(3, 5), 16),
-          b = parseInt(hex.slice(5, 7), 16);
-
-    return { r, g, b };
-  }
-  /**
-   * Divide 1 to n, handling floating point errors.
-   * Ensures that the value is in between 0 and 1.
-   **/
-  private bound01(n: number, max: number) {
-    n = Math.min(max, Math.max(0, n));
-    if (Math.abs(n - max) < 0.000001) {
-      return 1;
-    } else {
-      return (n % max) / max;
-    }
-  }
-  private rgb2Hsl(color: RgbColor) {
-    const r01 = this.bound01(color.r, 255);
-    const g01 = this.bound01(color.g, 255);
-    const b01 = this.bound01(color.b, 255);
-
-    const max = Math.max(r01, g01, b01);
-    const min = Math.min(r01, g01, b01);
-
-    let h: number, s: number;
-    const l = (max + min) / 2;
-    if (max === min) {
-      h = s = 0;
-    } else {
-      const d = max - min;
-      s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-
-      switch (max) {
-        case r01:
-          h = (g01 - b01) / d + (g01 < b01 ? 6 : 0);
-          break;
-        case g01:
-          h = (b01 - r01) / d + 2;
-          break;
-        case b01:
-          h = (r01 - g01) / d + 4;
-          break;
-        default: {
-          throw 'Invalid operation';
-        }
-      }
-
-      h /= 6;
-    }
-
-    h *= 360;
-
-    return { h, s, l };
-  }
-  //#endregion
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
@@ -18,13 +18,19 @@ export class BsColorPickerValueAccessor implements ControlValueAccessor {
   onValueChange?: (value: string) => void;
   onTouched?: () => void;
 
+  // The hex most recently observed (either written by the form or emitted to it).
+  // Lets the emit effect dedup the echo from writeValue, breaking the round-trip loop.
+  private lastHex: string | null = null;
+
   constructor() {
     effect(() => {
       const hs = this.host.hs();
       const brightness = this.host.brightness();
       const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
       const hex = rgb2hex(rgb);
-      setTimeout(() => this.onValueChange?.(hex), 10);
+      if (hex === this.lastHex) return;
+      this.lastHex = hex;
+      this.onValueChange?.(hex);
     });
   }
 
@@ -37,8 +43,9 @@ export class BsColorPickerValueAccessor implements ControlValueAccessor {
   }
 
   writeValue(value: string | null) {
-    if (!value || !this.host || !this.host.colorWheel()) return;
+    if (!value) return;
     const hsv = hex2hsv(value);
+    this.lastHex = rgb2hex(hsv2rgb(hsv));
     this.host.hs.set({ hue: hsv.hue, saturation: hsv.saturation });
     this.host.brightness.set(hsv.value);
   }

--- a/libs/mintplayer-ng-bootstrap/color-picker/index.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/index.ts
@@ -1,3 +1,4 @@
+export * from './color-math';
 export * from './components';
 export * from './directives';
 export * from './interfaces';

--- a/libs/mintplayer-ng-bootstrap/color-picker/interfaces/hs.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/interfaces/hs.ts
@@ -1,3 +1,8 @@
+/**
+ * Hue + Saturation pair shared between the wheel and the strips.
+ * Saturation is HSV-saturation (0..1) — at S=0 the color is white at V=1
+ * and gray at V<1. (Not HSL-saturation; HSL would put gray at S=0 regardless of L.)
+ */
 export interface HS {
     hue: number;
     saturation: number;

--- a/libs/mintplayer-ng-bootstrap/color-picker/interfaces/hsv-color.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/interfaces/hsv-color.ts
@@ -1,0 +1,5 @@
+export interface HsvColor {
+    hue: number;
+    saturation: number;
+    value: number;
+}

--- a/libs/mintplayer-ng-bootstrap/color-picker/interfaces/index.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './rgb-color';
 export * from './hsl-color';
+export * from './hsv-color';
 export * from './hs';

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.26.0",
+  "version": "21.27.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
## Summary

- Switch the color wheel from HSL (S as radius, fixed L=50%) to HSV (S as radius, V slider). White center, pure-hue rim — vibrant by default, full sRGB still reachable.
- Wheel renders via stacked CSS gradients (radial white→transparent on top of conic hue) — no canvas, crisp at any DPR. Brightness slider just dims an overlay, never re-renders the wheel.
- Hit-testing uses closed-form polar math; the canvas `getImageData` reverse-lookup is gone.
- New `color-math` module is the single source for rgb/hsl/hsv/hex + polar conversions; replaces the duplicated `rgb2Hsl` blocks in the wheel and the value accessor.
- `luminosity-strip` → `brightness-strip` via `git mv` (history preserved). HS interface flips to HSV semantics. `diameterRatio` removed (dead code).
- Hex `[(ngModel)]` contract on `<bs-color-picker>` is unchanged — Forms-driven consumers don't need to touch a line.

Clean break per the [PRD](https://github.com/MintPlayer/mintplayer-ng-bootstrap/blob/feat/color-picker-hsv-wheel/libs/mintplayer-ng-bootstrap/color-picker/PRD-color-wheel-redesign.md): no soft migration, no shims, no `[mode]` toggle.

Bumps `@mintplayer/ng-bootstrap` 21.26.0 → 21.27.0.

## Test plan

- [x] `nx build mintplayer-ng-bootstrap` clean
- [x] `nx test mintplayer-ng-bootstrap` — 396/396 pass, including new color-math round-trip suite
- [x] `nx build ng-bootstrap-demo` clean
- [x] Manual: wheel shows full rainbow with white center; brightness slider darkens uniformly; thumb drag round-trips through the native `<input type="color">` correctly.
- [ ] Reviewer eyeball: compare side-by-side with iro.js to confirm parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)