### PR TITLE
fix(color-picker): post-merge follow-ups for HSV redesign

### DIFF
--- a/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.html
@@ -1,6 +1,4 @@
-<bs-slider [disabled]="disabled()" [value]="alpha()" (valueChange)="alphaChange.emit($event)">
-    <canvas bsTrack class=" track position-absolute w-100" #track></canvas>
-
-    <!-- [style.background]="resultBackground()" -->
+<bs-slider [disabled]="disabled()" [value]="alpha()" (valueChange)="alpha.set($event)">
+    <div bsTrack class="position-absolute w-100" [style.background]="trackGradient()"></div>
     <div bsThumb [style.background]="resultBackground()"></div>
 </bs-slider>

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.scss
@@ -1,5 +1,19 @@
+$size: 8px;
+$thumb: 3 * $size;
+
 .track {
+    height: $size;
+    border-radius: $size;
     background-image: linear-gradient(45deg, #C0C0C0 25%, transparent 25%), linear-gradient(-45deg, #C0C0C0 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #C0C0C0 75%), linear-gradient(-45deg, transparent 75%, #C0C0C0 75%);
     background-size: 10px 10px;
     background-position: 0 0, 0 5px, 5px -5px, -5px 0px;
+}
+
+.thumb {
+    width: $thumb;
+    height: $thumb;
+    top: 0;
+    transform: translateX(-50%);
+    border-radius: 50%;
+    box-shadow: 0 0 0 0.1rem rgba(100, 107, 114, 0.25);
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/alpha-strip/alpha-strip.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, input, model, output, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
 import { HS } from '../../interfaces/hs';
 import { BsSliderComponent, BsThumbDirective, BsTrackDirective } from '../slider/slider.component';
 import { hsv2rgb } from '../../color-math';
@@ -11,15 +11,18 @@ import { hsv2rgb } from '../../color-math';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BsAlphaStripComponent {
-  readonly canvas = viewChild.required<ElementRef<HTMLCanvasElement>>('track');
-
   disabled = input<boolean>(false);
   hs = model<HS>({ hue: 0, saturation: 0 });
   brightness = model<number>(1);
   alpha = model<number>(1);
-  alphaChange = output<number>();
 
-  private canvasContext: CanvasRenderingContext2D | null = null;
+  trackGradient = computed(() => {
+    const hs = this.hs();
+    const brightness = this.brightness();
+    const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
+    const r = Math.round(rgb.r), g = Math.round(rgb.g), b = Math.round(rgb.b);
+    return `linear-gradient(to right, rgba(${r}, ${g}, ${b}, 0), rgba(${r}, ${g}, ${b}, 1))`;
+  });
 
   resultBackground = computed(() => {
     const hs = this.hs();
@@ -28,38 +31,4 @@ export class BsAlphaStripComponent {
     const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
     return `rgba(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)}, ${alpha})`;
   });
-
-  constructor() {
-    effect(() => {
-      const hs = this.hs();
-      const brightness = this.brightness();
-      setTimeout(() => {
-        if (this.canvasContext) {
-          const width = this.canvas().nativeElement.width;
-          const height = this.canvas().nativeElement.height;
-          this.canvasContext.clearRect(0, 0, width, height);
-          this.canvasContext.save();
-
-          const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
-          const r = Math.round(rgb.r), g = Math.round(rgb.g), b = Math.round(rgb.b);
-          const gradient = this.canvasContext.createLinearGradient(0, 0, width, 0);
-          gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, 0)`);
-          gradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, 1)`);
-          this.canvasContext.fillStyle = gradient;
-          this.canvasContext.fillRect(0, 0, width, height);
-        }
-      });
-    });
-
-    effect(() => {
-      const alpha = this.alpha();
-      this.alphaChange.emit(alpha);
-    });
-  }
-
-  ngAfterViewInit() {
-    if (typeof window !== 'undefined') {
-      this.canvasContext = this.canvas().nativeElement.getContext('2d', { willReadFrequently: true });
-    }
-  }
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.html
@@ -1,4 +1,4 @@
-<bs-slider [disabled]="disabled()" [value]="brightness()" (valueChange)="brightnessChange.emit($event)">
-    <canvas bsTrack class="position-absolute w-100" #canvas></canvas>
+<bs-slider [disabled]="disabled()" [value]="brightness()" (valueChange)="brightness.set($event)">
+    <div bsTrack class="position-absolute w-100" [style.background]="trackGradient()"></div>
     <div bsThumb [style.background]="resultBackground()"></div>
 </bs-slider>

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.scss
@@ -1,0 +1,16 @@
+$size: 8px;
+$thumb: 3 * $size;
+
+.track {
+    height: $size;
+    border-radius: $size;
+}
+
+.thumb {
+    width: $thumb;
+    height: $thumb;
+    top: 0;
+    transform: translateX(-50%);
+    border-radius: 50%;
+    box-shadow: 0 0 0 0.1rem rgba(100, 107, 114, 0.25);
+}

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/brightness-strip/brightness-strip.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, input, model, output, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
 import { HS } from '../../interfaces/hs';
 import { BsSliderComponent, BsThumbDirective, BsTrackDirective } from '../slider/slider.component';
 import { hsv2rgb } from '../../color-math';
@@ -11,14 +11,15 @@ import { hsv2rgb } from '../../color-math';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BsBrightnessStripComponent {
-  readonly canvas = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
-
   disabled = input<boolean>(false);
   hs = model<HS>({ hue: 0, saturation: 0 });
   brightness = model<number>(1);
-  brightnessChange = output<number>();
 
-  private canvasContext: CanvasRenderingContext2D | null = null;
+  trackGradient = computed(() => {
+    const hs = this.hs();
+    const peak = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: 1 });
+    return `linear-gradient(to right, #000, rgb(${Math.round(peak.r)}, ${Math.round(peak.g)}, ${Math.round(peak.b)}))`;
+  });
 
   resultBackground = computed(() => {
     const hs = this.hs();
@@ -26,34 +27,4 @@ export class BsBrightnessStripComponent {
     const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
     return `rgb(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)})`;
   });
-
-  constructor() {
-    effect(() => {
-      const hs = this.hs();
-      if (this.canvasContext) {
-        const width = this.canvas().nativeElement.width;
-        const height = this.canvas().nativeElement.height;
-        this.canvasContext.clearRect(0, 0, width, height);
-        this.canvasContext.save();
-
-        const peak = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: 1 });
-        const gradient = this.canvasContext.createLinearGradient(0, 0, width, 0);
-        gradient.addColorStop(0, 'rgb(0, 0, 0)');
-        gradient.addColorStop(1, `rgb(${Math.round(peak.r)}, ${Math.round(peak.g)}, ${Math.round(peak.b)})`);
-        this.canvasContext.fillStyle = gradient;
-        this.canvasContext.fillRect(0, 0, width, height);
-      }
-    });
-
-    effect(() => {
-      const brightness = this.brightness();
-      this.brightnessChange.emit(brightness);
-    });
-  }
-
-  ngAfterViewInit() {
-    if (typeof window !== 'undefined') {
-      this.canvasContext = this.canvas().nativeElement.getContext('2d', { willReadFrequently: true });
-    }
-  }
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.html
@@ -3,8 +3,8 @@
 @let letBrightness = brightness();
 @let letAlpha = alpha();
 
-<bs-color-wheel [disabled]="letDisabled" [hs]="letHS" (hsChange)="hs.set($event)" [brightness]="letBrightness" [width]="size()" [height]="size()" #wheel></bs-color-wheel>
-<bs-brightness-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" (brightnessChange)="brightness.set($event)" class="d-block mt-2" [style.width.px]="size()" #strip></bs-brightness-strip>
+<bs-color-wheel [disabled]="letDisabled" [hs]="letHS" (hsChange)="onUserHsChange($event)" [brightness]="letBrightness" [width]="size()" [height]="size()" #wheel></bs-color-wheel>
+<bs-brightness-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" (brightnessChange)="onUserBrightnessChange($event)" class="d-block mt-2" [style.width.px]="size()" #strip></bs-brightness-strip>
 @if (allowAlpha()) {
     <bs-alpha-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" [alpha]="letAlpha" (alphaChange)="alpha.set($event)" class="d-block mt-2" [style.width.px]="size()" #alphaStrip></bs-alpha-strip>
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.html
@@ -6,5 +6,5 @@
 <bs-color-wheel [disabled]="letDisabled" [hs]="letHS" (hsChange)="onUserHsChange($event)" [brightness]="letBrightness" [width]="size()" [height]="size()" #wheel></bs-color-wheel>
 <bs-brightness-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" (brightnessChange)="onUserBrightnessChange($event)" class="d-block mt-2" [style.width.px]="size()" #strip></bs-brightness-strip>
 @if (allowAlpha()) {
-    <bs-alpha-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" [alpha]="letAlpha" (alphaChange)="alpha.set($event)" class="d-block mt-2" [style.width.px]="size()" #alphaStrip></bs-alpha-strip>
+    <bs-alpha-strip [disabled]="letDisabled" [hs]="letHS" [brightness]="letBrightness" [alpha]="letAlpha" (alphaChange)="onUserAlphaChange($event)" class="d-block mt-2" [style.width.px]="size()" #alphaStrip></bs-alpha-strip>
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.spec.ts
@@ -1,38 +1,137 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MockComponent, MockDirective } from 'ng-mocks';
+import { MockComponent } from 'ng-mocks';
 
 import { BsColorPickerComponent } from './color-picker.component';
+import { BsColorPickerValueAccessor } from '../../directives/color-picker-value-accessor/color-picker-value-accessor.directive';
 import { BsAlphaStripComponent } from '../alpha-strip/alpha-strip.component';
 import { BsBrightnessStripComponent } from '../brightness-strip/brightness-strip.component';
 import { BsColorWheelComponent } from '../color-wheel/color-wheel.component';
 
 describe('ColorPickerComponent', () => {
   let component: BsColorPickerComponent;
+  let accessor: BsColorPickerValueAccessor;
   let fixture: ComponentFixture<BsColorPickerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        // Mock dependencies,
-        // Unit to test
         BsColorPickerComponent,
-
-        // Mock dependencies
         MockComponent(BsAlphaStripComponent),
         MockComponent(BsBrightnessStripComponent),
         MockComponent(BsColorWheelComponent),
       ]
-    })
-    .compileComponents();
+    }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(BsColorPickerComponent);
     component = fixture.componentInstance;
+    accessor = fixture.debugElement.injector.get(BsColorPickerValueAccessor);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('writeValue', () => {
+    it('parses a 6-digit hex into hue/saturation/brightness', () => {
+      accessor.writeValue('#0000FF');
+      expect(component.hs().hue).toBeCloseTo(240, 0);
+      expect(component.hs().saturation).toBeCloseTo(1, 5);
+      expect(component.brightness()).toBeCloseTo(1, 5);
+    });
+
+    it('parses a 3-digit hex', () => {
+      accessor.writeValue('#f00');
+      expect(component.hs().hue).toBeCloseTo(0, 0);
+      expect(component.hs().saturation).toBeCloseTo(1, 5);
+      expect(component.brightness()).toBeCloseTo(1, 5);
+    });
+
+    it('does NOT echo back to onChange — the form value is preserved across writeValue', () => {
+      let echoes = 0;
+      accessor.registerOnChange(() => echoes++);
+      accessor.writeValue('#0000FF');
+      expect(echoes).toBe(0);
+    });
+
+    it('does not touch the orthogonal alpha model', () => {
+      component.alpha.set(0.5);
+      accessor.writeValue('#0000FF');
+      expect(component.alpha()).toBe(0.5);
+    });
+
+    it('ignores null and empty values', () => {
+      const before = component.hs();
+      accessor.writeValue(null);
+      accessor.writeValue('');
+      expect(component.hs()).toBe(before);
+    });
+  });
+
+  describe('user-driven changes', () => {
+    it('onUserHsChange sets hs and fires userChanged', () => {
+      let fires = 0;
+      component.userChanged.subscribe(() => fires++);
+      component.onUserHsChange({ hue: 120, saturation: 1 });
+      expect(component.hs()).toEqual({ hue: 120, saturation: 1 });
+      expect(fires).toBe(1);
+    });
+
+    it('onUserBrightnessChange sets brightness and fires userChanged', () => {
+      let fires = 0;
+      component.userChanged.subscribe(() => fires++);
+      component.onUserBrightnessChange(0.5);
+      expect(component.brightness()).toBe(0.5);
+      expect(fires).toBe(1);
+    });
+
+    it('onUserAlphaChange sets alpha and fires userChanged', () => {
+      let fires = 0;
+      component.userChanged.subscribe(() => fires++);
+      component.onUserAlphaChange(0.3);
+      expect(component.alpha()).toBe(0.3);
+      expect(fires).toBe(1);
+    });
+  });
+
+  describe('value accessor emit', () => {
+    it('emits hex to onChange on user-driven hs/brightness change', () => {
+      const emitted: string[] = [];
+      accessor.registerOnChange(hex => emitted.push(hex));
+      component.onUserHsChange({ hue: 0, saturation: 1 });
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].toLowerCase()).toBe('#ff0000');
+    });
+
+    it('calls onTouched on user-driven change', () => {
+      let touched = 0;
+      accessor.registerOnTouched(() => touched++);
+      component.onUserBrightnessChange(0.5);
+      expect(touched).toBe(1);
+    });
+
+    it('alpha changes also fire onTouched (but the emitted hex is still the brightness color)', () => {
+      let touched = 0;
+      const emitted: string[] = [];
+      accessor.registerOnTouched(() => touched++);
+      accessor.registerOnChange(hex => emitted.push(hex));
+      accessor.writeValue('#FF0000');
+      component.onUserAlphaChange(0.3);
+      expect(touched).toBe(1);
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].toLowerCase()).toBe('#ff0000');
+    });
+
+    it('round-trips hex through writeValue + immediate user change', () => {
+      const emitted: string[] = [];
+      accessor.registerOnChange(hex => emitted.push(hex));
+      accessor.writeValue('#0000FF');
+      // Same color round-trips: drag the wheel back to (240, 1) at brightness 1
+      component.onUserHsChange({ hue: 240, saturation: 1 });
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].toLowerCase()).toBe('#0000ff');
+    });
   });
 });

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.ts
@@ -43,4 +43,9 @@ export class BsColorPickerComponent {
     this.brightness.set(brightness);
     this.userChanged.next();
   }
+
+  onUserAlphaChange(alpha: number) {
+    this.alpha.set(alpha);
+    this.userChanged.next();
+  }
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-picker/color-picker.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, effect, input, model, output, signal, viewChild } from "@angular/core";
+import { ChangeDetectionStrategy, Component, input, model, signal, viewChild } from "@angular/core";
+import { Subject } from "rxjs";
 import { HS } from "../../interfaces/hs";
 import { BsColorPickerValueAccessor } from "../../directives/color-picker-value-accessor/color-picker-value-accessor.directive";
 import { BsColorWheelComponent } from "../color-wheel/color-wheel.component";
@@ -25,12 +26,21 @@ export class BsColorPickerComponent {
   brightness = signal<number>(1);
 
   alpha = model<number>(1);
-  alphaChange = output<number>();
 
-  constructor() {
-    effect(() => {
-      const alpha = this.alpha();
-      this.alphaChange.emit(alpha);
-    });
+  /**
+   * Fires when the user drives a change (drags the wheel or the brightness strip).
+   * The value accessor subscribes to this so it only emits to the form on real
+   * user actions — not on writeValue echoes or initial signal-default state.
+   */
+  readonly userChanged = new Subject<void>();
+
+  onUserHsChange(hs: HS) {
+    this.hs.set(hs);
+    this.userChanged.next();
+  }
+
+  onUserBrightnessChange(brightness: number) {
+    this.brightness.set(brightness);
+    this.userChanged.next();
   }
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.html
@@ -18,6 +18,6 @@
          [style.height.px]="squareSize()"></div>
 
     @if (markerPosition(); as markerPosition) {
-        <div class="thumb position-absolute pe-none" [style.left.px]="markerPosition.x" [style.top.px]="markerPosition.y"></div>
+        <div class="marker position-absolute pe-none" [style.left.px]="markerPosition.x" [style.top.px]="markerPosition.y"></div>
     }
 </div>

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.scss
@@ -15,7 +15,7 @@ $thumb-size: 30px;
     transition: opacity 60ms linear;
 }
 
-.thumb {
+.marker {
     width: $thumb-size;
     height: $thumb-size;
     border-radius: calc($thumb-size / 2);

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/color-wheel/color-wheel.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BsColorWheelComponent } from './color-wheel.component';
+import { hs2polar } from '../../color-math';
 
 describe('BsColorWheelComponent', () => {
   let component: BsColorWheelComponent;
@@ -9,15 +10,73 @@ describe('BsColorWheelComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ BsColorWheelComponent ]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(BsColorWheelComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('width', 200);
+    fixture.componentRef.setInput('height', 200);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('markerPosition', () => {
+    it('places marker at disc center for saturation = 0', () => {
+      component.hs.set({ hue: 0, saturation: 0 });
+      const marker = component.markerPosition();
+      expect(marker.x).toBeCloseTo(100, 5);
+      expect(marker.y).toBeCloseTo(100, 5);
+    });
+
+    it('places marker on rim at hue=0 (3 o\'clock) for full saturation', () => {
+      component.hs.set({ hue: 0, saturation: 1 });
+      const marker = component.markerPosition();
+      expect(marker.x).toBeCloseTo(200, 5);
+      expect(marker.y).toBeCloseTo(100, 5);
+    });
+
+    it('matches hs2polar for blue (hue=240, sat=1)', () => {
+      component.hs.set({ hue: 240, saturation: 1 });
+      const polar = hs2polar(240, 1, 100);
+      const marker = component.markerPosition();
+      expect(marker.x).toBeCloseTo(100 + polar.dx, 5);
+      expect(marker.y).toBeCloseTo(100 + polar.dy, 5);
+    });
+
+    it('shifts horizontally for non-square width > height (centered disc)', () => {
+      fixture.componentRef.setInput('width', 300);
+      fixture.componentRef.setInput('height', 200);
+      component.hs.set({ hue: 0, saturation: 0 });
+      const marker = component.markerPosition();
+      expect(marker.x).toBeCloseTo(150, 5);
+      expect(marker.y).toBeCloseTo(100, 5);
+    });
+
+    it('handles half-saturation as half-radius', () => {
+      component.hs.set({ hue: 0, saturation: 0.5 });
+      const marker = component.markerPosition();
+      expect(marker.x).toBeCloseTo(150, 5);
+      expect(marker.y).toBeCloseTo(100, 5);
+    });
+  });
+
+  describe('overlayOpacity', () => {
+    it('is 0 at brightness=1', () => {
+      fixture.componentRef.setInput('brightness', 1);
+      expect(component.overlayOpacity()).toBe(0);
+    });
+
+    it('is 1 at brightness=0', () => {
+      fixture.componentRef.setInput('brightness', 0);
+      expect(component.overlayOpacity()).toBe(1);
+    });
+
+    it('is 0.5 at brightness=0.5', () => {
+      fixture.componentRef.setInput('brightness', 0.5);
+      expect(component.overlayOpacity()).toBe(0.5);
+    });
   });
 });

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.html
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.html
@@ -12,7 +12,7 @@
         (touchmove)="onPointerMove($event)"
         (touchend)="onPointerUp($event)"
         [class]="cursorClass()"
-        [style.margin-left.px]="thumbMarginLeft()">
+        [style.left]="thumbLeft()">
         <ng-content select="[bsThumb]"></ng-content>
     </div>
 </div>

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.scss
@@ -15,8 +15,7 @@ $thumb: 3 * $size;
         width: $thumb;
         height: $thumb;
         top: 0;
-        // margin-top: -$size;
-        // margin-bottom: -$size;
+        transform: translateX(-50%);
         border-radius: 50%;
         box-shadow: 0 0 0 0.1rem rgba(100, 107, 114, 0.25);
     }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.scss
@@ -1,5 +1,4 @@
 $size: 8px;
-$thumb: 3 * $size;
 
 .track2 {
     height: $size;
@@ -8,20 +7,4 @@ $thumb: 3 * $size;
 .wrapper {
     padding-top: $size;
     padding-bottom: $size;
-}
-
-:host ::ng-deep {
-    .thumb {
-        width: $thumb;
-        height: $thumb;
-        top: 0;
-        transform: translateX(-50%);
-        border-radius: 50%;
-        box-shadow: 0 0 0 0.1rem rgba(100, 107, 114, 0.25);
-    }
-
-    .track {
-        height: $size;
-        border-radius: $size;
-    }
 }

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.scss
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.scss
@@ -10,7 +10,7 @@ $thumb: 3 * $size;
     padding-bottom: $size;
 }
 
-::ng-deep {
+:host ::ng-deep {
     .thumb {
         width: $thumb;
         height: $thumb;

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.spec.ts
@@ -9,8 +9,7 @@ describe('BsSliderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ BsSliderComponent ]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(BsSliderComponent);
     component = fixture.componentInstance;
@@ -19,5 +18,35 @@ describe('BsSliderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('thumbLeft', () => {
+    it('returns 0% at value=0', () => {
+      component.value.set(0);
+      expect(component.thumbLeft()).toBe('0%');
+    });
+
+    it('returns 50% at value=0.5', () => {
+      component.value.set(0.5);
+      expect(component.thumbLeft()).toBe('50%');
+    });
+
+    it('returns 100% at value=1', () => {
+      component.value.set(1);
+      expect(component.thumbLeft()).toBe('100%');
+    });
+
+    it('returns 25% at value=0.25', () => {
+      component.value.set(0.25);
+      expect(component.thumbLeft()).toBe('25%');
+    });
+  });
+
+  describe('cursorClass', () => {
+    it('contains position-absolute and top-0 so [style.left] takes effect and aligns vertically', () => {
+      const cls = component.cursorClass();
+      expect(cls).toContain('position-absolute');
+      expect(cls).toContain('top-0');
+    });
   });
 });

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.ts
@@ -1,12 +1,10 @@
-import { ChangeDetectionStrategy, Component, computed, Directive, ElementRef, effect, inject, input, model, output, signal, viewChild } from '@angular/core';
-import { BsObserveSizeDirective } from '@mintplayer/ng-swiper/observe-size';
+import { ChangeDetectionStrategy, Component, computed, Directive, ElementRef, input, model, signal, viewChild } from '@angular/core';
 
 @Component({
   selector: 'bs-slider',
   templateUrl: './slider.component.html',
   styleUrls: ['./slider.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  hostDirectives: [BsObserveSizeDirective],
   host: {
     'class': 'd-block position-relative',
     '(document:mousemove)': 'onPointerMove($event)',
@@ -14,31 +12,16 @@ import { BsObserveSizeDirective } from '@mintplayer/ng-swiper/observe-size';
   },
 })
 export class BsSliderComponent {
-  private observeSize = inject(BsObserveSizeDirective);
   readonly track = viewChild.required<ElementRef<HTMLDivElement>>('track');
   readonly thumb = viewChild.required<ElementRef<HTMLDivElement>>('thumb');
 
   disabled = input<boolean>(false);
   value = model<number>(0.5);
-  valueChange = output<number>();
   private isPointerDown = signal<boolean>(false);
 
-  thumbMarginLeft = computed(() => {
-    const value = this.value();
-    const width = this.observeSize.width() ?? 0;
-    return value * width - 12;
-  });
+  thumbLeft = computed(() => `${this.value() * 100}%`);
 
-  cursorClass = computed(() => {
-    return this.isPointerDown() ? 'cursor-grabbing' : 'cursor-grab';
-  });
-
-  constructor() {
-    effect(() => {
-      const value = this.value();
-      this.valueChange.emit(value);
-    });
-  }
+  cursorClass = computed(() => this.isPointerDown() ? 'cursor-grabbing' : 'cursor-grab');
 
   onPointerDown(ev: MouseEvent | TouchEvent) {
     if (this.disabled()) return;
@@ -56,26 +39,15 @@ export class BsSliderComponent {
     }
   }
 
-  onPointerUp(ev: MouseEvent | TouchEvent) {
+  onPointerUp(_ev: MouseEvent | TouchEvent) {
     this.isPointerDown.set(false);
   }
 
   private updateColor(ev: MouseEvent | TouchEvent) {
-    let co: { x: number };
     const rect = this.track().nativeElement.getBoundingClientRect();
-    if ('touches' in ev) {
-      co = {
-        x: ev.touches[0].clientX - rect.left,
-      };
-    } else {
-      co = {
-        x: ev.clientX - rect.left,
-      };
-    }
-
-    const percent = co.x / this.track().nativeElement.clientWidth;
-    const limited = Math.max(0, Math.min(1, percent));
-    this.value.set(limited);
+    const clientX = 'touches' in ev ? ev.touches[0].clientX : ev.clientX;
+    const percent = (clientX - rect.left) / this.track().nativeElement.clientWidth;
+    this.value.set(Math.max(0, Math.min(1, percent)));
   }
 }
 

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.ts
@@ -21,7 +21,7 @@ export class BsSliderComponent {
 
   thumbLeft = computed(() => `${this.value() * 100}%`);
 
-  cursorClass = computed(() => this.isPointerDown() ? 'cursor-grabbing' : 'cursor-grab');
+  cursorClass = computed(() => 'position-absolute ' + (this.isPointerDown() ? 'cursor-grabbing' : 'cursor-grab'));
 
   onPointerDown(ev: MouseEvent | TouchEvent) {
     if (this.disabled()) return;

--- a/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/components/slider/slider.component.ts
@@ -21,7 +21,7 @@ export class BsSliderComponent {
 
   thumbLeft = computed(() => `${this.value() * 100}%`);
 
-  cursorClass = computed(() => 'position-absolute ' + (this.isPointerDown() ? 'cursor-grabbing' : 'cursor-grab'));
+  cursorClass = computed(() => 'position-absolute top-0 ' + (this.isPointerDown() ? 'cursor-grabbing' : 'cursor-grab'));
 
   onPointerDown(ev: MouseEvent | TouchEvent) {
     if (this.disabled()) return;

--- a/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, effect, forwardRef, inject } from '@angular/core';
+import { Directive, forwardRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BsColorPickerComponent } from '../../components/color-picker/color-picker.component';
 import { hex2hsv, hsv2rgb, rgb2hex } from '../../color-math';
@@ -18,20 +19,16 @@ export class BsColorPickerValueAccessor implements ControlValueAccessor {
   onValueChange?: (value: string) => void;
   onTouched?: () => void;
 
-  // The hex most recently observed (either written by the form or emitted to it).
-  // Lets the emit effect dedup the echo from writeValue, breaking the round-trip loop.
-  private lastHex: string | null = null;
-
   constructor() {
-    effect(() => {
-      const hs = this.host.hs();
-      const brightness = this.host.brightness();
-      const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
-      const hex = rgb2hex(rgb);
-      if (hex === this.lastHex) return;
-      this.lastHex = hex;
-      this.onValueChange?.(hex);
-    });
+    this.host.userChanged.pipe(takeUntilDestroyed()).subscribe(() => this.emit());
+  }
+
+  private emit() {
+    if (!this.onValueChange) return;
+    const hs = this.host.hs();
+    const brightness = this.host.brightness();
+    const rgb = hsv2rgb({ hue: hs.hue, saturation: hs.saturation, value: brightness });
+    this.onValueChange(rgb2hex(rgb));
   }
 
   registerOnChange(fn: (_: any) => void) {
@@ -45,7 +42,6 @@ export class BsColorPickerValueAccessor implements ControlValueAccessor {
   writeValue(value: string | null) {
     if (!value) return;
     const hsv = hex2hsv(value);
-    this.lastHex = rgb2hex(hsv2rgb(hsv));
     this.host.hs.set({ hue: hsv.hue, saturation: hsv.saturation });
     this.host.brightness.set(hsv.value);
   }

--- a/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/color-picker/directives/color-picker-value-accessor/color-picker-value-accessor.directive.ts
@@ -24,6 +24,7 @@ export class BsColorPickerValueAccessor implements ControlValueAccessor {
   }
 
   private emit() {
+    this.onTouched?.();
     if (!this.onValueChange) return;
     const hs = this.host.hs();
     const brightness = this.host.brightness();

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.27.1",
+  "version": "21.28.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.27.0",
+  "version": "21.27.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
Three related fixes that surfaced after #319 was merged.

## 1. Initial-load form value mismatch

On initial page load, two `[(ngModel)]` bindings on the same `model()` signal could end up displaying different colors — `<bs-color-picker>` showed the bound value while a sibling `<input type="color">` showed white.

**Cause:** the value accessor's constructor `effect()` fired on its first run with the host's default signals (`hs={0,0}`, `brightness=1` → `'#ffffff'`) and called `onValueChange` before `lastHex` was seeded — clobbering the form's actual initial value. This is the documented Angular footgun ([angular#58543](https://github.com/angular/angular/issues/58543), closed *as designed*).

**Fix:** stop emitting from an effect that observes derived state. Match the canonical Material / ng-bootstrap / ng-zorro / PrimeNG pattern — emit only when the user actually drove the change.

- `BsColorPickerComponent` exposes `userChanged: Subject<void>` and `onUserHsChange` / `onUserBrightnessChange` handlers that set the signal then fire the subject.
- `BsColorPickerValueAccessor` subscribes (via `takeUntilDestroyed`) and calls `onValueChange` with the current hex on each user-driven change. The constructor `effect` and the `lastHex` field are gone.
- Side fix: dropped the redundant `alphaChange = output<number>()` and the alpha effect on `BsColorPickerComponent`. `model<number>(1)` already exposes `alphaChange` implicitly for `[(alpha)]`.

## 2. Brightness strip rendered as solid white

The strips had the same canvas-init race the wheel had: the draw effect fires before `ngAfterViewInit` sets `canvasContext`, skips, and never re-fires for the input-signal-bound case. Result: brightness strip stayed empty (showing the slider's white background) until the user dragged the wheel thumb.

**Fix:** drop the canvas in both strips. Render the gradient via `[style.background]` on the `bsTrack` div, driven by a `trackGradient` computed signal. No more init race, no `setTimeout` debounce, crisp at any DPR.

Same shadowing cleanup as above on `BsBrightnessStripComponent` and `BsAlphaStripComponent` — explicit outputs and the redundant emit-effects removed; templates now use `(valueChange)="brightness.set($event)"` etc., letting `model()`'s implicit output do the work on the user-driven `.set()` call.

## 3. Slider thumb jump on SSR hydration

The slider's thumb position was computed in JS as `value * observedWidth - 12`. On SSR the observed width is 0 (no `ResizeObserver` on the server), so the thumb rendered at `margin-left: -12px` regardless of value. After hydration, `ResizeObserver` fired and the thumb jumped to its correct position — visible flicker.

**Fix:** pure-CSS positioning: `left: ${value * 100}%` plus a static `transform: translateX(-50%)` on the thumb to center it on the value point. No layout measurement needed, hydrates clean.

- Drop `BsObserveSizeDirective` from the slider's `hostDirectives` — the only consumer of the observed width is gone.
- Drop the explicit `valueChange = output<number>()` and the constructor effect that re-emitted on every signal change. Same shadow-the-implicit-output anti-pattern.

## Test plan

- [x] `nx build mintplayer-ng-bootstrap` clean
- [x] `nx test mintplayer-ng-bootstrap` — 397/397 pass
- [x] `nx build ng-bootstrap-demo` clean
- [x] Manual: initial load — bs-color-picker AND native input show the same color (blue); brightness strip shows the black→hue gradient immediately, before any user interaction
- [ ] Reviewer eyeball — including SSR/hydration: confirm slider thumbs paint at the correct position on first byte, no jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)