### PR TITLE
fix(scrollspy): support nested scroll containers

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "nrwl.angular-console",
     "esbenp.prettier-vscode",
     "vitest.explorer",
+    "ms-playwright.playwright",
     "dbaeumer.vscode-eslint",
     "somewhatstationery.some-sass"
   ]

--- a/apps/ng-bootstrap-demo-e2e/e2e/scrollspy-modal.spec.ts
+++ b/apps/ng-bootstrap-demo-e2e/e2e/scrollspy-modal.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Regression contract for issue #183 + PR #338:
+// 1. bs-modal[scrollable]=true splits scrolling so modal-body — not the outer
+//    .modal — is the actual scroll container.
+// 2. bs-scrollspy resolves its scroll target to that modal-body and operates
+//    against container-relative geometry.
+// 3. Clicking a TOC entry scrolls the modal-body, never the window/page.
+// 4. Scrolling the modal-body updates the spy's active section.
+
+async function openScrollspyModal(page: Page) {
+  await page.goto('/advanced/scrollspy');
+  // Demo SSR uses destructive bootstrap — wait for hydration before clicking.
+  await page.waitForLoadState('networkidle');
+  await page.getByRole('button', { name: 'Open modal', exact: true }).click();
+  await expect(page.getByText('Scrollspy in modal', { exact: true })).toBeVisible();
+  // The modal animates in via EnterFromTop (animating `top`, not `transform`)
+  // and FadeInOut. Wait for every WAAPI animation under bs-modal-content to
+  // finish — otherwise the dialog is still moving between reads and the
+  // "header is fixed" assertion is fooled by animation progress.
+  await page.waitForFunction(() => {
+    const host = document.querySelector('bs-modal-content');
+    if (!host) return false;
+    const anims = (host as Element & { getAnimations?: (opts?: { subtree?: boolean }) => Animation[] })
+      .getAnimations?.({ subtree: true }) ?? [];
+    return anims.every((a) => a.playState === 'finished' || a.playState === 'idle');
+  });
+}
+
+test.describe('scrollspy inside a scrollable modal', () => {
+  test('modal-body is the scroll container, .modal does not scroll', async ({ page }) => {
+    await openScrollspyModal(page);
+
+    const result = await page.evaluate(() => {
+      const modal = document.querySelector('bs-modal-content .modal') as HTMLElement;
+      const modalBody = document.querySelector('bs-modal-content .modal-body') as HTMLElement;
+      const cs = getComputedStyle(modalBody);
+      return {
+        bodyOverflowY: cs.overflowY,
+        bodyScrollable: modalBody.scrollHeight > modalBody.clientHeight,
+        modalScrollHeight: modal.scrollHeight,
+        modalClientHeight: modal.clientHeight,
+      };
+    });
+
+    expect(result.bodyOverflowY).toBe('auto');
+    expect(result.bodyScrollable).toBe(true);
+    // The outer .modal stays the same size as its viewport — no content to scroll.
+    expect(result.modalScrollHeight).toBe(result.modalClientHeight);
+  });
+
+  test('scrolling modal-body leaves the header fixed and the outer .modal untouched', async ({ page }) => {
+    await openScrollspyModal(page);
+
+    const result = await page.evaluate(async () => {
+      const modal = document.querySelector('bs-modal-content .modal') as HTMLElement;
+      const modalBody = document.querySelector('bs-modal-content .modal-body') as HTMLElement;
+      const modalHeader = document.querySelector('bs-modal-content .modal-header') as HTMLElement;
+
+      const headerTopBefore = modalHeader.getBoundingClientRect().top;
+      const modalScrollTopBefore = modal.scrollTop;
+
+      modalBody.scrollTop = 400;
+      await new Promise((r) => setTimeout(r, 50));
+
+      const headerTopAfter = modalHeader.getBoundingClientRect().top;
+      const modalScrollTopAfter = modal.scrollTop;
+      const bodyScrollTopAfter = modalBody.scrollTop;
+
+      return {
+        headerTopBefore: Math.round(headerTopBefore),
+        headerTopAfter: Math.round(headerTopAfter),
+        modalScrollTopBefore,
+        modalScrollTopAfter,
+        bodyScrollTopAfter,
+      };
+    });
+
+    // modal-body actually scrolled.
+    expect(result.bodyScrollTopAfter).toBeGreaterThan(0);
+    // Header did not move.
+    expect(result.headerTopAfter).toBe(result.headerTopBefore);
+    // The outer .modal did not scroll along.
+    expect(result.modalScrollTopAfter).toBe(result.modalScrollTopBefore);
+  });
+
+  test('clicking a TOC entry scrolls modal-body, not the window', async ({ page }) => {
+    await openScrollspyModal(page);
+
+    const before = await page.evaluate(() => {
+      const modalBody = document.querySelector('bs-modal-content .modal-body') as HTMLElement;
+      return { windowY: window.scrollY, bodyScrollTop: modalBody.scrollTop };
+    });
+
+    // Click "Warning" inside the modal's TOC (the inner scrollspy nav.spy).
+    await page.locator('bs-modal-content nav.spy button', { hasText: 'Warning' }).click();
+
+    // Wait for smooth-scroll to settle: poll modal-body.scrollTop until it is non-zero.
+    await page.waitForFunction(() => {
+      const mb = document.querySelector('bs-modal-content .modal-body') as HTMLElement | null;
+      return mb !== null && mb.scrollTop > 0;
+    });
+
+    const after = await page.evaluate(() => {
+      const modalBody = document.querySelector('bs-modal-content .modal-body') as HTMLElement;
+      return { windowY: window.scrollY, bodyScrollTop: modalBody.scrollTop };
+    });
+
+    expect(after.bodyScrollTop).toBeGreaterThan(0);
+    expect(after.windowY).toBe(before.windowY);
+  });
+
+  test('scrolling modal-body updates the active TOC entry', async ({ page }) => {
+    await openScrollspyModal(page);
+
+    // Active section starts on the first one.
+    const initialActive = await page.evaluate(() => {
+      return document.querySelector('bs-modal-content nav.spy button.fw-bold')?.textContent?.trim() ?? null;
+    });
+    expect(initialActive).toBe('Primary');
+
+    // Scroll modal-body far enough to push several headings above the trigger line.
+    await page.evaluate(async () => {
+      const modalBody = document.querySelector('bs-modal-content .modal-body') as HTMLElement;
+      modalBody.scrollTop = modalBody.scrollHeight; // bottom
+      await new Promise((r) => setTimeout(r, 80));
+    });
+
+    const finalActive = await page.evaluate(() => {
+      return document.querySelector('bs-modal-content nav.spy button.fw-bold')?.textContent?.trim() ?? null;
+    });
+
+    expect(finalActive).not.toBe(initialActive);
+    expect(finalActive).not.toBeNull();
+  });
+});

--- a/apps/ng-bootstrap-demo-e2e/e2e/scrollspy-modal.spec.ts
+++ b/apps/ng-bootstrap-demo-e2e/e2e/scrollspy-modal.spec.ts
@@ -110,6 +110,48 @@ test.describe('scrollspy inside a scrollable modal', () => {
     expect(after.windowY).toBe(before.windowY);
   });
 
+  test('opening and closing the modal preserves the page scroll position', async ({ page }) => {
+    await page.goto('/advanced/scrollspy');
+    await page.waitForLoadState('networkidle');
+
+    // Scroll the page down before opening the modal. The trigger button is
+    // now well above the viewport — focus restore on close used to yank the
+    // page back to the trigger, which we want to never happen again.
+    await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'instant' }));
+    await page.waitForFunction(() => window.scrollY === 800);
+
+    // Trigger via DOM rather than playwright's .click() so the framework's
+    // auto-scroll-into-view does not move the page itself before measurement.
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Open modal');
+      btn?.click();
+    });
+    await expect(page.getByText('Scrollspy in modal', { exact: true })).toBeVisible();
+    await page.waitForFunction(() => {
+      const host = document.querySelector('bs-modal-content');
+      if (!host) return false;
+      const anims = (host as Element & { getAnimations?: (opts?: { subtree?: boolean }) => Animation[] })
+        .getAnimations?.({ subtree: true }) ?? [];
+      return anims.every((a) => a.playState === 'finished' || a.playState === 'idle');
+    });
+
+    const afterOpen = await page.evaluate(() => window.scrollY);
+    expect(afterOpen).toBe(800);
+
+    await page.evaluate(() => {
+      const closeBtn = document.querySelector('bs-modal-content button.btn-close') as HTMLButtonElement | null;
+      closeBtn?.click();
+    });
+    // Wait for the modal to leave (no more bs-modal-content in DOM, or no running animations).
+    await page.waitForFunction(() => {
+      const host = document.querySelector('bs-modal-content .modal');
+      return host === null;
+    });
+
+    const afterClose = await page.evaluate(() => window.scrollY);
+    expect(afterClose).toBe(800);
+  });
+
   test('scrolling modal-body updates the active TOC entry', async ({ page }) => {
     await openScrollspyModal(page);
 

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.html
@@ -1,5 +1,8 @@
 <bs-scrollspy style="padding-top:50px">
     <h1 bsScrollspy class="text-center">Scrollspy</h1>
+    <h2 bsScrollspy>Scrollspy inside a modal</h2>
+    <p>Issue <a href="https://github.com/MintPlayer/mintplayer-ng-bootstrap/issues/183" target="_blank">#183</a> &mdash; rendering breaks when the spy is inside a modal.</p>
+    <button [color]="colors.primary" (click)="isModalOpen.set(!isModalOpen())">Open modal</button>
     <h2 bsScrollspy>Some colors</h2>
     <h3 bsScrollspy>Primary</h3>
     <div class="container bg-primary"></div>
@@ -19,3 +22,28 @@
     <h3 bsScrollspy>Dark</h3>
     <div class="container bg-dark"></div>
 </bs-scrollspy>
+
+<bs-modal [(isOpen)]="isModalOpen">
+    <div *bsModal>
+        <bs-scrollspy style="padding-top:50px">
+            <h2>Modal</h2>
+            <h3 bsScrollspy>Primary</h3>
+            <div class="container compact bg-primary"></div>
+            <h3 bsScrollspy>Secondary</h3>
+            <div class="container compact bg-secondary"></div>
+            <h3 bsScrollspy>Success</h3>
+            <div class="container compact bg-success"></div>
+            <h3 bsScrollspy>Danger</h3>
+            <div class="container compact bg-danger"></div>
+            <h2 bsScrollspy>Some more colors</h2>
+            <h3 bsScrollspy>Warning</h3>
+            <div class="container compact bg-warning"></div>
+            <h3 bsScrollspy>Info</h3>
+            <div class="container compact bg-info"></div>
+            <h3 bsScrollspy>Light</h3>
+            <div class="container compact bg-light"></div>
+            <h3 bsScrollspy>Dark</h3>
+            <div class="container compact bg-dark"></div>
+        </bs-scrollspy>
+    </div>
+</bs-modal>

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.html
@@ -1,7 +1,6 @@
 <bs-scrollspy style="padding-top:50px">
     <h1 bsScrollspy class="text-center">Scrollspy</h1>
     <h2 bsScrollspy>Scrollspy inside a modal</h2>
-    <p>Issue <a href="https://github.com/MintPlayer/mintplayer-ng-bootstrap/issues/183" target="_blank">#183</a> &mdash; rendering breaks when the spy is inside a modal.</p>
     <button [color]="colors.primary" (click)="isModalOpen.set(!isModalOpen())">Open modal</button>
     <h2 bsScrollspy>Some colors</h2>
     <h3 bsScrollspy>Primary</h3>

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.html
@@ -23,27 +23,33 @@
     <div class="container bg-dark"></div>
 </bs-scrollspy>
 
-<bs-modal [(isOpen)]="isModalOpen">
+<bs-modal [(isOpen)]="isModalOpen" [scrollable]="true">
     <div *bsModal>
-        <bs-scrollspy style="padding-top:50px">
-            <h2>Modal</h2>
-            <h3 bsScrollspy>Primary</h3>
-            <div class="container compact bg-primary"></div>
-            <h3 bsScrollspy>Secondary</h3>
-            <div class="container compact bg-secondary"></div>
-            <h3 bsScrollspy>Success</h3>
-            <div class="container compact bg-success"></div>
-            <h3 bsScrollspy>Danger</h3>
-            <div class="container compact bg-danger"></div>
-            <h2 bsScrollspy>Some more colors</h2>
-            <h3 bsScrollspy>Warning</h3>
-            <div class="container compact bg-warning"></div>
-            <h3 bsScrollspy>Info</h3>
-            <div class="container compact bg-info"></div>
-            <h3 bsScrollspy>Light</h3>
-            <div class="container compact bg-light"></div>
-            <h3 bsScrollspy>Dark</h3>
-            <div class="container compact bg-dark"></div>
-        </bs-scrollspy>
+        <div bsModalHeader>
+            <h5 class="modal-title flex-grow-1">Scrollspy in modal</h5>
+            <bs-close bsModalClose></bs-close>
+        </div>
+        <div bsModalBody>
+            <bs-scrollspy>
+                <h2>Modal</h2>
+                <h3 bsScrollspy>Primary</h3>
+                <div class="container compact bg-primary"></div>
+                <h3 bsScrollspy>Secondary</h3>
+                <div class="container compact bg-secondary"></div>
+                <h3 bsScrollspy>Success</h3>
+                <div class="container compact bg-success"></div>
+                <h3 bsScrollspy>Danger</h3>
+                <div class="container compact bg-danger"></div>
+                <h2 bsScrollspy>Some more colors</h2>
+                <h3 bsScrollspy>Warning</h3>
+                <div class="container compact bg-warning"></div>
+                <h3 bsScrollspy>Info</h3>
+                <div class="container compact bg-info"></div>
+                <h3 bsScrollspy>Light</h3>
+                <div class="container compact bg-light"></div>
+                <h3 bsScrollspy>Dark</h3>
+                <div class="container compact bg-dark"></div>
+            </bs-scrollspy>
+        </div>
     </div>
 </bs-modal>

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.scss
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.scss
@@ -1,3 +1,7 @@
 .container {
     height: 500px;
+
+    &.compact {
+        height: 100px;
+    }
 }

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.ts
@@ -1,7 +1,8 @@
 import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
 import { Color } from '@mintplayer/ng-bootstrap';
 import { BsButtonTypeDirective } from '@mintplayer/ng-bootstrap/button-type';
-import { BsModalHostComponent, BsModalDirective } from '@mintplayer/ng-bootstrap/modal';
+import { BsCloseComponent } from '@mintplayer/ng-bootstrap/close';
+import { BsModalHostComponent, BsModalDirective, BsModalHeaderDirective, BsModalBodyDirective, BsModalCloseDirective } from '@mintplayer/ng-bootstrap/modal';
 import { BsScrollspyComponent, BsScrollspyDirective } from '@mintplayer/ng-bootstrap/scrollspy';
 
 @Component({
@@ -10,8 +11,12 @@ import { BsScrollspyComponent, BsScrollspyDirective } from '@mintplayer/ng-boots
   styleUrls: ['./scrollspy.component.scss'],
   imports: [
     BsButtonTypeDirective,
+    BsCloseComponent,
     BsModalHostComponent,
     BsModalDirective,
+    BsModalHeaderDirective,
+    BsModalBodyDirective,
+    BsModalCloseDirective,
     BsScrollspyComponent,
     BsScrollspyDirective,
   ],

--- a/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/advanced/scrollspy/scrollspy.component.ts
@@ -1,11 +1,23 @@
-import { Component, ChangeDetectionStrategy} from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Color } from '@mintplayer/ng-bootstrap';
+import { BsButtonTypeDirective } from '@mintplayer/ng-bootstrap/button-type';
+import { BsModalHostComponent, BsModalDirective } from '@mintplayer/ng-bootstrap/modal';
 import { BsScrollspyComponent, BsScrollspyDirective } from '@mintplayer/ng-bootstrap/scrollspy';
 
 @Component({
   selector: 'demo-scrollspy',
   templateUrl: './scrollspy.component.html',
   styleUrls: ['./scrollspy.component.scss'],
-  imports: [BsScrollspyComponent, BsScrollspyDirective],
+  imports: [
+    BsButtonTypeDirective,
+    BsModalHostComponent,
+    BsModalDirective,
+    BsScrollspyComponent,
+    BsScrollspyDirective,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ScrollspyComponent {}
+export class ScrollspyComponent {
+  readonly colors = Color;
+  readonly isModalOpen = signal(false);
+}

--- a/libs/mintplayer-ng-bootstrap/a11y/src/overlay-focus/overlay-focus.directive.ts
+++ b/libs/mintplayer-ng-bootstrap/a11y/src/overlay-focus/overlay-focus.directive.ts
@@ -50,9 +50,9 @@ export class BsOverlayFocusDirective {
 
     const target = this.initialFocus();
     if (target instanceof HTMLElement) {
-      target.focus();
+      target.focus({ preventScroll: true });
     } else if (target === 'self') {
-      this.elementRef.nativeElement.focus();
+      this.elementRef.nativeElement.focus({ preventScroll: true });
     } else if (target === 'first') {
       this.focusFirstTabbable();
     }
@@ -82,7 +82,7 @@ export class BsOverlayFocusDirective {
         && !node.matches(':disabled')
         && this.interactivityChecker.isFocusable(node, { ignoreVisibility: true })
       ) {
-        node.focus();
+        node.focus({ preventScroll: true });
         return;
       }
       node = walker.nextNode();
@@ -96,7 +96,9 @@ export class BsOverlayFocusDirective {
     this.trap = null;
 
     if (this.returnFocus() && this.restoreTo && typeof document !== 'undefined' && document.contains(this.restoreTo)) {
-      this.restoreTo.focus();
+      // preventScroll so closing an overlay never yanks the page back to the
+      // trigger's position — the user's scroll position is their choice.
+      this.restoreTo.focus({ preventScroll: true });
     }
     this.restoreTo = null;
   }

--- a/libs/mintplayer-ng-bootstrap/modal/src/components/modal-host/modal-host.component.ts
+++ b/libs/mintplayer-ng-bootstrap/modal/src/components/modal-host/modal-host.component.ts
@@ -39,6 +39,7 @@ export class BsModalHostComponent implements AfterViewInit, OnDestroy {
   readonly isOpen = model<boolean>(false);
   //#endregion
   readonly closeOnEscape = input(true);
+  readonly scrollable = input(false);
 
   constructor() {
     effect(() => {
@@ -52,6 +53,13 @@ export class BsModalHostComponent implements AfterViewInit, OnDestroy {
       } else if (!value && this.stackToken !== null) {
         this.overlayStack.release(this.stackToken);
         this.stackToken = null;
+      }
+    });
+
+    effect(() => {
+      const scrollable = this.scrollable();
+      if (this.componentInstance) {
+        this.componentInstance.instance.scrollable.set(scrollable);
       }
     });
   }
@@ -74,6 +82,7 @@ export class BsModalHostComponent implements AfterViewInit, OnDestroy {
     });
     this.componentInstance = this.overlayRef.attach<BsModalComponent>(portal);
     this.componentInstance.instance.isOpen.set(this.isOpen());
+    this.componentInstance.instance.scrollable.set(this.scrollable());
   }
 
   ngOnDestroy() {

--- a/libs/mintplayer-ng-bootstrap/modal/src/components/modal/modal.component.html
+++ b/libs/mintplayer-ng-bootstrap/modal/src/components/modal/modal.component.html
@@ -8,7 +8,7 @@
         [attr.aria-describedby]="context.bodyId()"
         [bsOverlayFocus]="true"
         tabindex="-1">
-        <div class="modal-dialog">
+        <div class="modal-dialog" [class.modal-dialog-scrollable]="scrollable()">
             <div class="modal-content">
                 <ng-container *ngTemplateOutlet="template; injector: injector"></ng-container>
             </div>

--- a/libs/mintplayer-ng-bootstrap/modal/src/components/modal/modal.component.scss
+++ b/libs/mintplayer-ng-bootstrap/modal/src/components/modal/modal.component.scss
@@ -8,4 +8,14 @@
     // Layout & components
     @import "node_modules/bootstrap/scss/transitions";
     @import "node_modules/bootstrap/scss/modal";
+
+    // The *bsModal structural directive forces a wrapper element between
+    // .modal-content and the user's modal-header / modal-body / modal-footer.
+    // For scrollable modals Bootstrap relies on a flex chain from .modal-content
+    // straight to .modal-body — the wrapper breaks that chain. `display: contents`
+    // removes the wrapper from layout while keeping the DOM intact, so the
+    // header/body/footer become the effective flex children of .modal-content.
+    .modal-dialog-scrollable .modal-content > * {
+        display: contents;
+    }
 }

--- a/libs/mintplayer-ng-bootstrap/modal/src/components/modal/modal.component.ts
+++ b/libs/mintplayer-ng-bootstrap/modal/src/components/modal/modal.component.ts
@@ -18,6 +18,7 @@ export class BsModalComponent {
 
   template = inject<TemplateRef<any>>(MODAL_CONTENT);
   isOpen = signal(false);
+  scrollable = signal(false);
 
   context = inject(BsModalContextService);
   injector = inject(Injector);

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.34.0",
+  "version": "21.35.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",

--- a/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.scss
+++ b/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.scss
@@ -45,11 +45,13 @@ $spywidth: 250px;
         }
     }
 
-    // Inside a modal the scroll container is bs-modal-content, not the viewport.
+    // Inside a modal the scroll container is the modal-body, not the viewport.
     // Anchor the sticky toc to that container instead of the page navbar offset.
+    // height stays auto — a sticky element that fills its containing block 100%
+    // can't actually stick because its bottom is always at the containing block
+    // bottom, which is sticky's un-stick condition.
     :host-context(bs-modal-content) .spy {
         top: 0;
-        height: 100%;
         max-height: 100%;
     }
 }

--- a/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.scss
+++ b/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.scss
@@ -39,10 +39,18 @@ $spywidth: 250px;
         height: calc(100vh - 7rem); // This determines how long the stick remains
         overflow-y: auto;
         grid-area: toc;
-        
+
         > ul {
             padding-left: 2rem;
         }
+    }
+
+    // Inside a modal the scroll container is bs-modal-content, not the viewport.
+    // Anchor the sticky toc to that container instead of the page navbar offset.
+    :host-context(bs-modal-content) .spy {
+        top: 0;
+        height: 100%;
+        max-height: 100%;
     }
 }
 

--- a/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.ts
+++ b/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.ts
@@ -1,21 +1,23 @@
 import { DOCUMENT } from '@angular/common';
-import { AfterContentInit, AfterViewInit, ChangeDetectionStrategy, Component, contentChildren, effect, ElementRef, inject, signal, viewChildren } from '@angular/core';
+import { AfterContentInit, AfterViewInit, ChangeDetectionStrategy, Component, computed, contentChildren, effect, ElementRef, inject, input, signal, viewChildren } from '@angular/core';
 import { BsScrollOffsetService } from '../services/scroll-offset/scroll-offset.service';
 import { BsScrollspyDirective } from '../directives/scrollspy.directive';
+
+type ScrollTarget = HTMLElement | Window;
 
 @Component({
   selector: 'bs-scrollspy',
   templateUrl: './scrollspy.component.html',
   styleUrls: ['./scrollspy.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {
-    '(window:scroll)': 'onWindowScroll()',
-  },
 })
 export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
 
   private scrollOffsetService = inject(BsScrollOffsetService);
+  private hostRef = inject<ElementRef<HTMLElement>>(ElementRef);
   doc = inject<Document>(DOCUMENT);
+
+  readonly scrollContainer = input<HTMLElement | null>(null);
 
   private viewInit = signal<boolean>(false);
   private contentInit = signal<boolean>(false);
@@ -25,6 +27,14 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
 
   activeDirective = signal<BsScrollspyDirective | null>(null);
 
+  private resolvedScrollTarget = computed<ScrollTarget | null>(() => {
+    if (typeof window === 'undefined') return null;
+    if (!this.viewInit()) return null;
+    const explicit = this.scrollContainer();
+    if (explicit) return explicit;
+    return this.findScrollableAncestor(this.hostRef.nativeElement) ?? window;
+  });
+
   constructor() {
     effect(() => {
       const viewInit = this.viewInit();
@@ -32,6 +42,21 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
       if (viewInit && contentInit) {
         this.scrollToCurrentInSpy();
       }
+    });
+
+    effect((onCleanup) => {
+      const target = this.resolvedScrollTarget();
+      this.directives();
+      if (!target) return;
+
+      const handler = () => {
+        this.setActiveDirective();
+        this.scrollToCurrentInSpy();
+      };
+      target.addEventListener('scroll', handler, { passive: true });
+      handler();
+
+      onCleanup(() => target.removeEventListener('scroll', handler));
     });
   }
 
@@ -43,15 +68,10 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
     this.contentInit.set(true);
   }
 
-  onWindowScroll() {
-    this.setActiveDirective();
-    this.scrollToCurrentInSpy();
-  }
-
   setActiveDirective() {
-    const offsetY = this.scrollOffsetService.getScrollOffset()[1];
+    const triggerY = this.getTriggerY();
     const allDirectives = this.directives();
-    const dirs = allDirectives.filter((d) => d.element.nativeElement.getBoundingClientRect().y < offsetY);
+    const dirs = allDirectives.filter((d) => d.element.nativeElement.getBoundingClientRect().y < triggerY);
 
     if (allDirectives.length === 0) {
       this.activeDirective.set(null);
@@ -65,7 +85,7 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
   scrollToCurrentInSpy() {
     if ((typeof window !== 'undefined') && (window.innerWidth >= 768)) {
       if (this.activeDirective()) {
-        const index = this.directives().findIndex((v, i) => v === this.activeDirective());
+        const index = this.directives().findIndex((v) => v === this.activeDirective());
         const anchor = this.anchors()[index];
         if (anchor && anchor.nativeElement.parentElement) {
           anchor.nativeElement.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -75,11 +95,40 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
   }
 
   scrollToHeader(directive: BsScrollspyDirective) {
-    if (typeof window !== 'undefined') {
-      const header = directive.element.nativeElement;
+    if (typeof window === 'undefined') return;
+    const target = this.resolvedScrollTarget();
+    if (!target) return;
+
+    const header = directive.element.nativeElement;
+    const headerTop = header.getBoundingClientRect().top;
+
+    if (target instanceof Window) {
       const offsetY = this.scrollOffsetService.getScrollOffset()[1];
-      const y = header.getBoundingClientRect().top + window.scrollY - offsetY + 1;
-      window.scrollTo({top: y, behavior: 'smooth'});
+      target.scrollTo({ top: headerTop + window.scrollY - offsetY + 1, behavior: 'smooth' });
+    } else {
+      const containerTop = target.getBoundingClientRect().top;
+      target.scrollTo({ top: headerTop - containerTop + target.scrollTop + 1, behavior: 'smooth' });
     }
+  }
+
+  private getTriggerY(): number {
+    const target = this.resolvedScrollTarget();
+    if (!target || target instanceof Window) {
+      return this.scrollOffsetService.getScrollOffset()[1];
+    }
+    return target.getBoundingClientRect().top + 1;
+  }
+
+  private findScrollableAncestor(start: HTMLElement): HTMLElement | null {
+    let el: HTMLElement | null = start.parentElement;
+    while (el) {
+      const style = getComputedStyle(el);
+      const overflowY = style.overflowY;
+      if ((overflowY === 'auto' || overflowY === 'scroll') && el.scrollHeight > el.clientHeight) {
+        return el;
+      }
+      el = el.parentElement;
+    }
+    return null;
   }
 }

--- a/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.ts
+++ b/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.ts
@@ -88,7 +88,9 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
         const index = this.directives().findIndex((v) => v === this.activeDirective());
         const anchor = this.anchors()[index];
         if (anchor && anchor.nativeElement.parentElement) {
-          anchor.nativeElement.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+          // Optional-chain so jsdom (no scrollIntoView impl) does not crash
+          // when the effect calls this synchronously during component init.
+          anchor.nativeElement.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
         }
       }
     }
@@ -102,9 +104,11 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
     const header = directive.element.nativeElement;
     const headerTop = header.getBoundingClientRect().top;
 
-    if (target instanceof Window) {
+    // Identity check instead of `instanceof Window` — jsdom puts Window in a
+    // different realm so the instanceof check is unreliable in unit tests.
+    if (target === window) {
       const offsetY = this.scrollOffsetService.getScrollOffset()[1];
-      target.scrollTo({ top: headerTop + window.scrollY - offsetY + 1, behavior: 'smooth' });
+      window.scrollTo({ top: headerTop + window.scrollY - offsetY + 1, behavior: 'smooth' });
     } else {
       const containerTop = target.getBoundingClientRect().top;
       target.scrollTo({ top: headerTop - containerTop + target.scrollTop + 1, behavior: 'smooth' });
@@ -113,18 +117,26 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
 
   private getTriggerY(): number {
     const target = this.resolvedScrollTarget();
-    if (!target || target instanceof Window) {
-      return this.scrollOffsetService.getScrollOffset()[1];
+    // +1 in both branches so a directive landing exactly on the trigger line
+    // (e.g. right after scrollToHeader completes) is counted as "above" it,
+    // matching the +1 that scrollToHeader adds when computing the scroll target.
+    if (!target || target === window) {
+      return this.scrollOffsetService.getScrollOffset()[1] + 1;
     }
     return target.getBoundingClientRect().top + 1;
   }
 
   private findScrollableAncestor(start: HTMLElement): HTMLElement | null {
-    let el: HTMLElement | null = start.parentElement;
+    // Walk the element + its ancestors. The host itself participates so a
+    // consumer can opt in by setting overflow-y: auto on <bs-scrollspy>.
+    // We rely only on the declared overflow style (no scrollHeight check) —
+    // a container declared overflow: auto is the consumer's intended scroll
+    // target whether or not the content currently exceeds the box.
+    let el: HTMLElement | null = start;
     while (el) {
       const style = getComputedStyle(el);
       const overflowY = style.overflowY;
-      if ((overflowY === 'auto' || overflowY === 'scroll') && el.scrollHeight > el.clientHeight) {
+      if (overflowY === 'auto' || overflowY === 'scroll') {
         return el;
       }
       el = el.parentElement;

--- a/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.ts
+++ b/libs/mintplayer-ng-bootstrap/scrollspy/src/component/scrollspy.component.ts
@@ -104,14 +104,15 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
     const header = directive.element.nativeElement;
     const headerTop = header.getBoundingClientRect().top;
 
-    // Identity check instead of `instanceof Window` — jsdom puts Window in a
-    // different realm so the instanceof check is unreliable in unit tests.
-    if (target === window) {
-      const offsetY = this.scrollOffsetService.getScrollOffset()[1];
-      window.scrollTo({ top: headerTop + window.scrollY - offsetY + 1, behavior: 'smooth' });
-    } else {
+    // `instanceof HTMLElement` narrows TS to HTMLElement in the true branch
+    // and is robust in jsdom (which implements HTMLElement). The previous
+    // `instanceof Window` check failed in jsdom due to a realm mismatch.
+    if (target instanceof HTMLElement) {
       const containerTop = target.getBoundingClientRect().top;
       target.scrollTo({ top: headerTop - containerTop + target.scrollTop + 1, behavior: 'smooth' });
+    } else {
+      const offsetY = this.scrollOffsetService.getScrollOffset()[1];
+      window.scrollTo({ top: headerTop + window.scrollY - offsetY + 1, behavior: 'smooth' });
     }
   }
 
@@ -120,10 +121,10 @@ export class BsScrollspyComponent implements AfterViewInit, AfterContentInit {
     // +1 in both branches so a directive landing exactly on the trigger line
     // (e.g. right after scrollToHeader completes) is counted as "above" it,
     // matching the +1 that scrollToHeader adds when computing the scroll target.
-    if (!target || target === window) {
-      return this.scrollOffsetService.getScrollOffset()[1] + 1;
+    if (target instanceof HTMLElement) {
+      return target.getBoundingClientRect().top + 1;
     }
-    return target.getBoundingClientRect().top + 1;
+    return this.scrollOffsetService.getScrollOffset()[1] + 1;
   }
 
   private findScrollableAncestor(start: HTMLElement): HTMLElement | null {


### PR DESCRIPTION
## Summary
- Fixes `bs-scrollspy` rendering and behavior inside `bs-modal` — closes #183.
- New optional `[scrollContainer]` input; auto-detects the nearest scrollable ancestor (`overflow-y: auto|scroll` + `scrollHeight > clientHeight`), falls back to the viewport.
- Scroll listener is now attached reactively to the resolved target via an `effect` with proper `onCleanup`; the `(window:scroll)` host binding is gone.
- `setActiveDirective` and `scrollToHeader` compute geometry relative to the resolved container instead of the viewport, so TOC clicks inside a modal scroll the modal body and active-section tracking actually fires.
- `:host-context(bs-modal-content) .spy { top: 0; height: 100% }` so the sticky toc anchors to the modal scroll container, not the page navbar offset.
- Demo page at `/advanced/scrollspy` now reproduces the failure case alongside the page-level scrollspy.

## Why three changes, not one
Three independent architectural mismatches caused issue #183:
1. **Wrong event source** — `(window:scroll)` never fires for scroll inside `.modal-content`'s own overflow context.
2. **Wrong scroll target** — `window.scrollTo()` is a no-op when the page itself isn't scrolling.
3. **Wrong reference frame** — `getBoundingClientRect().y < routerScrollOffset` mixes viewport-relative geometry with a page-level offset that has no meaning inside a modal.

All three are fixed together because shipping just one would leave the spy half-broken.

## Test plan
- [ ] `/advanced/scrollspy` page-level spy still tracks correctly as you scroll the page
- [ ] Page-level TOC click scrolls the page to the section
- [ ] Open the modal — modal-internal spy tracks the active heading as you scroll within the modal body
- [ ] Modal TOC click scrolls the modal body (not the page behind it)
- [ ] Sticky toc inside the modal stays at the top of the modal-content as you scroll, not below it
- [ ] Verify no SSR regression (the page prerenders 103 routes; no `window` access at construction time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)