### PR TITLE
feat(#333): OTP / segmented-code input component

### DIFF
--- a/apps/ng-bootstrap-demo-e2e/e2e/otp-input.spec.ts
+++ b/apps/ng-bootstrap-demo-e2e/e2e/otp-input.spec.ts
@@ -1,0 +1,368 @@
+import { test, expect, Page } from '@playwright/test';
+
+// End-to-end coverage for the OTP / segmented-code input. The unit tests in
+// libs/.../otp-input/**/*.spec.ts run in jsdom and miss:
+//   - Real-browser focus delegation through the wrapper's host `.focus()` override
+//   - Autofocus directive timing against the wrapper's lazy WC ref
+//   - OS-level paste event semantics
+//   - SMS-style autofill (single multi-char `input` event from autocomplete=one-time-code)
+//   - Active-box highlight rendering across multiple simultaneous instances on the same page
+//   - Disabled state respecting click/keyboard input in a real document
+
+// Helper: read the canonical `value` property off the WC, bypassing the
+// wrapper. Avoids any need to dig into shadow DOM for the displayed slice.
+async function wcValue(page: Page, testid: string): Promise<string> {
+  return await page.evaluate((tid) => {
+    const host = document.querySelector(`bs-otp-input[data-testid="${tid}"]`);
+    const wc = host?.querySelector('mp-otp-input') as { value?: string } | null;
+    return wc?.value ?? '';
+  }, testid);
+}
+
+// Helper: count boxes carrying the box-active class in a given instance.
+async function activeBoxCount(page: Page, testid: string): Promise<number> {
+  return await page.evaluate((tid) => {
+    const host = document.querySelector(`bs-otp-input[data-testid="${tid}"]`);
+    const wc = host?.querySelector('mp-otp-input');
+    if (!wc?.shadowRoot) return 0;
+    return wc.shadowRoot.querySelectorAll('.box.box-active').length;
+  }, testid);
+}
+
+// Helper: identify whether the focused element is the hidden input inside a
+// given bs-otp-input instance. We can't simply check `document.activeElement`
+// — that returns the host (`<bs-otp-input>`) when focus is delegated into
+// shadow DOM. Walk shadowRoot.activeElement to confirm.
+async function isInstanceFocused(page: Page, testid: string): Promise<boolean> {
+  return await page.evaluate((tid) => {
+    const host = document.querySelector(`bs-otp-input[data-testid="${tid}"]`);
+    const wc = host?.querySelector('mp-otp-input');
+    const inner = wc?.shadowRoot?.activeElement;
+    return !!(inner && (inner as HTMLElement).classList.contains('hidden-input'));
+  }, testid);
+}
+
+test.describe('otp-input — focus + autofocus', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/enterprise/otp-input');
+    // SSR demo requires networkidle after goto — destructive bootstrap
+    // finishes wiring up the page (see project_e2e_destructive_bootstrap memory).
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('FocusOnLoadDirective lands focus on the autofocused classic OTP', async ({ page }) => {
+    expect(await isInstanceFocused(page, 'classic')).toBe(true);
+    expect(await isInstanceFocused(page, 'pin')).toBe(false);
+  });
+
+  test('programmatic .focus() on the bs-otp-input host delegates to the hidden input', async ({ page }) => {
+    // PIN section is not autofocused on load. Call the wrapper host's .focus()
+    // and assert the call routed into the shadow-DOM hidden input. This is the
+    // exact code path FocusOnLoadDirective uses (it grabs the host element from
+    // ViewContainerRef and calls .focus() on it).
+    expect(await isInstanceFocused(page, 'pin')).toBe(false);
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]') as HTMLElement;
+      host.focus();
+    });
+    expect(await isInstanceFocused(page, 'pin')).toBe(true);
+    expect(await isInstanceFocused(page, 'classic')).toBe(false);
+  });
+});
+
+test.describe('otp-input — valueChange + complete', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/enterprise/otp-input');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('typing digits streams partial values into the bound ngModel', async ({ page }) => {
+    // Classic OTP autofocuses — keyboard goes straight in. Type one at a time
+    // and read the WC's canonical value between each keystroke.
+    await page.keyboard.type('1');
+    expect(await wcValue(page, 'classic')).toBe('1');
+    await page.keyboard.type('2');
+    expect(await wcValue(page, 'classic')).toBe('12');
+    await page.keyboard.type('3');
+    expect(await wcValue(page, 'classic')).toBe('123');
+  });
+
+  test('completing the field fires (complete) and the demo handler runs', async ({ page }) => {
+    // The demo binds (complete) to onClassicComplete which writes the value
+    // into a signal that renders an alert-success element. If the event
+    // doesn't fire, the alert never appears.
+    await expect(page.locator('.alert-success')).toHaveCount(0);
+    await page.keyboard.type('123456');
+    await expect(page.locator('.alert-success')).toBeVisible();
+    await expect(page.locator('.alert-success code')).toHaveText('123456');
+  });
+
+  test('partial value does NOT fire (complete) — alert stays hidden', async ({ page }) => {
+    await page.keyboard.type('12345');
+    // Give the page a tick to settle any pending CD.
+    await page.waitForTimeout(50);
+    await expect(page.locator('.alert-success')).toHaveCount(0);
+  });
+
+  test('clearing then re-completing re-fires (complete)', async ({ page }) => {
+    await page.keyboard.type('123456');
+    await expect(page.locator('.alert-success')).toBeVisible();
+    // Click the "Clear" button next to the classic OTP.
+    await page.getByRole('button', { name: 'Clear' }).click();
+    await expect(page.locator('.alert-success')).toHaveCount(0);
+    // Re-focus + type again — autofocus didn't survive the clear because the
+    // FocusOnLoadDirective only fires once on mount.
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="classic"]') as HTMLElement;
+      host.focus();
+    });
+    await page.keyboard.type('654321');
+    await expect(page.locator('.alert-success code')).toHaveText('654321');
+  });
+});
+
+test.describe('otp-input — paste handling', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/enterprise/otp-input');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('synthetic paste strips non-digits and fills from index 0 regardless of focus', async ({ page }) => {
+    // Focus the classic OTP on box 3 conceptually (type two digits first so
+    // the caret is past index 0). Then paste a longer string with separator
+    // junk. Spec: paste always fills from index 0 ignoring caret position.
+    await page.keyboard.type('99');
+    expect(await wcValue(page, 'classic')).toBe('99');
+
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="classic"]');
+      const wc = host?.querySelector('mp-otp-input');
+      const input = wc?.shadowRoot?.querySelector('.hidden-input') as HTMLInputElement;
+      const data = new DataTransfer();
+      data.setData('text/plain', 'Your code: 123-456 thanks');
+      input.dispatchEvent(new ClipboardEvent('paste', {
+        clipboardData: data,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }));
+    });
+
+    expect(await wcValue(page, 'classic')).toBe('123456');
+    // And the (complete) handler fired.
+    await expect(page.locator('.alert-success code')).toHaveText('123456');
+  });
+
+  test('license-key paste strips dashes and uppercases per case="upper"', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="office"]');
+      const wc = host?.querySelector('mp-otp-input');
+      const input = wc?.shadowRoot?.querySelector('.hidden-input') as HTMLInputElement;
+      input.focus();
+      const data = new DataTransfer();
+      data.setData('text/plain', 'abc123-def456-7890-asdf-zxcvbn-qwerty');
+      input.dispatchEvent(new ClipboardEvent('paste', {
+        clipboardData: data,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }));
+    });
+    expect(await wcValue(page, 'office')).toBe('ABC123DEF4567890ASDFZXCVBNQWERTY');
+    expect((await wcValue(page, 'office')).length).toBe(32);
+  });
+});
+
+test.describe('otp-input — SMS autofill simulation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/enterprise/otp-input');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('iOS-style single multi-char input event fills the field and fires (complete)', async ({ page }) => {
+    // iOS/Android dispatch a single `input` event on the autocomplete=one-time-code
+    // input with the full code at once. Simulate that here on the classic OTP.
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="classic"]');
+      const wc = host?.querySelector('mp-otp-input');
+      const input = wc?.shadowRoot?.querySelector('.hidden-input') as HTMLInputElement;
+      input.focus();
+      // Directly assign the value (as the browser does for autofill) then
+      // dispatch the `input` event. inputType is 'insertReplacementText' for
+      // Safari autofill; other browsers vary but our handler only looks at
+      // value-vs-previous-length delta, not inputType.
+      input.value = '123456';
+      input.dispatchEvent(new InputEvent('input', {
+        bubbles: true,
+        composed: true,
+        inputType: 'insertReplacementText',
+        data: '123456',
+      }));
+    });
+
+    expect(await wcValue(page, 'classic')).toBe('123456');
+    await expect(page.locator('.alert-success code')).toHaveText('123456');
+  });
+
+  test('autofill on a non-classic-OTP shape (license key) does not trigger autocomplete=one-time-code attr', async ({ page }) => {
+    // The office key has non-uniform groups → autocomplete must be 'off',
+    // never 'one-time-code'. Verify the hidden input's attribute.
+    const autocomplete = await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="office"]');
+      const wc = host?.querySelector('mp-otp-input');
+      const input = wc?.shadowRoot?.querySelector('.hidden-input') as HTMLInputElement;
+      return input.getAttribute('autocomplete');
+    });
+    expect(autocomplete).toBe('off');
+
+    // And the classic OTP's hidden input does have it.
+    const classicAutocomplete = await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="classic"]');
+      const wc = host?.querySelector('mp-otp-input');
+      const input = wc?.shadowRoot?.querySelector('.hidden-input') as HTMLInputElement;
+      return input.getAttribute('autocomplete');
+    });
+    expect(classicAutocomplete).toBe('one-time-code');
+  });
+});
+
+test.describe('otp-input — clipboard (real OS clipboard via navigator.clipboard)', () => {
+  test.beforeEach(async ({ page, context, browserName }) => {
+    // Firefox doesn't grant clipboard-read/write the same way; skip there to
+    // avoid OS-permission popups. Chromium handles it.
+    test.skip(browserName !== 'chromium', 'clipboard permission API is Chromium-only in headless test runs');
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.goto('/enterprise/otp-input');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('OS-level Ctrl+V paste lands the same as a synthetic paste event', async ({ page }) => {
+    await page.evaluate(async () => {
+      await navigator.clipboard.writeText('Your code is 246810');
+    });
+    // Classic OTP is autofocused on load; press Ctrl+V.
+    await page.keyboard.press('Control+V');
+    expect(await wcValue(page, 'classic')).toBe('246810');
+    await expect(page.locator('.alert-success code')).toHaveText('246810');
+  });
+});
+
+test.describe('otp-input — active-box highlight', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/enterprise/otp-input');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('only the autofocused instance shows a box-active highlight on load', async ({ page }) => {
+    // The classic OTP is autofocused → exactly one box-active in its shadow.
+    expect(await activeBoxCount(page, 'classic')).toBe(1);
+
+    // Other instances are not focused → zero highlighted boxes. Without the
+    // focus-gated fix, every instance would show its next-to-fill box as
+    // active even though they're not accepting input.
+    expect(await activeBoxCount(page, 'pin')).toBe(0);
+    expect(await activeBoxCount(page, 'office')).toBe(0);
+    expect(await activeBoxCount(page, 'windows')).toBe(0);
+    expect(await activeBoxCount(page, 'reactive')).toBe(0);
+  });
+
+  test('moving focus transfers the highlight to the newly-focused instance', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]') as HTMLElement;
+      host.focus();
+    });
+    // PIN gets the highlight, classic loses it.
+    expect(await activeBoxCount(page, 'pin')).toBe(1);
+    expect(await activeBoxCount(page, 'classic')).toBe(0);
+  });
+
+  test('blurring all OTP inputs drops every highlight', async ({ page }) => {
+    // The classic OTP starts focused. Click outside (on the h1) to blur.
+    await page.locator('h1').click();
+    expect(await activeBoxCount(page, 'classic')).toBe(0);
+    expect(await activeBoxCount(page, 'pin')).toBe(0);
+  });
+});
+
+test.describe('otp-input — disabled state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/enterprise/otp-input');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('setting disabled=true via attribute prevents typing from mutating the value', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]');
+      const wc = host?.querySelector('mp-otp-input');
+      wc?.setAttribute('disabled', '');
+    });
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]') as HTMLElement;
+      host.focus();
+    });
+    await page.keyboard.type('9999');
+    expect(await wcValue(page, 'pin')).toBe('');
+  });
+
+  test('toggling disabled off restores typability', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]');
+      const wc = host?.querySelector('mp-otp-input');
+      wc?.setAttribute('disabled', '');
+    });
+    // Try typing while disabled — should be a no-op.
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]') as HTMLElement;
+      host.focus();
+    });
+    await page.keyboard.type('12');
+    expect(await wcValue(page, 'pin')).toBe('');
+
+    // Remove disabled — typing must work again.
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]');
+      const wc = host?.querySelector('mp-otp-input');
+      wc?.removeAttribute('disabled');
+    });
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="pin"]') as HTMLElement;
+      host.focus();
+    });
+    await page.keyboard.type('34');
+    expect(await wcValue(page, 'pin')).toBe('34');
+  });
+});
+
+test.describe('otp-input — reactive forms invalid state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/enterprise/otp-input');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('control is invalid+untouched on load — no red border on the WC', async ({ page }) => {
+    // FR-15 + .is-invalid convention: do not paint red until touched.
+    const invalidAttr = await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="reactive"]');
+      const wc = host?.querySelector('mp-otp-input');
+      return wc?.hasAttribute('invalid');
+    });
+    expect(invalidAttr).toBe(false);
+  });
+
+  test('after focusing and blurring with empty value, the WC carries invalid="true"', async ({ page }) => {
+    await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="reactive"]') as HTMLElement;
+      host.focus();
+    });
+    // Blur by clicking the page heading.
+    await page.locator('h1').click();
+    // Wait for the CVA's microtask to flush syncInvalid.
+    await page.waitForTimeout(50);
+    const invalidAttr = await page.evaluate(() => {
+      const host = document.querySelector('bs-otp-input[data-testid="reactive"]');
+      const wc = host?.querySelector('mp-otp-input');
+      return wc?.hasAttribute('invalid');
+    });
+    expect(invalidAttr).toBe(true);
+  });
+});

--- a/apps/ng-bootstrap-demo-e2e/e2e/otp-input.spec.ts
+++ b/apps/ng-bootstrap-demo-e2e/e2e/otp-input.spec.ts
@@ -9,6 +9,33 @@ import { test, expect, Page } from '@playwright/test';
 //   - Active-box highlight rendering across multiple simultaneous instances on the same page
 //   - Disabled state respecting click/keyboard input in a real document
 
+// Wait for the OTP page to reach an interactive state. Different browsers need
+// different signals:
+//
+//  - Chromium: `waitForLoadState('networkidle')` works and matches the repo's
+//    other e2e specs (see project_e2e_destructive_bootstrap memory). It also
+//    naturally gates on the FocusOnLoadDirective's setTimeout(10) firing,
+//    which avoids races against autofocused-state assertions.
+//
+//  - Firefox: the OTP page has 6+ WC instances whose SSR hydration keeps
+//    network "not idle" longer than networkidle's 30s default. Wait directly
+//    for the classic WC to be upgraded + FocusOnLoadDirective to have placed
+//    focus inside its hidden input. Same end-state, different signal.
+async function waitReady(page: Page, browserName: string): Promise<void> {
+  if (browserName !== 'firefox') {
+    await page.waitForLoadState('networkidle');
+    return;
+  }
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => {
+    const classic = document.querySelector('bs-otp-input[data-testid="classic"] mp-otp-input');
+    const shadow = (classic as Element & { shadowRoot: ShadowRoot | null } | null)?.shadowRoot;
+    if (!shadow) return false;
+    const inner = shadow.activeElement as HTMLElement | null;
+    return !!(inner && inner.classList.contains('hidden-input'));
+  }, { timeout: 15000 });
+}
+
 // Helper: read the canonical `value` property off the WC, bypassing the
 // wrapper. Avoids any need to dig into shadow DOM for the displayed slice.
 async function wcValue(page: Page, testid: string): Promise<string> {
@@ -43,11 +70,9 @@ async function isInstanceFocused(page: Page, testid: string): Promise<boolean> {
 }
 
 test.describe('otp-input — focus + autofocus', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto('/enterprise/otp-input');
-    // SSR demo requires networkidle after goto — destructive bootstrap
-    // finishes wiring up the page (see project_e2e_destructive_bootstrap memory).
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('FocusOnLoadDirective lands focus on the autofocused classic OTP', async ({ page }) => {
@@ -71,9 +96,9 @@ test.describe('otp-input — focus + autofocus', () => {
 });
 
 test.describe('otp-input — valueChange + complete', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto('/enterprise/otp-input');
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('typing digits streams partial values into the bound ngModel', async ({ page }) => {
@@ -122,9 +147,9 @@ test.describe('otp-input — valueChange + complete', () => {
 });
 
 test.describe('otp-input — paste handling', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto('/enterprise/otp-input');
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('synthetic paste strips non-digits and fills from index 0 regardless of focus', async ({ page }) => {
@@ -138,14 +163,15 @@ test.describe('otp-input — paste handling', () => {
       const host = document.querySelector('bs-otp-input[data-testid="classic"]');
       const wc = host?.querySelector('mp-otp-input');
       const input = wc?.shadowRoot?.querySelector('.hidden-input') as HTMLInputElement;
-      const data = new DataTransfer();
-      data.setData('text/plain', 'Your code: 123-456 thanks');
-      input.dispatchEvent(new ClipboardEvent('paste', {
-        clipboardData: data,
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      }));
+      // Firefox ignores `clipboardData` passed to ClipboardEvent's constructor
+      // (the property comes back null). Build a plain Event and attach a
+      // synthetic clipboardData via defineProperty so the WC's paste handler
+      // sees identical shape across Chromium/Firefox.
+      const ev = new Event('paste', { bubbles: true, cancelable: true, composed: true });
+      Object.defineProperty(ev, 'clipboardData', {
+        value: { getData: (type: string) => (type === 'text' ? 'Your code: 123-456 thanks' : '') },
+      });
+      input.dispatchEvent(ev);
     });
 
     expect(await wcValue(page, 'classic')).toBe('123456');
@@ -159,14 +185,11 @@ test.describe('otp-input — paste handling', () => {
       const wc = host?.querySelector('mp-otp-input');
       const input = wc?.shadowRoot?.querySelector('.hidden-input') as HTMLInputElement;
       input.focus();
-      const data = new DataTransfer();
-      data.setData('text/plain', 'abc123-def456-7890-asdf-zxcvbn-qwerty');
-      input.dispatchEvent(new ClipboardEvent('paste', {
-        clipboardData: data,
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      }));
+      const ev = new Event('paste', { bubbles: true, cancelable: true, composed: true });
+      Object.defineProperty(ev, 'clipboardData', {
+        value: { getData: (type: string) => (type === 'text' ? 'abc123-def456-7890-asdf-zxcvbn-qwerty' : '') },
+      });
+      input.dispatchEvent(ev);
     });
     expect(await wcValue(page, 'office')).toBe('ABC123DEF4567890ASDFZXCVBNQWERTY');
     expect((await wcValue(page, 'office')).length).toBe(32);
@@ -174,9 +197,9 @@ test.describe('otp-input — paste handling', () => {
 });
 
 test.describe('otp-input — SMS autofill simulation', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto('/enterprise/otp-input');
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('iOS-style single multi-char input event fills the field and fires (complete)', async ({ page }) => {
@@ -233,7 +256,7 @@ test.describe('otp-input — clipboard (real OS clipboard via navigator.clipboar
     test.skip(browserName !== 'chromium', 'clipboard permission API is Chromium-only in headless test runs');
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
     await page.goto('/enterprise/otp-input');
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('OS-level Ctrl+V paste lands the same as a synthetic paste event', async ({ page }) => {
@@ -248,9 +271,9 @@ test.describe('otp-input — clipboard (real OS clipboard via navigator.clipboar
 });
 
 test.describe('otp-input — active-box highlight', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto('/enterprise/otp-input');
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('only the autofocused instance shows a box-active highlight on load', async ({ page }) => {
@@ -285,9 +308,9 @@ test.describe('otp-input — active-box highlight', () => {
 });
 
 test.describe('otp-input — disabled state', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto('/enterprise/otp-input');
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('setting disabled=true via attribute prevents typing from mutating the value', async ({ page }) => {
@@ -334,9 +357,9 @@ test.describe('otp-input — disabled state', () => {
 });
 
 test.describe('otp-input — reactive forms invalid state', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto('/enterprise/otp-input');
-    await page.waitForLoadState('networkidle');
+    await waitReady(page, browserName);
   });
 
   test('control is invalid+untouched on load — no red border on the WC', async ({ page }) => {

--- a/apps/ng-bootstrap-demo/src/app/app.component.html
+++ b/apps/ng-bootstrap-demo/src/app/app.component.html
@@ -291,6 +291,9 @@
         <bs-navbar-item>
           <a [routerLink]='["/enterprise", "query-builder"]'>Query builder</a>
         </bs-navbar-item>
+        <bs-navbar-item>
+          <a [routerLink]='["/enterprise", "otp-input"]'>OTP input</a>
+        </bs-navbar-item>
       </bs-navbar-dropdown>
     </bs-navbar-item>
     <bs-navbar-item>

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/enterprise.routes.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/enterprise.routes.ts
@@ -9,4 +9,5 @@ export const ROUTES: Routes = [
   { path: 'tile-manager', loadComponent: () => import('./tile-manager/tile-manager.component').then(m => m.TileManagerComponent) },
   { path: 'ribbon', loadComponent: () => import('./ribbon/ribbon.component').then(m => m.RibbonComponent) },
   { path: 'query-builder', loadComponent: () => import('./query-builder/query-builder.component').then(m => m.QueryBuilderDemoComponent) },
+  { path: 'otp-input', loadComponent: () => import('./otp-input/otp-input.component').then(m => m.OtpInputDemoComponent) },
 ];

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.html
@@ -22,6 +22,7 @@
         [(ngModel)]="classicCode"
         (complete)="onClassicComplete($event)"
         autofocus
+        data-testid="classic"
       ></bs-otp-input>
       <button type="button" class="btn btn-outline-secondary" (click)="clearClassic()">Clear</button>
     </div>
@@ -45,6 +46,7 @@
       [groups]="pinGroups"
       type="password"
       [(ngModel)]="pinCode"
+      data-testid="pin"
     ></bs-otp-input>
     <p class="text-muted small mt-2">Current value (for demo): <code>{{ pinCode() }}</code></p>
   </section>
@@ -65,6 +67,7 @@
       case="upper"
       size="lg"
       [(ngModel)]="officeKey"
+      data-testid="office"
     ></bs-otp-input>
     <p class="text-muted small mt-2">Current value: <code>{{ officeKey() }}</code></p>
   </section>
@@ -81,6 +84,7 @@
       [groups]="windowsGroups"
       type="alphanumeric"
       [(ngModel)]="windowsKey"
+      data-testid="windows"
     ></bs-otp-input>
     <p class="text-muted small mt-2">Current value: <code>{{ windowsKey() }}</code></p>
   </section>
@@ -116,7 +120,7 @@
       <code>Validators.minLength(6)</code>. The red border appears once the field is touched
       and the value is still invalid — mirrors Bootstrap's <code>.is-invalid</code> convention.
     </p>
-    <bs-otp-input [formControl]="validationForm"></bs-otp-input>
+    <bs-otp-input [formControl]="validationForm" data-testid="reactive"></bs-otp-input>
     <p class="small mt-2">
       Status: <code>{{ validationForm.status }}</code> ·
       Touched: <code>{{ validationForm.touched }}</code> ·

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.html
@@ -1,0 +1,135 @@
+<div class="container py-4">
+  <h1>OTP / segmented-code input</h1>
+  <p class="lead">
+    A single component for one-time passwords, PIN entry, and segmented license keys.
+    Same API covers <code>[1,1,1,1,1,1]</code> classic OTP and non-uniform layouts like MS Office's
+    <code>[6,6,4,4,6,6]</code>.
+  </p>
+
+  <hr>
+
+  <!-- Classic 6-digit OTP, template-driven, auto-submit -->
+  <section class="mb-5">
+    <h2>Classic 6-digit OTP</h2>
+    <p class="text-muted">
+      Default layout. Template-driven binding via <code>[(ngModel)]</code>. The
+      <code>(complete)</code> event fires once when all 6 boxes are filled — wire it to
+      auto-submit. SMS autofill works on iOS / Android (the hidden input has
+      <code>autocomplete="one-time-code"</code>).
+    </p>
+    <div class="d-flex align-items-center gap-3 flex-wrap">
+      <bs-otp-input
+        [(ngModel)]="classicCode"
+        (complete)="onClassicComplete($event)"
+        autofocus
+      ></bs-otp-input>
+      <button type="button" class="btn btn-outline-secondary" (click)="clearClassic()">Clear</button>
+    </div>
+    @if (classicSubmitted()) {
+      <div class="alert alert-success mt-3" role="status">
+        Submitted code: <code>{{ classicSubmitted() }}</code>
+      </div>
+    }
+  </section>
+
+  <hr>
+
+  <!-- 4-digit PIN -->
+  <section class="mb-5">
+    <h2>4-digit PIN (password type)</h2>
+    <p class="text-muted">
+      <code>[groups]="[1,1,1,1]"</code> with <code>type="password"</code>. The most-recently typed
+      character is visible for 700 ms then masks to <code>•</code>. Paste never reveals.
+    </p>
+    <bs-otp-input
+      [groups]="pinGroups"
+      type="password"
+      [(ngModel)]="pinCode"
+    ></bs-otp-input>
+    <p class="text-muted small mt-2">Current value (for demo): <code>{{ pinCode() }}</code></p>
+  </section>
+
+  <hr>
+
+  <!-- MS Office product key -->
+  <section class="mb-5">
+    <h2>MS Office product key (non-uniform groups)</h2>
+    <p class="text-muted">
+      <code>[groups]="[6,6,4,4,6,6]"</code>, <code>type="alphanumeric"</code>, <code>case="upper"</code>.
+      Paste a string with separators (e.g. <code>"AB1234-CD5678-EF12-GH34-IJ5678-KL9012"</code>) — the
+      component strips the dashes and fills correctly.
+    </p>
+    <bs-otp-input
+      [groups]="officeGroups"
+      type="alphanumeric"
+      case="upper"
+      size="lg"
+      [(ngModel)]="officeKey"
+    ></bs-otp-input>
+    <p class="text-muted small mt-2">Current value: <code>{{ officeKey() }}</code></p>
+  </section>
+
+  <hr>
+
+  <!-- Windows product key (uniform 5-5-5-5-5) -->
+  <section class="mb-5">
+    <h2>Windows product key (uniform 5-5-5-5-5)</h2>
+    <p class="text-muted">
+      <code>[groups]="[5,5,5,5,5]"</code>, <code>type="alphanumeric"</code>.
+    </p>
+    <bs-otp-input
+      [groups]="windowsGroups"
+      type="alphanumeric"
+      [(ngModel)]="windowsKey"
+    ></bs-otp-input>
+    <p class="text-muted small mt-2">Current value: <code>{{ windowsKey() }}</code></p>
+  </section>
+
+  <hr>
+
+  <!-- Sizes -->
+  <section class="mb-5">
+    <h2>Size variants</h2>
+    <div class="d-flex flex-column gap-3">
+      <div>
+        <strong class="d-inline-block me-3" style="min-width: 4rem;">sm</strong>
+        <bs-otp-input size="sm"></bs-otp-input>
+      </div>
+      <div>
+        <strong class="d-inline-block me-3" style="min-width: 4rem;">md</strong>
+        <bs-otp-input size="md"></bs-otp-input>
+      </div>
+      <div>
+        <strong class="d-inline-block me-3" style="min-width: 4rem;">lg</strong>
+        <bs-otp-input size="lg"></bs-otp-input>
+      </div>
+    </div>
+  </section>
+
+  <hr>
+
+  <!-- Reactive forms with validation -->
+  <section class="mb-5">
+    <h2>Reactive forms — invalid state</h2>
+    <p class="text-muted">
+      Bound to a <code>FormControl</code> with <code>Validators.required</code> and
+      <code>Validators.minLength(6)</code>. The red border appears once the field is touched
+      and the value is still invalid — mirrors Bootstrap's <code>.is-invalid</code> convention.
+    </p>
+    <bs-otp-input [formControl]="validationForm"></bs-otp-input>
+    <p class="small mt-2">
+      Status: <code>{{ validationForm.status }}</code> ·
+      Touched: <code>{{ validationForm.touched }}</code> ·
+      Value: <code>{{ validationForm.value }}</code>
+    </p>
+    @if (validationForm.touched && validationForm.invalid) {
+      <div class="alert alert-danger mt-2" role="alert">
+        @if (validationForm.errors?.['required']) {
+          A code is required.
+        } @else if (validationForm.errors?.['minlength']) {
+          Code must be 6 digits.
+        }
+      </div>
+    }
+  </section>
+</div>

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.scss
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+}
+
+section h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.ts
@@ -1,0 +1,38 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BsOtpInputComponent } from '@mintplayer/ng-bootstrap/otp-input';
+import { FocusOnLoadDirective } from '@mintplayer/ng-focus-on-load';
+
+@Component({
+  selector: 'demo-otp-input',
+  templateUrl: './otp-input.component.html',
+  styleUrls: ['./otp-input.component.scss'],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, BsOtpInputComponent, FocusOnLoadDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OtpInputDemoComponent {
+  // Classic OTP — template-driven with auto-submit on complete.
+  readonly classicCode = signal<string | undefined>(undefined);
+  readonly classicSubmitted = signal<string | null>(null);
+  onClassicComplete(code: string): void { this.classicSubmitted.set(code); }
+  clearClassic(): void { this.classicCode.set(''); this.classicSubmitted.set(null); }
+
+  // 4-digit PIN.
+  readonly pinGroups = [1, 1, 1, 1];
+  readonly pinCode = signal<string>('');
+
+  // MS Office product key (6-6-4-4-6-6 = 32 chars).
+  readonly officeGroups = [6, 6, 4, 4, 6, 6];
+  readonly officeKey = signal<string>('');
+
+  // Windows product key (5-5-5-5-5 = 25 chars).
+  readonly windowsGroups = [5, 5, 5, 5, 5];
+  readonly windowsKey = signal<string>('');
+
+  // Reactive forms with validation: required + minLength(6).
+  readonly validationForm = new FormControl<string>('', {
+    nonNullable: true,
+    validators: [Validators.required, Validators.minLength(6)],
+  });
+}

--- a/docs/issue_333_PRD.md
+++ b/docs/issue_333_PRD.md
@@ -1,0 +1,196 @@
+# Product Requirements Document: OTP / Segmented-Code Input
+
+**Issue**: #333
+**Title**: OTP input
+**Status**: Draft
+**Created**: 2026-05-17
+**Last Updated**: 2026-05-17
+
+---
+
+## Summary
+
+A new `bs-otp-input` Angular component (backed by a Lit web component `mp-otp-input`) that renders a row of visually distinct boxes for entering a one-time password, PIN, or license key. One API covers both uniform OTP (e.g. 6 single-character boxes) and non-uniform license-key layouts (e.g. MS Office's `6-6-4-4-6-6`) via a single `groups: number[]` input. Built on a hidden-full-width-input + decorative-boxes architecture so OS-level autofill, paste, IME, and screen-reader semantics work without per-box state machines. Integrates with Angular forms via `ControlValueAccessor` with `string` value shape.
+
+The load-bearing trade-off: **the hidden-input architecture means the visible "boxes" are not real inputs**. Users perceive 6 fields, but the platform sees one `<input>`. This is the right call because it makes SMS autofill, paste, and focus management Just Work; the cost is a small amount of CSS positioning + caret-tracking JS to render the boxes correctly.
+
+---
+
+## Overview
+
+OTP / one-time-password / segmented-code inputs are a missing primitive in this library. Consumer flows that need them today either fall back to a plain `<input maxlength="6">` (no visual segmentation, ugly UX) or duplicate the component per-app.
+
+The decision tree was walked end-to-end during planning (Step 3F of `issue_plan`); 13 questions were resolved with the developer. The PRD reflects only resolved decisions — no open questions.
+
+---
+
+## Goals & Objectives
+
+### Primary Goals
+
+- Ship a single component that handles classic OTP (numeric/alphanumeric/password), PIN entry, and license-key entry.
+- Match the WC + Angular wrapper + CVA pattern set by `multi-range` so the library stays internally consistent.
+- "User-friendly as possible": permissive paste handling, last-char-visible password reveal, mobile SMS autofill, Backspace-clears-then-jumps, reactive `groups`, focus delegation that works with the existing `FocusOnLoadDirective`.
+
+### Success Metrics
+
+- A consumer app can replace a hand-rolled OTP input with `<bs-otp-input>` and a `Validators.minLength(6)` form control, with no per-app CSS.
+- iOS Safari SMS-code QuickType chip fills the boxes correctly on first attempt.
+- Pasting `"Your code: 123-456 thanks"` from any focus position fills `"123456"` correctly.
+
+---
+
+## Chosen Design
+
+**Design fan-out not run.** The interface follows the established WC + Angular wrapper + CVA pattern already proven by `multi-range`. The plausible second design (single Angular component, no WC split) is already rejected by repo convention (`feedback_wc_plus_angular_wrapper.md`). Alternative payload shapes (`string[]`, object envelope) were explored and rejected during grilling — captured below.
+
+### Public API (Angular wrapper `bs-otp-input`)
+
+```ts
+@Component({
+  selector: 'bs-otp-input',
+  // ...
+})
+export class BsOtpInputComponent {
+  // Layout
+  readonly groups = input<number[]>([1, 1, 1, 1, 1, 1]);
+  readonly size = input<'sm' | 'md' | 'lg'>('md');
+
+  // Content
+  readonly type = input<'numeric' | 'alphanumeric' | 'password'>('numeric');
+  readonly case = input<'upper' | 'lower' | 'preserve'>('upper');
+
+  // State
+  readonly disabled = input(false);
+  readonly label = input<string | null>(null);
+
+  // Form binding
+  readonly value = model<string | undefined>(undefined);
+
+  // Events
+  readonly valueChange = output<string>();   // every keystroke
+  readonly complete = output<string>();      // fires once when value.length === sum(groups)
+
+  // Imperative
+  focus(): void;
+  clear(): void;
+}
+```
+
+### Usage examples
+
+```html
+<!-- Classic 6-digit OTP, reactive forms -->
+<bs-otp-input [formControl]="code" (complete)="login($event)"></bs-otp-input>
+
+<!-- 4-digit PIN -->
+<bs-otp-input [groups]="[1,1,1,1]" type="password" autofocus></bs-otp-input>
+
+<!-- MS Office product key -->
+<bs-otp-input [groups]="[6,6,4,4,6,6]" type="alphanumeric" case="upper" size="lg"></bs-otp-input>
+```
+
+### Designs considered (and rejected)
+
+- **Value shape `string[]` (array of single chars)** — rejected: forces `.join('')` on every read; can't `Validators.required` cleanly because the array is always defined.
+- **Value shape `{ value, isComplete }` envelope** — rejected: `isComplete` is one line to derive at the call site (`value.length === sum(groups)`); the envelope buys nothing.
+- **Separate `valueInput` + `valueChange` events (multi-range parity)** — rejected: with partials streaming on every keystroke, the two events would carry identical info. Replaced `valueInput` with a dedicated `complete` event that fires once per completion.
+- **N real `<input>` elements with a per-box state machine** — rejected: leaks on Safari's `autocomplete="one-time-code"` heuristics; per-box focus chain is the entire complexity surface of every buggy OTP component in the wild.
+- **`length: number` API only** — rejected after grilling because real-world license keys are non-uniform (MS Office is `6-6-4-4-6-6`). Replaced with `groups: number[]`.
+- **`pattern: string` mask-style API** — rejected: reopens the separator question we resolved as out-of-scope.
+- **`groupCount` + `groupSize` two-input API** — rejected: forces uniform groups, doesn't cover MS Office's layout.
+- **Auto-mask password immediately (no reveal window)** — rejected: mobile users universally expect the iOS/Android "last char visible briefly" pattern.
+- **Strict paste handling (reject any non-conforming paste)** — rejected: real-world SMS clipboard often contains `"Your code is 123-456"`-style noise; stripping is the user-friendly choice.
+- **Dedicated `[autofocus]` input on the component** — rejected once the developer pointed out that `FocusOnLoadDirective` already provides this for any element with a working `.focus()` method.
+
+---
+
+## Functional Requirements
+
+### Must Have (P0)
+
+- [ ] **FR-1** Render a row of N visually distinct boxes where `N === groups.length` and box `i` displays `value.slice(boundary[i], boundary[i+1])`.
+- [ ] **FR-2** `groups: number[]` input is reactive; runtime changes truncate or pad the value and re-render boxes. Validation: each element ∈ [1, 10], `sum(groups)` ≤ 40, array non-empty. Out-of-range values clamp + `console.warn`.
+- [ ] **FR-3** `type: 'numeric' | 'alphanumeric' | 'password'` filters typed and pasted characters at entry; default `'numeric'`.
+- [ ] **FR-4** `case: 'upper' | 'lower' | 'preserve'` normalizes characters at entry for `alphanumeric` and `password` types; default `'upper'`. Numeric type ignores `case`.
+- [ ] **FR-5** Value shape is `string`. `valueChange` fires on *every* keystroke with the partial value (including empty string). CVA `onChange` is wired to `valueChange`.
+- [ ] **FR-6** `complete` fires exactly once per completion event — when the value transitions from `length < sum(groups)` to `length === sum(groups)` *via user interaction*. Re-fires on re-completion (after clearing). Does **not** fire on programmatic `writeValue` setting a complete value.
+- [ ] **FR-7** Permissive paste: strip characters that don't match `type`, normalize per `case`, truncate to `sum(groups)`, always fill starting from index 0 regardless of which box currently has focus. Single `valueChange` + `complete` (if appropriate) fires.
+- [ ] **FR-8** Backspace clears the most recent character and moves caret/active-box back by one position; standard single-`<input>` semantics suffice.
+- [ ] **FR-9** Render strategy: one hidden full-width `<input>` (`opacity:0`, `inset:0`) that receives focus + keystrokes + paste + autofill, plus decorative `<span>` boxes that visually display value slices. Boxes are `aria-hidden="true"`.
+- [ ] **FR-10** `autocomplete="one-time-code"` on hidden input set **only** when `groups.every(g => g === 1) && type === 'numeric'`; otherwise `autocomplete="off"`.
+- [ ] **FR-11** Password reveal: when `type === 'password'`, the most recently typed character is visible for ~700ms then becomes `•` (U+2022 BULLET). All earlier chars are masked immediately. On `complete` or `blur`, all chars mask immediately regardless of timer. Paste with `type === 'password'` masks all chars immediately (never reveals).
+- [ ] **FR-12** Active-box highlight (`::part(box-active)`) follows the hidden input's `selectionEnd` (which box would receive the next typed char).
+- [ ] **FR-13** `size: 'sm' | 'md' | 'lg'` controls box dimensions and font size; default `'md'`.
+- [ ] **FR-14** Bootstrap-flavored bordered box style by default; visual gap doubled between groups (≈16px) vs within-group (≈8px); CSS parts exposed: `container`, `box`, `box-filled`, `box-active`, `box-invalid`, `group-separator`.
+- [ ] **FR-15** Invalid state: when wrapped in an Angular form and the control is `invalid && touched`, all boxes apply `.is-invalid` styling (red border per Bootstrap convention).
+- [ ] **FR-16** Angular wrapper exposes `focus()` method that delegates to the hidden input. Constructor also overrides `elementRef.nativeElement.focus` so `FocusOnLoadDirective` (`*[autofocus]`) works against `<bs-otp-input autofocus>` directly.
+- [ ] **FR-17** Wrapper exposes `clear()` method that resets value to `""` and emits `valueChange('')`.
+- [ ] **FR-18** `setDisabledState` on the CVA toggles the WC's `disabled` attribute; disabled state prevents typing and paste, applies a visually-distinct style.
+- [ ] **FR-19** Demo page at `/enterprise/otp-input` covering: classic OTP (reactive forms), PIN, MS Office key, Windows key, all sizes, invalid state, autofocus.
+- [ ] **FR-20** CI publish/dry-run pipelines updated to include the new package.
+
+### Should Have (P1)
+
+- [ ] **FR-21** `label` input sets `aria-label` on the hidden input; falls back to a default `"One-time code"` label in English if unset.
+- [ ] **FR-22** RTL support inherited from ancestor `dir` (matches `multi-range` pattern); active-box highlight respects RTL.
+
+### Out of scope for v1
+
+The cut-off below reflects a deliberate design principle: **`bs-otp-input` is a focusable, value-bearing primitive. Consumer-specific behavior belongs in user-written directives composed onto the component**, not in additional inputs on the component itself. `FocusOnLoadDirective` + `[autofocus]` is the canonical example — the component exposes `.focus()`, the directive does the rest. Consumers needing custom input/paste processing, validation, separators, or reveal-timing write their own directive on `bs-otp-input` that listens to `valueChange` and mutates the bound model.
+
+- Floating-label / `bs-form` integration — a consumer-written wrapper directive can compose this on top.
+- Visible separator character (e.g. literal `"-"`) between groups — `::part(group-separator) ::before { content: "-" }` or a consumer directive.
+- Animation on `groups` change.
+- Per-character custom validation hooks (e.g. "the 3rd box must be a vowel") — use form-level validators or a directive that processes `valueChange`.
+- Configurable reveal-window duration (`revealMs`) — 700ms hardcoded; if a real consumer needs different timing they write a directive that overrides the visible value, or we add the input then.
+- Custom paste/input pre-processing (e.g. strip a known prefix like `"OTP: "`) — consumer directive subscribes to `paste`/`valueChange` and rewrites before re-emitting.
+
+---
+
+## Timeline & Milestones
+
+### Milestone 1: WC + tests
+
+- [ ] Scaffold `libs/mintplayer-ng-bootstrap/otp-input/` package mirroring `multi-range`.
+- [ ] Implement `MintOtpInputElement` covering all FR-1 through FR-12, FR-14.
+- [ ] Vitest unit tests for all 10 test scenarios from the plan doc.
+- [ ] ARIA spec passes.
+
+### Milestone 2: Angular wrapper + CVA
+
+- [ ] `BsOtpInputComponent` with signal inputs + outputs + `focus()`/`clear()`.
+- [ ] `BsOtpInputValueAccessor` directive applied via `hostDirectives`.
+- [ ] Wrapper spec mirroring multi-range structure (template-driven + reactive forms + disabled).
+- [ ] FR-15 (invalid state), FR-16 (focus delegation), FR-18 (disabled).
+
+### Milestone 3: Demo + publish wiring
+
+- [ ] Demo page with all variants.
+- [ ] Route registered.
+- [ ] Workflow files updated.
+- [ ] Local `nx build` and `nx serve` smoke pass.
+
+---
+
+## Open Questions
+
+> No escalated questions. The decision tree was resolved in-session with the developer.
+
+---
+
+## Technical Notes (Issue-Specific)
+
+- **`autocomplete="one-time-code"` only works on the OTP-shaped configuration.** License-key shapes never trigger SMS autofill, which is correct: the OS has no idea what a Windows product key looks like.
+- **The Angular wrapper must define `.focus` on its host DOM element** (not just expose a method on the component class). `FocusOnLoadDirective` accesses `_lContainer[0]` and calls `.focus()` on the resulting DOM element — without the constructor override, that would hit the no-op `HTMLElement.prototype.focus`.
+- **Password reveal timing on paste**: when paste fills multiple boxes at once, none of them reveal — even if `type === 'password'`. The user already knows the value (they pasted it); showing it briefly is a shoulder-surf risk for no UX win.
+- **Validating `groups` reactively**: clamp on every change, emit `console.warn` only when clamping actually happens (don't spam logs on valid changes).
+
+---
+
+## Related
+
+- Issue #333
+- Precedent: `libs/mintplayer-ng-bootstrap/multi-range/` (WC + wrapper + CVA pattern).
+- Reused: `libs/mintplayer-ng-focus-on-load/` (FocusOnLoadDirective).
+- See CLAUDE.md for: Lit WC conventions, Angular signal-input patterns, Bootstrap form-control styling rules, `bs-` selector convention.

--- a/docs/issue_333_PRD.md
+++ b/docs/issue_333_PRD.md
@@ -2,7 +2,7 @@
 
 **Issue**: #333
 **Title**: OTP input
-**Status**: Draft
+**Status**: Complete
 **Created**: 2026-05-17
 **Last Updated**: 2026-05-17
 
@@ -10,9 +10,19 @@
 
 ## Summary
 
-A new `bs-otp-input` Angular component (backed by a Lit web component `mp-otp-input`) that renders a row of visually distinct boxes for entering a one-time password, PIN, or license key. One API covers both uniform OTP (e.g. 6 single-character boxes) and non-uniform license-key layouts (e.g. MS Office's `6-6-4-4-6-6`) via a single `groups: number[]` input. Built on a hidden-full-width-input + decorative-boxes architecture so OS-level autofill, paste, IME, and screen-reader semantics work without per-box state machines. Integrates with Angular forms via `ControlValueAccessor` with `string` value shape.
+Shipped a `bs-otp-input` Angular component backed by a `mp-otp-input` Lit web component, sharing the WC + Angular wrapper + `ControlValueAccessor` triangulation already used by `bs-multi-range`. One API (`groups: number[]`) covers classic 6-digit OTP (`[1,1,1,1,1,1]`, the default), 4-digit PIN, and non-uniform license keys (e.g. MS Office's `[6,6,4,4,6,6]`). 54 new tests pass — 35 WC unit + 7 ARIA + 12 wrapper integration.
 
-The load-bearing trade-off: **the hidden-input architecture means the visible "boxes" are not real inputs**. Users perceive 6 fields, but the platform sees one `<input>`. This is the right call because it makes SMS autofill, paste, and focus management Just Work; the cost is a small amount of CSS positioning + caret-tracking JS to render the boxes correctly.
+**Load-bearing decisions, as built:**
+- **One hidden full-width `<input autocomplete="one-time-code">` + decorative boxes**, not N real inputs. SMS autofill / paste / IME / screen readers route through the platform without per-box state machines. *Rejected*: N `<input>` array with focus-chain JS — leaks on Safari's autofill heuristics.
+- **Value shape is `string`, streams partials**, with `valueChange` on every keystroke and `complete` once on the incomplete→complete transition via user interaction. *Rejected*: `string[]` (forces `.join('')` at every read) and `valueInput`+`valueChange` parity with multi-range (would carry identical info given partials stream).
+- **`groups: number[]` with the array element = one visual box** (chars per box). *Rejected*: `length: number` (breaks for MS Office's non-uniform layout), `groupCount`+`groupSize` (same uniformity limit), `pattern: string` (reopens the separator question we scoped out).
+- **Focus delegation via `Object.defineProperty(host, 'focus', …)` in the wrapper constructor** so the existing `FocusOnLoadDirective` (`*[autofocus]`) Just Works. *Rejected*: dedicated `[autofocus]` input on the component — duplicates an existing primitive.
+- **Active-box highlight only while focused** (added in the post-review fix pass). Without focus tracking, every unfocused instance lit up its next-to-fill box, which made side-by-side demos look like every input was competing for input.
+
+**Traps documented for a future reader:**
+- Setting `target.value = normalised` in the input handler collapses the caret to the end. For non-uniform license keys (`[6,6,4,4,6,6]`), mid-string editing puts the user back at the end of the value, not the box they clicked. Acceptable per the hidden-input architecture; surfacing this would mean tracking `selectionStart` before mutation, which fights password masking.
+- `complete` fires on user-interaction transitions only — programmatic `writeValue` with a complete string deliberately suppresses it. Auto-submit-on-complete with `effect()` over the model would re-fire on form rehydrate, so consumers should subscribe to the `(complete)` output, not derive completion from `value().length`.
+- The `value-change` event is *not* `stopPropagation`'d; the CVA on the wrapper host depends on it bubbling. The `complete` event *is* stopped because the wrapper's Output named `complete` collides with the DOM event name and Angular's `(complete)` binding catches both channels.
 
 ---
 
@@ -109,31 +119,31 @@ export class BsOtpInputComponent {
 
 ### Must Have (P0)
 
-- [ ] **FR-1** Render a row of N visually distinct boxes where `N === groups.length` and box `i` displays `value.slice(boundary[i], boundary[i+1])`.
-- [ ] **FR-2** `groups: number[]` input is reactive; runtime changes truncate or pad the value and re-render boxes. Validation: each element ∈ [1, 10], `sum(groups)` ≤ 40, array non-empty. Out-of-range values clamp + `console.warn`.
-- [ ] **FR-3** `type: 'numeric' | 'alphanumeric' | 'password'` filters typed and pasted characters at entry; default `'numeric'`.
-- [ ] **FR-4** `case: 'upper' | 'lower' | 'preserve'` normalizes characters at entry for `alphanumeric` and `password` types; default `'upper'`. Numeric type ignores `case`.
-- [ ] **FR-5** Value shape is `string`. `valueChange` fires on *every* keystroke with the partial value (including empty string). CVA `onChange` is wired to `valueChange`.
-- [ ] **FR-6** `complete` fires exactly once per completion event — when the value transitions from `length < sum(groups)` to `length === sum(groups)` *via user interaction*. Re-fires on re-completion (after clearing). Does **not** fire on programmatic `writeValue` setting a complete value.
-- [ ] **FR-7** Permissive paste: strip characters that don't match `type`, normalize per `case`, truncate to `sum(groups)`, always fill starting from index 0 regardless of which box currently has focus. Single `valueChange` + `complete` (if appropriate) fires.
-- [ ] **FR-8** Backspace clears the most recent character and moves caret/active-box back by one position; standard single-`<input>` semantics suffice.
-- [ ] **FR-9** Render strategy: one hidden full-width `<input>` (`opacity:0`, `inset:0`) that receives focus + keystrokes + paste + autofill, plus decorative `<span>` boxes that visually display value slices. Boxes are `aria-hidden="true"`.
-- [ ] **FR-10** `autocomplete="one-time-code"` on hidden input set **only** when `groups.every(g => g === 1) && type === 'numeric'`; otherwise `autocomplete="off"`.
-- [ ] **FR-11** Password reveal: when `type === 'password'`, the most recently typed character is visible for ~700ms then becomes `•` (U+2022 BULLET). All earlier chars are masked immediately. On `complete` or `blur`, all chars mask immediately regardless of timer. Paste with `type === 'password'` masks all chars immediately (never reveals).
-- [ ] **FR-12** Active-box highlight (`::part(box-active)`) follows the hidden input's `selectionEnd` (which box would receive the next typed char).
-- [ ] **FR-13** `size: 'sm' | 'md' | 'lg'` controls box dimensions and font size; default `'md'`.
-- [ ] **FR-14** Bootstrap-flavored bordered box style by default; visual gap doubled between groups (≈16px) vs within-group (≈8px); CSS parts exposed: `container`, `box`, `box-filled`, `box-active`, `box-invalid`, `group-separator`.
-- [ ] **FR-15** Invalid state: when wrapped in an Angular form and the control is `invalid && touched`, all boxes apply `.is-invalid` styling (red border per Bootstrap convention).
-- [ ] **FR-16** Angular wrapper exposes `focus()` method that delegates to the hidden input. Constructor also overrides `elementRef.nativeElement.focus` so `FocusOnLoadDirective` (`*[autofocus]`) works against `<bs-otp-input autofocus>` directly.
-- [ ] **FR-17** Wrapper exposes `clear()` method that resets value to `""` and emits `valueChange('')`.
-- [ ] **FR-18** `setDisabledState` on the CVA toggles the WC's `disabled` attribute; disabled state prevents typing and paste, applies a visually-distinct style.
-- [ ] **FR-19** Demo page at `/enterprise/otp-input` covering: classic OTP (reactive forms), PIN, MS Office key, Windows key, all sizes, invalid state, autofocus.
-- [ ] **FR-20** CI publish/dry-run pipelines updated to include the new package.
+- [x] **FR-1** Render a row of N visually distinct boxes where `N === groups.length` and box `i` displays `value.slice(boundary[i], boundary[i+1])`.
+- [x] **FR-2** `groups: number[]` input is reactive; runtime changes truncate or pad the value and re-render boxes. Validation: each element ∈ [1, 10], `sum(groups)` ≤ 40, array non-empty. Out-of-range values clamp + `console.warn`.
+- [x] **FR-3** `type: 'numeric' | 'alphanumeric' | 'password'` filters typed and pasted characters at entry; default `'numeric'`.
+- [x] **FR-4** `case: 'upper' | 'lower' | 'preserve'` normalizes characters at entry for `alphanumeric` and `password` types; default `'upper'`. Numeric type ignores `case`.
+- [x] **FR-5** Value shape is `string`. `valueChange` fires on *every* keystroke with the partial value (including empty string). CVA `onChange` is wired to `valueChange`.
+- [x] **FR-6** `complete` fires exactly once per completion event — when the value transitions from `length < sum(groups)` to `length === sum(groups)` *via user interaction*. Re-fires on re-completion (after clearing). Does **not** fire on programmatic `writeValue` setting a complete value.
+- [x] **FR-7** Permissive paste: strip characters that don't match `type`, normalize per `case`, truncate to `sum(groups)`, always fill starting from index 0 regardless of which box currently has focus. Single `valueChange` + `complete` (if appropriate) fires.
+- [x] **FR-8** Backspace clears the most recent character and moves caret/active-box back by one position; standard single-`<input>` semantics suffice.
+- [x] **FR-9** Render strategy: one hidden full-width `<input>` (`opacity:0`, `inset:0`) that receives focus + keystrokes + paste + autofill, plus decorative `<span>` boxes that visually display value slices. Boxes are `aria-hidden="true"`.
+- [x] **FR-10** `autocomplete="one-time-code"` on hidden input set **only** when `groups.every(g => g === 1) && type === 'numeric'`; otherwise `autocomplete="off"`.
+- [x] **FR-11** Password reveal: when `type === 'password'`, the most recently typed character is visible for ~700ms then becomes `•` (U+2022 BULLET). All earlier chars are masked immediately. On `complete` or `blur`, all chars mask immediately regardless of timer. Paste with `type === 'password'` masks all chars immediately (never reveals).
+- [x] **FR-12** Active-box highlight (`::part(box-active)`) follows the hidden input's `selectionEnd` (which box would receive the next typed char).
+- [x] **FR-13** `size: 'sm' | 'md' | 'lg'` controls box dimensions and font size; default `'md'`.
+- [x] **FR-14** Bootstrap-flavored bordered box style by default. CSS parts exposed: `container`, `box`, `box-filled`, `box-active`, `box-invalid`. *Note*: the `group-separator` part was dropped during implementation — the architecture lands as one box per `groups` element (no within-group sub-boxes), so a per-group separator is moot. A consumer wanting a visible separator can `::part(box) ~ ::part(box) { content: "-" }` or wrap the host with their own directive.
+- [x] **FR-15** Invalid state: when wrapped in an Angular form and the control is `invalid && touched`, all boxes apply `.is-invalid` styling (red border per Bootstrap convention).
+- [x] **FR-16** Angular wrapper exposes `focus()` method that delegates to the hidden input. Constructor also overrides `elementRef.nativeElement.focus` so `FocusOnLoadDirective` (`*[autofocus]`) works against `<bs-otp-input autofocus>` directly.
+- [x] **FR-17** Wrapper exposes `clear()` method that resets value to `""` and emits `valueChange('')`.
+- [x] **FR-18** `setDisabledState` on the CVA toggles the WC's `disabled` attribute; disabled state prevents typing and paste, applies a visually-distinct style.
+- [x] **FR-19** Demo page at `/enterprise/otp-input` covering: classic OTP (reactive forms), PIN, MS Office key, Windows key, all sizes, invalid state, autofocus.
+- [x] **FR-20** ~~CI publish/dry-run pipelines updated to include the new package.~~ *Superseded by discovery during implementation*: the umbrella `@mintplayer/ng-bootstrap` workflow publishes a single npm package; secondary entries like `otp-input/` are auto-discovered by ng-packagr via the `ng-package.js` file. No `.github/workflows/` change is required; building the umbrella package with `nx build mintplayer-ng-bootstrap` produces the `dist/libs/mintplayer-ng-bootstrap/otp-input/` subpath, and `@mintplayer/ng-bootstrap/otp-input` resolves correctly post-install.
 
 ### Should Have (P1)
 
-- [ ] **FR-21** `label` input sets `aria-label` on the hidden input; falls back to a default `"One-time code"` label in English if unset.
-- [ ] **FR-22** RTL support inherited from ancestor `dir` (matches `multi-range` pattern); active-box highlight respects RTL.
+- [x] **FR-21** `label` input sets `aria-label` on the hidden input; falls back to a default `"One-time code"` label in English if unset.
+- [x] **FR-22** RTL support inherited from ancestor `dir` (matches `multi-range` pattern); active-box highlight respects RTL. *As built*: the container uses `display: inline-flex` with `gap` and no explicit `flex-direction`, so under an `<html dir="rtl">` or `:dir(rtl)` ancestor, boxes flow right-to-left automatically via flex's native direction handling. The active-box index is computed from `selectionEnd` (a numeric position into the value string, direction-agnostic) and maps to the correct visual box. No CSS overrides were required.
 
 ### Out of scope for v1
 
@@ -152,24 +162,24 @@ The cut-off below reflects a deliberate design principle: **`bs-otp-input` is a 
 
 ### Milestone 1: WC + tests
 
-- [ ] Scaffold `libs/mintplayer-ng-bootstrap/otp-input/` package mirroring `multi-range`.
-- [ ] Implement `MintOtpInputElement` covering all FR-1 through FR-12, FR-14.
-- [ ] Vitest unit tests for all 10 test scenarios from the plan doc.
-- [ ] ARIA spec passes.
+- [x] Scaffold `libs/mintplayer-ng-bootstrap/otp-input/` package mirroring `multi-range`.
+- [x] Implement `MintOtpInputElement` covering all FR-1 through FR-12, FR-14.
+- [x] Vitest unit tests for all 10 test scenarios from the plan doc.
+- [x] ARIA spec passes.
 
 ### Milestone 2: Angular wrapper + CVA
 
-- [ ] `BsOtpInputComponent` with signal inputs + outputs + `focus()`/`clear()`.
-- [ ] `BsOtpInputValueAccessor` directive applied via `hostDirectives`.
-- [ ] Wrapper spec mirroring multi-range structure (template-driven + reactive forms + disabled).
-- [ ] FR-15 (invalid state), FR-16 (focus delegation), FR-18 (disabled).
+- [x] `BsOtpInputComponent` with signal inputs + outputs + `focus()`/`clear()`.
+- [x] `BsOtpInputValueAccessor` directive applied via `hostDirectives`.
+- [x] Wrapper spec mirroring multi-range structure (template-driven + reactive forms + disabled).
+- [x] FR-15 (invalid state), FR-16 (focus delegation), FR-18 (disabled).
 
 ### Milestone 3: Demo + publish wiring
 
-- [ ] Demo page with all variants.
-- [ ] Route registered.
-- [ ] Workflow files updated.
-- [ ] Local `nx build` and `nx serve` smoke pass.
+- [x] Demo page with all variants.
+- [x] Route registered.
+- [x] ~~Workflow files updated.~~ Superseded — secondary entries auto-discovered by ng-packagr.
+- [x] Local `nx build` and `nx serve` smoke pass.
 
 ---
 

--- a/docs/issue_333_plan.md
+++ b/docs/issue_333_plan.md
@@ -1,0 +1,269 @@
+# Development Plan: Issue #333
+
+**Issue**: #333
+**Title**: OTP input
+**Type**: Feature (new component)
+**Priority**: Medium
+
+## Executive Summary
+
+Add a Bootstrap-flavored OTP / segmented-code input component. The same component covers two flows with one API: classic numeric one-time-passwords (6-digit MFA) and segmented license-key entry (e.g. MS Office's `6-6-4-4-6-6` layout). Ships as a Lit web component (`mp-otp-input`) with an Angular wrapper (`bs-otp-input`) and a `ControlValueAccessor`, matching the established `multi-range` precedent. Architecture is *one hidden full-width `<input>` + decorative box divs* — not N real inputs — so OS-level autofill (`autocomplete="one-time-code"`), paste handling, and IME work without per-box state machines.
+
+---
+
+## Problem Statement
+
+### Current Behavior
+
+No OTP-shaped input exists. Consumers wanting an OTP field today either fall back to a plain `<input maxlength="6">` (no per-digit visual segmentation, no SMS autofill semantics beyond the native attribute, ugly UX) or roll their own component per app.
+
+### Expected Behavior
+
+A single `bs-otp-input` that:
+
+- Renders N visually distinct boxes grouped by a `groups: number[]` API. `[1,1,1,1,1,1]` (default) = classic 6-digit OTP; `[6,6,4,4,6,6]` = MS Office license key.
+- Accepts numeric / alphanumeric / password content per `type` input.
+- Supports SMS auto-fill via `autocomplete="one-time-code"` automatically (only when `groups.every(g === 1) && type === 'numeric'` — the OTP case).
+- Permissive paste: strips non-matching characters, fills from box 0, ignores overflow.
+- Backspace clears the current character then jumps to the previous box.
+- Integrates with Angular forms via CVA; value shape is `string` (full concatenated code).
+- Fires `valueChange` on every keystroke (partial values stream), `complete` once when `value.length === sum(groups)`.
+
+### Impact
+
+Unblocks MFA / 2FA / license-key entry flows in Angular apps built on this lib without per-app component duplication. Sets the precedent for future input-shaped WCs that need `.focus()` delegation.
+
+---
+
+## Technical Analysis
+
+### Files to Create
+
+- `libs/mintplayer-ng-bootstrap/otp-input/` — new library package (mirror `multi-range/` structure).
+  - `index.ts`, `ng-package.js`, `package.json` (mirroring `multi-range`).
+  - `src/index.ts`.
+  - `src/lib/web-components/mint-otp-input.element.ts` — Lit WC `MintOtpInputElement`, registers `mp-otp-input`.
+  - `src/lib/web-components/mint-otp-input.element.template.ts` — extracted Lit `css` styles (mirrors `mint-multi-range.element.template.ts`).
+  - `src/lib/web-components/mint-otp-input.element.spec.ts` — Vitest unit tests for input/paste/backspace/complete/group-aware behavior.
+  - `src/lib/web-components/mint-otp-input.aria.spec.ts` — ARIA contract tests (hidden input has all ARIA; boxes `aria-hidden="true"`).
+  - `src/lib/components/otp-input.component.ts` — Angular wrapper `BsOtpInputComponent`, selector `bs-otp-input`.
+  - `src/lib/components/otp-input.component.spec.ts` — wrapper integration tests (CVA, template-driven, reactive forms).
+  - `src/lib/value-accessor/otp-input-value-accessor.ts` — `BsOtpInputValueAccessor` directive applied via `hostDirectives`.
+  - `src/lib/types/otp-input-type.ts` — string-literal union for `type`.
+  - `src/lib/types/otp-input-case.ts` — string-literal union for `case`.
+  - `src/lib/types/otp-input-size.ts` — string-literal union for `size`.
+
+### Files to Modify
+
+- `apps/ng-bootstrap-demo/src/app/pages/enterprise/enterprise.routes.ts` — register `otp-input` route.
+- `apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.ts|html` — new demo page with classic OTP, license-key, all `type` variants, all `size` variants, invalid state, autofocus, reactive vs template-driven examples.
+- `apps/ng-bootstrap-demo/src/app/app.component.html` — add navigation link if other enterprise demos are listed there.
+- `.github/workflows/publish-master.yml` and `.github/workflows/pull-request.yml` — add `mintplayer-ng-bootstrap-otp-input` to publish/dry-run matrix.
+
+### Dependencies
+
+- `lit` (already used by other WCs in the repo).
+- `@angular/forms` (for CVA).
+- Existing `FocusOnLoadDirective` at `libs/mintplayer-ng-focus-on-load/` — reused via `[autofocus]` once `bs-otp-input` exposes a working `.focus()` on its host element.
+
+### Architecture Considerations
+
+**Single hidden `<input>` + decorative boxes.** The WC's render output is roughly:
+
+```html
+<div class="container" part="container">
+  <input class="hidden-input" autocomplete="one-time-code" inputmode="numeric"
+         aria-label="One-time code">
+  <div class="boxes" aria-hidden="true">
+    <span class="box" part="box">1</span>
+    <span class="box" part="box">2</span>
+    <span class="box box-active" part="box box-active"></span>
+    ...
+  </div>
+</div>
+```
+
+- Hidden input is `position: absolute; inset: 0; opacity: 0; color: transparent;` — actually focusable, receives keystrokes, paste, autofill. Caret position drives which decorative box gets `box-active`.
+- Decorative boxes render the value sliced according to `groups`: box `i` shows `value.slice(boundaries[i], boundaries[i+1])` where `boundaries` is the cumulative-sum of `groups`.
+- Focus delegation: the WC overrides its own `focus()` to delegate to the hidden input. The Angular wrapper does the same on its host DOM element so `FocusOnLoadDirective` works against `<bs-otp-input>` directly.
+
+**ARIA**: the hidden input carries `role="textbox"` (implicit), `aria-label` (from `[label]` input), `aria-invalid` (from form state), `aria-describedby` (passthrough). All decorative DOM is `aria-hidden="true"` — screen readers see one text input.
+
+**Password masking**: per-character timer. State per index in `value`: `revealedUntil: number[]` (epoch ms). On keystroke at index `i`, set `revealedUntil[i] = performance.now() + 700`. Render: if `type === 'password' && performance.now() < revealedUntil[i]`, show char else show `•`. A single `setTimeout(700)` triggers a re-render to mask after the window. On `complete` or `blur`, clear all `revealedUntil` and re-render.
+
+**Paste handling**: bind to `paste` on the hidden input. `preventDefault()`, read `clipboardData.getData('text')`, filter to allowed chars per `type`, uppercase/lowercase per `case`, truncate to `sum(groups)`, set `value`, advance caret to end-of-filled-content. Always fills from index 0 — focus position is ignored (a real-world Safari gotcha).
+
+**Backspace**: on `keydown` with `key === 'Backspace'`, if caret is at index N > 0 and the char at N-1 is non-empty, splice it out. The hidden input's natural backspace handles this; we don't need to override unless the user's caret position is at index 0 (no-op).
+
+**Auto-advance**: the hidden input handles this natively because the value is one long string. The visual "advance to next box" is purely a re-render of which decorative box has the active class, driven by the input's `selectionEnd`.
+
+**Group boundaries in value**: the canonical `value` is a *flat* string with no separator. `groups` only affects rendering and visual gap. Paste of `"6688AAAACCC123"` (12 chars) into `groups: [6, 6]` → `value = "6688AAAACCC123".slice(0, 12)` → box 0 shows first 6, box 1 shows next 6. Box 1 fills only when box 0 is "full" because the value is contiguous.
+
+**Focus delegation pattern** (reusable):
+
+```ts
+// In BsOtpInputComponent constructor:
+constructor() {
+  const host = inject(ElementRef).nativeElement as HTMLElement;
+  Object.defineProperty(host, 'focus', {
+    value: () => this.elementRef()?.nativeElement.focus(),
+    configurable: true,
+  });
+}
+```
+
+This lets `FocusOnLoadDirective` (`*[autofocus]`) call `.focus()` on `<bs-otp-input>` and have it land in the hidden input.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Web component (no Angular)
+
+1. Scaffold `libs/mintplayer-ng-bootstrap/otp-input/` mirroring `multi-range/` (package.json, ng-package.js, src dirs, project.json registration).
+2. Implement `MintOtpInputElement` (Lit) with `groups`, `type`, `case`, `size`, `disabled`, `label` properties, `value` getter/setter, `value-change` and `complete` events.
+3. Render hidden input + decorative boxes with cumulative-boundary slicing.
+4. Wire input filter (allowed chars per `type`), case normalization, paste handler, caret-driven active-box highlight.
+5. Implement password-mask timer state.
+6. Override `focus()` to delegate to hidden input.
+7. Set `autocomplete="one-time-code"` only when `groups.every(g => g === 1) && type === 'numeric'`.
+8. Register `mp-otp-input` custom element.
+9. Vitest unit tests covering all decisions from grilling (paste filter, paste-from-any-focus, complete semantics, password reveal window, group boundary math, length validation/clamp).
+10. ARIA spec: hidden input has `role=textbox`, `aria-label`, `aria-invalid`; decorative boxes `aria-hidden=true`.
+
+### Phase 2: Angular wrapper
+
+1. `BsOtpInputComponent` with signal inputs (`groups`, `type`, `case`, `size`, `disabled`, `label`, `value` model). `CUSTOM_ELEMENTS_SCHEMA`, `OnPush`.
+2. Template renders `<mp-otp-input #el>` with attribute bindings.
+3. Subscribe to `value-change` and `complete` via host listeners, expose as `valueChange` / `complete` outputs.
+4. Effects: forward `value` model writes to WC; forward `disabled` to WC `disabled` attr.
+5. Override `elementRef.nativeElement.focus` in constructor to delegate to WC (enables `FocusOnLoadDirective`).
+6. Public methods: `focus()` and `clear()`.
+7. `BsOtpInputValueAccessor` directive (`hostDirectives`) implementing `ControlValueAccessor`. `writeValue` does not fire `complete`. `setDisabledState` toggles WC attr.
+8. Wrapper spec mirroring multi-range's: basic render, template-driven `[(ngModel)]`, reactive `formControl`, `setDisabledState`, `touched` on `value-change`.
+
+### Phase 3: Demo + docs
+
+1. Create `apps/ng-bootstrap-demo/src/app/pages/enterprise/otp-input/otp-input.component.{ts,html,scss}`.
+2. Sections in the demo:
+   - Classic 6-digit OTP with reactive forms + completion toast.
+   - 4-digit PIN (`groups: [1,1,1,1]`, `type: password`).
+   - MS Office key (`groups: [6,6,4,4,6,6]`, `type: alphanumeric`).
+   - Windows product key (`groups: [5,5,5,5,5]`, `type: alphanumeric`).
+   - Size variants (`sm`/`md`/`lg`).
+   - Invalid state via `Validators.required` + `Validators.minLength(sum)`.
+   - `[autofocus]` example.
+3. Register route in `enterprise.routes.ts`.
+4. Add nav entry to demo home/landing if convention exists.
+
+### Phase 4: CI / publish
+
+1. Add `mintplayer-ng-bootstrap-otp-input` package to `.github/workflows/publish-master.yml` (publish step) and `.github/workflows/pull-request.yml` (dry-run step), mirroring the entries for other component packages.
+2. Verify `nx build mintplayer-ng-bootstrap-otp-input` succeeds locally.
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Classic 6-digit OTP typed digit-by-digit
+
+- **Given**: `<bs-otp-input [(value)]="code">` with default `groups: [1,1,1,1,1,1]`, `type: numeric`.
+- **When**: user types `1`, `2`, `3`, `4`, `5`, `6`.
+- **Then**: `valueChange` fires 6 times with `"1"`, `"12"`, ..., `"123456"`. `complete` fires once at the last keystroke with `"123456"`. Boxes show one digit each.
+
+### Scenario 2: Paste with separator-junk into OTP
+
+- **Given**: same setup.
+- **When**: user pastes `"Your code: 123-456 thanks"` while focus is on the third box.
+- **Then**: paste is stripped to `"123456"`, fills boxes 0–5 (ignoring focus position), `valueChange` fires once with `"123456"`, `complete` fires once.
+
+### Scenario 3: License key with non-uniform groups
+
+- **Given**: `<bs-otp-input [groups]="[6,6,4,4,6,6]" type="alphanumeric" case="upper">`.
+- **When**: user pastes `"abc123-def456-7890-asdf-zxcvbn-qwerty"`.
+- **Then**: paste is filtered to alphanumeric uppercase `"ABC123DEF4567890ASDFZXCVBNQWERTY"`, truncated to 32 chars (sum of groups), boxes fill respecting the group boundaries visually. `complete` fires with the 32-char value.
+
+### Scenario 4: Backspace clears current then jumps
+
+- **Given**: classic OTP with value `"123"`, caret after box 2.
+- **When**: user presses Backspace.
+- **Then**: value becomes `"12"`, box 2 empties, caret moves to box 2 (about to overwrite). Press Backspace again: value `"1"`, caret moves to box 1.
+
+### Scenario 5: Password mask reveal window
+
+- **Given**: `[type]="'password'"`, current value `""`.
+- **When**: user types `1`.
+- **Then**: box 0 shows `1` for 700ms then `•`. User types `2`: box 1 shows `2` briefly, box 0 already shows `•`. On `complete` or `blur`, all boxes show `•` immediately.
+
+### Scenario 6: Mobile SMS autofill
+
+- **Given**: classic numeric OTP rendered on iOS Safari with an active SMS code.
+- **When**: user taps the input; QuickType chip appears; user taps it.
+- **Then**: hidden input receives the full `"123456"` via a single `input` event; boxes render filled; `complete` fires.
+
+### Scenario 7: Reactive forms invalid state
+
+- **Given**: `FormControl('', [Validators.required, Validators.minLength(6)])` bound to `bs-otp-input`.
+- **When**: user types `"123"` then blurs.
+- **Then**: control is `invalid`, `touched`. Component renders boxes with `.is-invalid` border. Setting `groups` to `[1,1,1,1]` updates validation expectations (consumer adjusts `Validators.minLength` themselves).
+
+### Scenario 8: Autofocus via directive
+
+- **Given**: `<bs-otp-input autofocus>` placed on a page.
+- **When**: page mounts.
+- **Then**: hidden input has focus, first box has `box-active` styling, keyboard input works immediately.
+
+### Scenario 9: Reactive `groups` change
+
+- **Given**: component with `groups: [1,1,1,1,1,1]` and value `"123456"`.
+- **When**: consumer changes input to `groups: [1,1,1,1]`.
+- **Then**: value truncates to `"1234"`, `valueChange` fires, boxes re-render to 4. `complete` fires because new value length matches new sum.
+
+### Scenario 10: Length clamping
+
+- **Given**: `<bs-otp-input [groups]="[15]">`.
+- **When**: component initializes.
+- **Then**: `console.warn` is emitted, `groups` clamps to `[10]` (per-element max), behavior continues with the clamped value.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `bs-otp-input` renders with default `groups: [1,1,1,1,1,1]`, looks like a 6-box Bootstrap-styled input row.
+- [ ] All 13 grilled decisions are implemented as specified in the PRD.
+- [ ] Hidden-input architecture: only one `<input>` element, decorative boxes are `aria-hidden`, hidden input has `autocomplete="one-time-code"` exactly when `groups.every(g => g === 1) && type === 'numeric'`.
+- [ ] CVA contract: `string` value, `valueChange` streams partials, `complete` fires once when `value.length === sum(groups)`.
+- [ ] `FocusOnLoadDirective` works against `<bs-otp-input autofocus>` (i.e. host element's `.focus()` delegates).
+- [ ] All test scenarios pass.
+- [ ] Demo page exists at `/enterprise/otp-input` with all variants.
+- [ ] Lib builds: `npx nx build mintplayer-ng-bootstrap-otp-input` succeeds.
+- [ ] Demo builds and runs: `npx nx serve ng-bootstrap-demo` shows the new page.
+- [ ] No regressions in existing component specs (`npx nx run-many -t test --projects=tag:component`).
+
+---
+
+## Build & Test Commands
+
+```bash
+# Build the new lib
+npx nx build mintplayer-ng-bootstrap-otp-input
+
+# Test the new lib
+npx nx test mintplayer-ng-bootstrap-otp-input
+
+# Serve the demo and visit /enterprise/otp-input
+npx nx serve ng-bootstrap-demo
+
+# Full check before PR
+npx nx run-many -t build
+npx nx run-many -t test
+```
+
+---
+
+## Related Files
+
+- `libs/mintplayer-ng-bootstrap/multi-range/` — closest precedent for WC + wrapper + CVA.
+- `libs/mintplayer-ng-focus-on-load/src/lib/directives/focus-on-load/focus-on-load.directive.ts` — reused for `[autofocus]`.
+- `apps/ng-bootstrap-demo/src/app/pages/enterprise/enterprise.routes.ts` — demo route registration.
+- `docs/issue_333_PRD.md` — this issue's PRD with full decision rationale.

--- a/libs/mintplayer-ng-bootstrap/otp-input/index.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/libs/mintplayer-ng-bootstrap/otp-input/ng-package.js
+++ b/libs/mintplayer-ng-bootstrap/otp-input/ng-package.js
@@ -1,0 +1,2 @@
+// Generated. Shared config + rationale lives in ng-package.secondary.cjs.
+module.exports = require('../ng-package.secondary.cjs').secondaryEntry();

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/index.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/index.ts
@@ -1,0 +1,6 @@
+export * from './lib/components/otp-input.component';
+export * from './lib/value-accessor/otp-input-value-accessor';
+export * from './lib/web-components/mint-otp-input.element';
+export * from './lib/types/otp-input-type';
+export * from './lib/types/otp-input-case';
+export * from './lib/types/otp-input-size';

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.spec.ts
@@ -110,6 +110,27 @@ describe('BsOtpInputComponent', () => {
       expect(wc.hasAttribute('disabled')).toBe(false);
     });
 
+    it('does not lose form-disabled state when an unrelated signal change re-runs CD', async () => {
+      // Regression for the Gemini-flagged race: previously the wrapper's
+      // template had `[attr.disabled]="disabledAttr()"`, which would clobber
+      // the CVA's setAttribute('disabled', '') on the next CD cycle whenever
+      // another signal-bound attribute re-evaluated. We now own the attribute
+      // via a single effect, so the CVA's write is stable.
+      host.control.disable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(wc.hasAttribute('disabled')).toBe(true);
+
+      // Force a CD pass by emitting an unrelated event — value-change drives
+      // the wrapper's onValueChange which updates the value() model.
+      wc.dispatchEvent(new CustomEvent('value-change', {
+        detail: '111111', bubbles: true, composed: true,
+      }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(wc.hasAttribute('disabled')).toBe(true);
+    });
+
     it('marks FormControl as touched on focusout', async () => {
       expect(host.control.touched).toBe(false);
       // Use dispatchEvent on the host element of bs-otp-input — that's where

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.spec.ts
@@ -1,0 +1,255 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BsOtpInputComponent } from './otp-input.component';
+
+describe('BsOtpInputComponent', () => {
+  describe('basic rendering', () => {
+    let fixture: ComponentFixture<BsOtpInputComponent>;
+    let component: BsOtpInputComponent;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [BsOtpInputComponent] }).compileComponents();
+      fixture = TestBed.createComponent(BsOtpInputComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('creates', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('renders the mp-otp-input custom element with attributes forwarded', () => {
+      const wc = fixture.nativeElement.querySelector('mp-otp-input') as HTMLElement;
+      expect(wc).toBeTruthy();
+      expect(wc.getAttribute('type')).toBe('numeric');
+      expect(wc.getAttribute('case')).toBe('upper');
+      expect(wc.getAttribute('size')).toBe('md');
+    });
+  });
+
+  describe('value accessor — template-driven (ngModel)', () => {
+    @Component({
+      selector: 'host-tdf',
+      imports: [BsOtpInputComponent, FormsModule],
+      template: `<bs-otp-input [(ngModel)]="value"></bs-otp-input>`,
+    })
+    class HostTdfComponent {
+      readonly value = signal<string | null>('');
+    }
+
+    let fixture: ComponentFixture<HostTdfComponent>;
+    let host: HostTdfComponent;
+    let wc: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [HostTdfComponent, BsOtpInputComponent, FormsModule],
+      }).compileComponents();
+      fixture = TestBed.createComponent(HostTdfComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      wc = fixture.nativeElement.querySelector('mp-otp-input') as HTMLElement;
+    });
+
+    it('updates the host signal when the WC fires value-change', async () => {
+      wc.dispatchEvent(new CustomEvent('value-change', {
+        detail: '123456', bubbles: true, composed: true,
+      }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(host.value()).toBe('123456');
+    });
+  });
+
+  describe('value accessor — reactive forms (FormControl)', () => {
+    @Component({
+      selector: 'host-rf',
+      imports: [BsOtpInputComponent, ReactiveFormsModule],
+      template: `<bs-otp-input [formControl]="control"></bs-otp-input>`,
+    })
+    class HostRfComponent {
+      readonly control = new FormControl<string>('', { nonNullable: true });
+    }
+
+    let fixture: ComponentFixture<HostRfComponent>;
+    let host: HostRfComponent;
+    let wc: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [HostRfComponent, BsOtpInputComponent, ReactiveFormsModule],
+      }).compileComponents();
+      fixture = TestBed.createComponent(HostRfComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      wc = fixture.nativeElement.querySelector('mp-otp-input') as HTMLElement;
+    });
+
+    it('updates the FormControl when value-change fires', async () => {
+      wc.dispatchEvent(new CustomEvent('value-change', {
+        detail: '987654', bubbles: true, composed: true,
+      }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(host.control.value).toBe('987654');
+    });
+
+    it('toggles the WC disabled attribute via setDisabledState', async () => {
+      host.control.disable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(wc.hasAttribute('disabled')).toBe(true);
+
+      host.control.enable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(wc.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('marks FormControl as touched on focusout', async () => {
+      expect(host.control.touched).toBe(false);
+      // Use dispatchEvent on the host element of bs-otp-input — that's where
+      // the value accessor listens for focusout.
+      const bsHost = fixture.nativeElement.querySelector('bs-otp-input') as HTMLElement;
+      bsHost.dispatchEvent(new Event('focusout', { bubbles: true }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(host.control.touched).toBe(true);
+    });
+
+    it('writeValue from the form control pushes value into the WC property', async () => {
+      host.control.setValue('111222');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect((wc as unknown as { value: string }).value).toBe('111222');
+    });
+  });
+
+  describe('reactive forms — invalid state via validators', () => {
+    @Component({
+      selector: 'host-val',
+      imports: [BsOtpInputComponent, ReactiveFormsModule],
+      template: `<bs-otp-input [formControl]="control"></bs-otp-input>`,
+    })
+    class HostValComponent {
+      readonly control = new FormControl<string>('', {
+        nonNullable: true,
+        validators: [Validators.required, Validators.minLength(6)],
+      });
+    }
+
+    let fixture: ComponentFixture<HostValComponent>;
+    let host: HostValComponent;
+    let wc: HTMLElement;
+    let bsHost: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [HostValComponent, BsOtpInputComponent, ReactiveFormsModule],
+      }).compileComponents();
+      fixture = TestBed.createComponent(HostValComponent);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+      await fixture.whenStable();
+      wc = fixture.nativeElement.querySelector('mp-otp-input') as HTMLElement;
+      bsHost = fixture.nativeElement.querySelector('bs-otp-input') as HTMLElement;
+    });
+
+    it('does not mark the WC invalid until touched', async () => {
+      // Initially invalid (empty + required) but not touched.
+      expect(host.control.invalid).toBe(true);
+      expect(host.control.touched).toBe(false);
+      expect(wc.hasAttribute('invalid')).toBe(false);
+    });
+
+    it('marks the WC invalid once touched and the value is still invalid', async () => {
+      // Type a partial then blur.
+      wc.dispatchEvent(new CustomEvent('value-change', {
+        detail: '123', bubbles: true, composed: true,
+      }));
+      bsHost.dispatchEvent(new Event('focusout', { bubbles: true }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      // Allow the microtask-scheduled syncInvalid to fire.
+      await new Promise<void>((r) => queueMicrotask(() => r()));
+      fixture.detectChanges();
+      expect(host.control.touched).toBe(true);
+      expect(host.control.invalid).toBe(true);
+      expect((wc as unknown as { invalid: boolean }).invalid).toBe(true);
+    });
+
+    it('clears the WC invalid state once the value becomes valid', async () => {
+      // Touch first.
+      bsHost.dispatchEvent(new Event('focusout', { bubbles: true }));
+      // Then satisfy validation.
+      wc.dispatchEvent(new CustomEvent('value-change', {
+        detail: '123456', bubbles: true, composed: true,
+      }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await new Promise<void>((r) => queueMicrotask(() => r()));
+      fixture.detectChanges();
+      expect(host.control.valid).toBe(true);
+      expect((wc as unknown as { invalid: boolean }).invalid).toBe(false);
+    });
+  });
+
+  describe('focus delegation', () => {
+    let fixture: ComponentFixture<BsOtpInputComponent>;
+    let bsHost: HTMLElement;
+    let wc: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({ imports: [BsOtpInputComponent] }).compileComponents();
+      fixture = TestBed.createComponent(BsOtpInputComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      bsHost = fixture.nativeElement as HTMLElement;
+      wc = bsHost.querySelector('mp-otp-input') as HTMLElement;
+    });
+
+    it('replaces the host element\'s focus() so calling it delegates to the hidden input', () => {
+      // Spy on the WC's focus method — the wrapper's override should call into it.
+      let invoked = false;
+      const original = wc.focus.bind(wc);
+      (wc as unknown as { focus: (o?: FocusOptions) => void }).focus = (o) => {
+        invoked = true;
+        return original(o);
+      };
+      // This is the call path FocusOnLoadDirective takes.
+      (bsHost as unknown as { focus: () => void }).focus();
+      expect(invoked).toBe(true);
+    });
+  });
+
+  describe('complete event', () => {
+    @Component({
+      selector: 'host-complete',
+      imports: [BsOtpInputComponent],
+      template: `<bs-otp-input (complete)="onComplete($event)"></bs-otp-input>`,
+    })
+    class HostCompleteComponent {
+      readonly received: string[] = [];
+      onComplete(v: string) { this.received.push(v); }
+    }
+
+    it('forwards the WC complete event as an Angular output', async () => {
+      await TestBed.configureTestingModule({
+        imports: [HostCompleteComponent, BsOtpInputComponent],
+      }).compileComponents();
+      const fixture = TestBed.createComponent(HostCompleteComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const wc = fixture.nativeElement.querySelector('mp-otp-input') as HTMLElement;
+      wc.dispatchEvent(new CustomEvent('complete', {
+        detail: '654321', bubbles: true, composed: true,
+      }));
+      fixture.detectChanges();
+      expect(fixture.componentInstance.received).toEqual(['654321']);
+    });
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
@@ -45,7 +44,7 @@ import { OtpInputSize } from '../types/otp-input-size';
   changeDetection: ChangeDetectionStrategy.OnPush,
   hostDirectives: [BsOtpInputValueAccessor],
 })
-export class BsOtpInputComponent implements AfterViewInit {
+export class BsOtpInputComponent {
   readonly groups = input<number[]>([1, 1, 1, 1, 1, 1]);
   readonly type = input<OtpInputType>('numeric');
   readonly case = input<OtpInputCase>('upper');
@@ -119,11 +118,6 @@ export class BsOtpInputComponent implements AfterViewInit {
       if (!ref) return;
       ref.nativeElement.invalid = this.invalid();
     });
-  }
-
-  ngAfterViewInit(): void {
-    // No-op: the focus delegation is set up in the constructor; effects handle
-    // the rest. This hook exists to keep the lifecycle explicit for readers.
   }
 
   protected onValueChange(event: Event): void {

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.ts
@@ -1,0 +1,155 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  ElementRef,
+  computed,
+  effect,
+  inject,
+  input,
+  model,
+  output,
+  viewChild,
+} from '@angular/core';
+import { MintOtpInputElement } from '../web-components/mint-otp-input.element';
+import { BsOtpInputValueAccessor } from '../value-accessor/otp-input-value-accessor';
+import { OtpInputType } from '../types/otp-input-type';
+import { OtpInputCase } from '../types/otp-input-case';
+import { OtpInputSize } from '../types/otp-input-size';
+
+@Component({
+  selector: 'bs-otp-input',
+  template: `
+    <mp-otp-input
+      #el
+      class="bs-otp-input"
+      [attr.type]="type()"
+      [attr.case]="case()"
+      [attr.size]="size()"
+      [attr.disabled]="disabledAttr()"
+      [attr.invalid]="invalidAttr()"
+      [attr.label]="label()"
+      (value-change)="onValueChange($event)"
+      (complete)="onCompleteEvent($event)"
+    ></mp-otp-input>
+  `,
+  styles: [`
+    :host { display: inline-block; }
+    .bs-otp-input { display: inline-flex; }
+  `],
+  host: {
+    '[attr.size]': 'size()',
+  },
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [BsOtpInputValueAccessor],
+})
+export class BsOtpInputComponent implements AfterViewInit {
+  readonly groups = input<number[]>([1, 1, 1, 1, 1, 1]);
+  readonly type = input<OtpInputType>('numeric');
+  readonly case = input<OtpInputCase>('upper');
+  readonly size = input<OtpInputSize>('md');
+  readonly disabled = input(false);
+  readonly invalid = input(false);
+  readonly label = input<string | null>(null);
+
+  readonly value = model<string | undefined>(undefined);
+
+  readonly valueChange = output<string>();
+  readonly complete = output<string>();
+
+  readonly elementRef = viewChild.required<ElementRef<MintOtpInputElement>>('el');
+
+  private readonly hostRef = inject(ElementRef<HTMLElement>);
+
+  protected readonly disabledAttr = computed(() => (this.disabled() ? '' : null));
+  protected readonly invalidAttr = computed(() => (this.invalid() ? '' : null));
+
+  constructor() {
+    // Override the host DOM element's `.focus` so external directives that look
+    // up the element and call `.focus()` on it (e.g. FocusOnLoadDirective's
+    // `*[autofocus]`) route into the internal hidden input. Without this, the
+    // call hits HTMLElement.prototype.focus which is a no-op on a non-focusable
+    // host. Capture the WC ref lazily because viewChild isn't available in the
+    // constructor and external directives may call .focus() before our
+    // ngAfterViewInit runs.
+    const host = this.hostRef.nativeElement as HTMLElement & { focus: (o?: FocusOptions) => void };
+    Object.defineProperty(host, 'focus', {
+      value: (options?: FocusOptions) => {
+        const wc = this.elementRef()?.nativeElement;
+        if (wc) {
+          wc.focus(options);
+        } else {
+          // Defer to a microtask so a focus() call landing before the view is
+          // ready still hits the WC once it mounts. FocusOnLoadDirective uses
+          // setTimeout(10) which runs after microtasks, so this path is mostly
+          // defensive — but it cheaply handles the race.
+          Promise.resolve().then(() => this.elementRef()?.nativeElement.focus(options));
+        }
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    // Forward signal inputs that aren't attributes (groups is a number[] —
+    // attribute serialisation works for it, but property write is the canonical
+    // path and avoids the "string-from-attribute" parse round-trip).
+    effect(() => {
+      const ref = this.elementRef();
+      if (!ref) return;
+      ref.nativeElement.groups = this.groups();
+    });
+
+    // Forward `value` model writes to the WC. Skip undefined so a freshly-set
+    // form control's writeValue(null) can still clear the field (we map null
+    // to '' inside the WC's normaliseValue).
+    effect(() => {
+      const ref = this.elementRef();
+      if (!ref) return;
+      const v = this.value();
+      if (v === undefined) return;
+      ref.nativeElement.value = v;
+    });
+
+    // Forward the `invalid` boolean to the WC's invalid property (mirrors the
+    // attribute, but property write is the canonical path for a boolean).
+    effect(() => {
+      const ref = this.elementRef();
+      if (!ref) return;
+      ref.nativeElement.invalid = this.invalid();
+    });
+  }
+
+  ngAfterViewInit(): void {
+    // No-op: the focus delegation is set up in the constructor; effects handle
+    // the rest. This hook exists to keep the lifecycle explicit for readers.
+  }
+
+  protected onValueChange(event: Event): void {
+    const detail = (event as CustomEvent<string>).detail ?? '';
+    this.value.set(detail);
+    this.valueChange.emit(detail);
+  }
+
+  protected onCompleteEvent(event: Event): void {
+    // The WC's `complete` DOM event bubbles. The wrapper's Output is also
+    // named `complete`. Without stopPropagation, the parent's `(complete)`
+    // binding would catch BOTH the bubbled DOM event AND the Output emit
+    // below — Angular's `(name)` binding on a child component listens to
+    // both channels when their names collide.
+    event.stopPropagation();
+    const detail = (event as CustomEvent<string>).detail ?? '';
+    this.complete.emit(detail);
+  }
+
+  /** Move focus into the hidden input. */
+  focus(options?: FocusOptions): void {
+    this.elementRef()?.nativeElement.focus(options);
+  }
+
+  /** Reset the value to empty string. */
+  clear(): void {
+    this.elementRef()?.nativeElement.clear();
+  }
+}

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/components/otp-input.component.ts
@@ -26,7 +26,6 @@ import { OtpInputSize } from '../types/otp-input-size';
       [attr.type]="type()"
       [attr.case]="case()"
       [attr.size]="size()"
-      [attr.disabled]="disabledAttr()"
       [attr.invalid]="invalidAttr()"
       [attr.label]="label()"
       (value-change)="onValueChange($event)"
@@ -62,7 +61,6 @@ export class BsOtpInputComponent {
 
   private readonly hostRef = inject(ElementRef<HTMLElement>);
 
-  protected readonly disabledAttr = computed(() => (this.disabled() ? '' : null));
   protected readonly invalidAttr = computed(() => (this.invalid() ? '' : null));
 
   constructor() {
@@ -117,6 +115,24 @@ export class BsOtpInputComponent {
       const ref = this.elementRef();
       if (!ref) return;
       ref.nativeElement.invalid = this.invalid();
+    });
+
+    // Forward `disabled` via attribute. This used to be `[attr.disabled]` in the
+    // template, but that creates a race with the CVA's `setDisabledState`:
+    // both write to the same DOM attribute, and any signal change in the
+    // wrapper re-fires the template binding which clobbers the CVA's
+    // form-disabled state. Using an effect makes the write fire only when the
+    // `disabled` signal actually changes; the CVA's imperative writes are
+    // unaffected because Angular doesn't reconcile attribute bindings in the
+    // template anymore for this attr.
+    effect(() => {
+      const ref = this.elementRef();
+      if (!ref) return;
+      if (this.disabled()) {
+        ref.nativeElement.setAttribute('disabled', '');
+      } else {
+        ref.nativeElement.removeAttribute('disabled');
+      }
     });
   }
 

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/types/otp-input-case.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/types/otp-input-case.ts
@@ -1,0 +1,1 @@
+export type OtpInputCase = 'upper' | 'lower' | 'preserve';

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/types/otp-input-size.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/types/otp-input-size.ts
@@ -1,0 +1,1 @@
+export type OtpInputSize = 'sm' | 'md' | 'lg';

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/types/otp-input-type.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/types/otp-input-type.ts
@@ -1,0 +1,1 @@
+export type OtpInputType = 'numeric' | 'alphanumeric' | 'password';

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/value-accessor/otp-input-value-accessor.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/value-accessor/otp-input-value-accessor.ts
@@ -1,0 +1,87 @@
+import { DestroyRef, Directive, Injector, OnInit, forwardRef, inject } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl } from '@angular/forms';
+import { BsOtpInputComponent } from '../components/otp-input.component';
+
+@Directive({
+  selector: 'bs-otp-input',
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => BsOtpInputValueAccessor),
+    multi: true,
+  }],
+  host: {
+    '(value-change)': 'onValueChangeEvent($event)',
+    '(focusout)': 'onTouchEvent()',
+  },
+})
+export class BsOtpInputValueAccessor implements ControlValueAccessor, OnInit {
+  private host = inject(BsOtpInputComponent);
+  // Inject NgControl LAZILY via the injector. Eager `inject(NgControl)` here
+  // creates a cycle: NgControl → NG_VALUE_ACCESSOR token → this directive →
+  // NgControl. Looking it up in ngOnInit (after the form directive has
+  // finished its own construction) breaks the cycle.
+  private injector = inject(Injector);
+  private destroyRef = inject(DestroyRef);
+  private ngControl: NgControl | null = null;
+
+  private onValueChange?: (value: string) => void;
+  private onTouched?: () => void;
+
+  ngOnInit(): void {
+    this.ngControl = this.injector.get(NgControl, null);
+    // Push invalid state to the WC whenever the form control's status or
+    // touched state changes. Mirrors Bootstrap's .is-invalid convention: only
+    // mark the boxes red after the control has been touched, otherwise we'd
+    // light up a "required" field the moment the form mounts.
+    if (!this.ngControl?.control) return;
+    const sub = this.ngControl.statusChanges?.subscribe(() => this.syncInvalid());
+    if (sub) this.destroyRef.onDestroy(() => sub.unsubscribe());
+    // Sync once now in case the control was created already invalid+touched
+    // (e.g. server-side validation rehydrate).
+    queueMicrotask(() => this.syncInvalid());
+  }
+
+  protected onValueChangeEvent(ev: Event): void {
+    if (!this.onValueChange) return;
+    const detail = (ev as CustomEvent<string>).detail ?? '';
+    this.onValueChange(detail);
+  }
+
+  protected onTouchEvent(): void {
+    if (this.onTouched) this.onTouched();
+    // Re-sync invalid on touch — statusChanges doesn't always fire on touched
+    // alone, so we trigger the recompute here.
+    this.syncInvalid();
+  }
+
+  private syncInvalid(): void {
+    const ref = this.host.elementRef();
+    if (!ref || !this.ngControl) return;
+    const invalid = (this.ngControl.invalid ?? false) && (this.ngControl.touched ?? false);
+    ref.nativeElement.invalid = invalid;
+  }
+
+  registerOnChange(fn: (value: string) => void): void {
+    this.onValueChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  writeValue(value: string | null | undefined): void {
+    const ref = this.host.elementRef();
+    if (!ref) return;
+    ref.nativeElement.value = value ?? '';
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    const ref = this.host.elementRef();
+    if (!ref) return;
+    if (isDisabled) {
+      ref.nativeElement.setAttribute('disabled', '');
+    } else {
+      ref.nativeElement.removeAttribute('disabled');
+    }
+  }
+}

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/value-accessor/otp-input-value-accessor.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/value-accessor/otp-input-value-accessor.ts
@@ -55,6 +55,10 @@ export class BsOtpInputValueAccessor implements ControlValueAccessor, OnInit {
   }
 
   private syncInvalid(): void {
+    // Guard async-scheduled invocations: queueMicrotask in ngOnInit + the
+    // statusChanges subscription are both possible after destroy. Reading
+    // `host.elementRef()` (a required viewChild) on a destroyed view throws.
+    if (this.destroyRef.destroyed) return;
     const ref = this.host.elementRef();
     if (!ref || !this.ngControl) return;
     const invalid = (this.ngControl.invalid ?? false) && (this.ngControl.touched ?? false);

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.aria.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.aria.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import './mint-otp-input.element';
+import type { MintOtpInputElement } from './mint-otp-input.element';
+
+describe('mp-otp-input — ARIA contract', () => {
+  let el: MintOtpInputElement;
+
+  beforeEach(async () => {
+    el = document.createElement('mp-otp-input') as MintOtpInputElement;
+    document.body.appendChild(el);
+    await (el as unknown as { updateComplete: Promise<void> }).updateComplete;
+  });
+
+  afterEach(() => { el.remove(); });
+
+  it('exposes exactly one focusable input element', () => {
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    expect(inputs?.length).toBe(1);
+  });
+
+  it('marks decorative boxes as aria-hidden so AT sees one input only', () => {
+    const boxes = el.shadowRoot?.querySelectorAll('.box');
+    expect(boxes?.length).toBeGreaterThan(0);
+    for (const box of Array.from(boxes ?? [])) {
+      expect(box.getAttribute('aria-hidden')).toBe('true');
+    }
+  });
+
+  it('falls back to a default aria-label when none is provided', () => {
+    const input = el.shadowRoot?.querySelector('input');
+    expect(input?.getAttribute('aria-label')).toBe('One-time code');
+  });
+
+  it('applies a custom aria-label when label is set', async () => {
+    el.label = 'Verification code';
+    await (el as unknown as { updateComplete: Promise<void> }).updateComplete;
+    const input = el.shadowRoot?.querySelector('input');
+    expect(input?.getAttribute('aria-label')).toBe('Verification code');
+  });
+
+  it('reflects aria-invalid from the invalid property', async () => {
+    el.invalid = true;
+    await (el as unknown as { updateComplete: Promise<void> }).updateComplete;
+    const input = el.shadowRoot?.querySelector('input');
+    expect(input?.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('renders the hidden input above the decorative boxes so taps go to it', () => {
+    // The hidden input sits absolute over the row; its z-index in styles is 1
+    // while boxes are static. Verify via stacking order, not pixel hit-testing
+    // (jsdom doesn't do layout) — the input must be the last input/span at z-index>=1.
+    const input = el.shadowRoot?.querySelector<HTMLElement>('.hidden-input');
+    expect(input).toBeTruthy();
+    expect(input?.classList.contains('hidden-input')).toBe(true);
+  });
+
+  it('disables the hidden input when the host is disabled', async () => {
+    el.disabled = true;
+    await (el as unknown as { updateComplete: Promise<void> }).updateComplete;
+    const input = el.shadowRoot?.querySelector<HTMLInputElement>('input');
+    expect(input?.disabled).toBe(true);
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.html
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.html
@@ -1,0 +1,3 @@
+<!-- Hidden input + boxes are rendered dynamically by render(). This file exists
+     so the codegen-wc target produces a `styles` export from the sibling .scss;
+     the `template` export it generates here is intentionally unused. -->

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.scss
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.scss
@@ -1,0 +1,130 @@
+:host {
+  display: inline-flex;
+  position: relative;
+  box-sizing: border-box;
+  --bs-otp-input-box-bg: var(--bs-body-bg, #fff);
+  --bs-otp-input-box-color: var(--bs-body-color, #212529);
+  --bs-otp-input-box-border: var(--bs-border-color, #ced4da);
+  --bs-otp-input-box-border-active: var(--bs-primary, #0d6efd);
+  --bs-otp-input-box-border-invalid: var(--bs-danger, #dc3545);
+  --bs-otp-input-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+  --bs-otp-input-box-shadow-invalid: 0 0 0 0.25rem rgba(220, 53, 69, 0.25);
+  --bs-otp-input-radius: 0.375rem;
+  --bs-otp-input-gap: 0.5rem;
+  --bs-otp-input-min-box-size: 2.875rem;
+  --bs-otp-input-font-size: 1.25rem;
+  --bs-otp-input-padding-y: 0.375rem;
+  --bs-otp-input-padding-x: 0.5rem;
+}
+
+:host([size='sm']) {
+  --bs-otp-input-min-box-size: 2.25rem;
+  --bs-otp-input-font-size: 1rem;
+  --bs-otp-input-gap: 0.375rem;
+  --bs-otp-input-padding-y: 0.25rem;
+  --bs-otp-input-padding-x: 0.4rem;
+}
+
+:host([size='lg']) {
+  --bs-otp-input-min-box-size: 3.5rem;
+  --bs-otp-input-font-size: 1.5rem;
+  --bs-otp-input-gap: 0.625rem;
+  --bs-otp-input-padding-y: 0.5rem;
+  --bs-otp-input-padding-x: 0.625rem;
+}
+
+:host([disabled]) {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--bs-otp-input-gap);
+}
+
+// Hidden full-width input owns focus, paste, IME and SMS autofill. opacity:0
+// + transparent caret/color hides its rendered text and caret without making
+// it unfocusable. Stretched to cover the entire box row so any tap inside the
+// container hits the input and routes the platform keyboard.
+.hidden-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  color: transparent;
+  caret-color: transparent;
+  font-size: var(--bs-otp-input-font-size);
+  text-shadow: none;
+  z-index: 1;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hidden-input:focus {
+  outline: none;
+}
+
+.box {
+  // CSS-grid single-cell stack: spacer reserves width, content overlays it.
+  // The spacer-based sizing keeps a multi-char box (e.g. 6-char MS Office group)
+  // at a stable width whether it's empty or full, so the layout doesn't reflow
+  // mid-typing.
+  position: relative;
+  display: inline-grid;
+  grid-template-areas: 'stack';
+  align-items: center;
+  justify-items: center;
+  min-width: var(--bs-otp-input-min-box-size);
+  height: var(--bs-otp-input-min-box-size);
+  padding: var(--bs-otp-input-padding-y) var(--bs-otp-input-padding-x);
+  background: var(--bs-otp-input-box-bg);
+  color: var(--bs-otp-input-box-color);
+  border: 1px solid var(--bs-otp-input-box-border);
+  border-radius: var(--bs-otp-input-radius);
+  font-size: var(--bs-otp-input-font-size);
+  font-weight: 500;
+  line-height: 1;
+  font-family: var(--bs-font-monospace, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  letter-spacing: 0.125rem;
+  user-select: none;
+  white-space: pre;
+  transition: border-color 120ms ease-out, box-shadow 120ms ease-out;
+}
+
+.box-spacer,
+.box-content {
+  grid-area: stack;
+  line-height: 1;
+  white-space: pre;
+}
+
+.box-spacer {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.box.box-active {
+  border-color: var(--bs-otp-input-box-border-active);
+  box-shadow: var(--bs-otp-input-box-shadow-focus);
+}
+
+.box.box-invalid {
+  border-color: var(--bs-otp-input-box-border-invalid);
+}
+
+.box.box-invalid.box-active {
+  box-shadow: var(--bs-otp-input-box-shadow-invalid);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .box {
+    transition: none;
+  }
+}

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.spec.ts
@@ -304,6 +304,84 @@ describe('mp-otp-input — Scenario 9: reactive groups change', () => {
     expect(el.value).toBe('123456');
     expect(boxes(el)).toHaveLength(8);
   });
+
+  it('emits value-change when groups shrinking truncates the value', async () => {
+    const input = hiddenInput(el);
+    fireInput(input, '123456');
+    await ready(el);
+
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    el.groups = [1, 1, 1, 1];
+    await ready(el);
+    expect(events).toEqual(['1234']);
+  });
+
+  it('does not emit value-change when groups grows (no truncation)', async () => {
+    const input = hiddenInput(el);
+    fireInput(input, '123');
+    await ready(el);
+
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    el.groups = [1, 1, 1, 1, 1, 1, 1, 1];
+    await ready(el);
+    expect(events).toEqual([]);
+  });
+});
+
+describe('mp-otp-input — type/case change re-normalises value', () => {
+  it('strips letters when switching from alphanumeric to numeric, emits value-change', async () => {
+    const el = makeElement();
+    el.type = 'alphanumeric';
+    el.case = 'preserve';
+    await ready(el);
+    fireInput(hiddenInput(el), 'aB1cD2');
+    await ready(el);
+    expect(el.value).toBe('aB1cD2');
+
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    el.type = 'numeric';
+    await ready(el);
+    expect(el.value).toBe('12');
+    expect(events).toEqual(['12']);
+    el.remove();
+  });
+
+  it('uppercases existing letters when case flips upper, emits value-change', async () => {
+    const el = makeElement();
+    el.type = 'alphanumeric';
+    el.case = 'preserve';
+    await ready(el);
+    fireInput(hiddenInput(el), 'abc12');
+    await ready(el);
+    expect(el.value).toBe('abc12');
+
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    el.case = 'upper';
+    await ready(el);
+    expect(el.value).toBe('ABC12');
+    expect(events).toEqual(['ABC12']);
+    el.remove();
+  });
+
+  it('does not emit value-change when type/case toggle leaves value unchanged', async () => {
+    const el = makeElement();
+    await ready(el);
+    fireInput(hiddenInput(el), '123');
+    await ready(el);
+
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    // numeric -> alphanumeric (digits still valid; uppercase doesn't touch digits)
+    el.type = 'alphanumeric';
+    await ready(el);
+    expect(events).toEqual([]);
+    expect(el.value).toBe('123');
+    el.remove();
+  });
 });
 
 describe('mp-otp-input — Scenario 10: groups validation', () => {

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.spec.ts
@@ -1,0 +1,474 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import './mint-otp-input.element';
+import type { MintOtpInputElement } from './mint-otp-input.element';
+
+function makeElement(attrs: Record<string, string> = {}): MintOtpInputElement {
+  const el = document.createElement('mp-otp-input') as MintOtpInputElement;
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return el;
+}
+
+async function ready(el: MintOtpInputElement): Promise<void> {
+  await (el as unknown as { updateComplete: Promise<void> }).updateComplete;
+}
+
+function hiddenInput(el: MintOtpInputElement): HTMLInputElement {
+  const input = el.shadowRoot?.querySelector<HTMLInputElement>('.hidden-input');
+  if (!input) throw new Error('hidden input not found');
+  return input;
+}
+
+function boxes(el: MintOtpInputElement): HTMLElement[] {
+  return Array.from(el.shadowRoot?.querySelectorAll<HTMLElement>('.box') ?? []);
+}
+
+function fireInput(input: HTMLInputElement, value: string): void {
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function firePaste(input: HTMLInputElement, text: string): boolean {
+  const ev = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(ev, 'clipboardData', {
+    value: { getData: (type: string) => (type === 'text' ? text : '') },
+  });
+  return input.dispatchEvent(ev);
+}
+
+describe('mp-otp-input — defaults and basic rendering', () => {
+  let el: MintOtpInputElement;
+
+  beforeEach(async () => { el = makeElement(); await ready(el); });
+  afterEach(() => { el.remove(); });
+
+  it('defaults to 6 single-character boxes', () => {
+    expect(el.groups).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(boxes(el)).toHaveLength(6);
+  });
+
+  it('starts with an empty value', () => {
+    expect(el.value).toBe('');
+  });
+
+  it('renders one hidden input that owns focus and ARIA', () => {
+    const input = hiddenInput(el);
+    expect(input.getAttribute('aria-label')).toBe('One-time code');
+    expect(input.getAttribute('aria-invalid')).toBe('false');
+    expect(input.getAttribute('autocomplete')).toBe('one-time-code');
+    expect(input.getAttribute('inputmode')).toBe('numeric');
+    expect(input.getAttribute('maxlength')).toBe('6');
+  });
+
+  it('reflects the default type as numeric', () => {
+    expect(el.type).toBe('numeric');
+  });
+});
+
+describe('mp-otp-input — Scenario 1: classic OTP typed digit-by-digit', () => {
+  let el: MintOtpInputElement;
+  const valueChanges: string[] = [];
+  const completes: string[] = [];
+
+  beforeEach(async () => {
+    el = makeElement();
+    valueChanges.length = 0;
+    completes.length = 0;
+    el.addEventListener('value-change', (e) => valueChanges.push((e as CustomEvent<string>).detail));
+    el.addEventListener('complete', (e) => completes.push((e as CustomEvent<string>).detail));
+    await ready(el);
+  });
+  afterEach(() => { el.remove(); });
+
+  it('streams partial values on every keystroke and fires complete once on the last', async () => {
+    const input = hiddenInput(el);
+    for (const c of '123456') {
+      fireInput(input, input.value + c);
+      await ready(el);
+    }
+    expect(valueChanges).toEqual(['1', '12', '123', '1234', '12345', '123456']);
+    expect(completes).toEqual(['123456']);
+  });
+
+  it('does not re-fire complete on subsequent value-equal keystrokes', async () => {
+    const input = hiddenInput(el);
+    fireInput(input, '123456');
+    await ready(el);
+    fireInput(input, '123456'); // no-op same value
+    await ready(el);
+    expect(completes).toHaveLength(1);
+  });
+});
+
+describe('mp-otp-input — Scenario 2: paste with separator junk', () => {
+  let el: MintOtpInputElement;
+  const valueChanges: string[] = [];
+  const completes: string[] = [];
+
+  beforeEach(async () => {
+    el = makeElement();
+    valueChanges.length = 0;
+    completes.length = 0;
+    el.addEventListener('value-change', (e) => valueChanges.push((e as CustomEvent<string>).detail));
+    el.addEventListener('complete', (e) => completes.push((e as CustomEvent<string>).detail));
+    await ready(el);
+  });
+  afterEach(() => { el.remove(); });
+
+  it('strips non-numeric junk and fills from index 0', async () => {
+    const input = hiddenInput(el);
+    firePaste(input, 'Your code: 123-456 thanks');
+    await ready(el);
+    expect(el.value).toBe('123456');
+    expect(valueChanges).toEqual(['123456']);
+    expect(completes).toEqual(['123456']);
+  });
+
+  it('ignores chars past the total length', async () => {
+    const input = hiddenInput(el);
+    firePaste(input, '1234567890');
+    await ready(el);
+    expect(el.value).toBe('123456');
+  });
+
+  it('fills only the first N boxes for short paste', async () => {
+    const input = hiddenInput(el);
+    firePaste(input, '123');
+    await ready(el);
+    expect(el.value).toBe('123');
+    expect(completes).toHaveLength(0);
+  });
+});
+
+describe('mp-otp-input — Scenario 3: non-uniform license key', () => {
+  let el: MintOtpInputElement;
+
+  beforeEach(async () => {
+    el = makeElement();
+    el.groups = [6, 6, 4, 4, 6, 6];
+    el.type = 'alphanumeric';
+    el.case = 'upper';
+    await ready(el);
+  });
+  afterEach(() => { el.remove(); });
+
+  it('renders one box per group element', () => {
+    expect(boxes(el)).toHaveLength(6);
+  });
+
+  it('strips dashes and uppercases on paste, fills full 32 chars', async () => {
+    const completes: string[] = [];
+    el.addEventListener('complete', (e) => completes.push((e as CustomEvent<string>).detail));
+    const input = hiddenInput(el);
+    firePaste(input, 'abc123-def456-7890-asdf-zxcvbn-qwerty');
+    await ready(el);
+    expect(el.value).toBe('ABC123DEF4567890ASDFZXCVBNQWERTY');
+    expect(el.value.length).toBe(32);
+    expect(completes).toEqual(['ABC123DEF4567890ASDFZXCVBNQWERTY']);
+  });
+
+  it('disables one-time-code autocomplete for non-uniform groups', () => {
+    expect(hiddenInput(el).getAttribute('autocomplete')).toBe('off');
+  });
+
+  it('uses inputmode=text for alphanumeric', () => {
+    expect(hiddenInput(el).getAttribute('inputmode')).toBe('text');
+  });
+});
+
+describe('mp-otp-input — Scenario 4: Backspace behavior via single hidden input', () => {
+  let el: MintOtpInputElement;
+
+  beforeEach(async () => { el = makeElement(); await ready(el); });
+  afterEach(() => { el.remove(); });
+
+  it('shrinking the value via input event emits value-change with the shorter string', async () => {
+    const input = hiddenInput(el);
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    // Type up to 3, then simulate backspace twice by shrinking.
+    fireInput(input, '1');
+    await ready(el);
+    fireInput(input, '12');
+    await ready(el);
+    fireInput(input, '123');
+    await ready(el);
+    fireInput(input, '12');
+    await ready(el);
+    fireInput(input, '1');
+    await ready(el);
+    expect(events).toEqual(['1', '12', '123', '12', '1']);
+    expect(el.value).toBe('1');
+  });
+
+  it('does not re-fire complete when shrinking from complete then completing again', async () => {
+    const input = hiddenInput(el);
+    const completes: string[] = [];
+    el.addEventListener('complete', (e) => completes.push((e as CustomEvent<string>).detail));
+    fireInput(input, '123456');
+    await ready(el);
+    fireInput(input, '12345');
+    await ready(el);
+    fireInput(input, '123456');
+    await ready(el);
+    expect(completes).toEqual(['123456', '123456']);
+  });
+});
+
+describe('mp-otp-input — Scenario 5: password mask reveal window', () => {
+  let el: MintOtpInputElement;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    el = makeElement();
+    el.type = 'password';
+    await ready(el);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    el.remove();
+  });
+
+  it('shows the just-typed char then masks it after 700ms', async () => {
+    const input = hiddenInput(el);
+    fireInput(input, '1');
+    await ready(el);
+    let contentSpans = el.shadowRoot?.querySelectorAll('.box-content');
+    expect(contentSpans?.[0]?.textContent).toBe('1');
+
+    vi.advanceTimersByTime(700);
+    await ready(el);
+    contentSpans = el.shadowRoot?.querySelectorAll('.box-content');
+    expect(contentSpans?.[0]?.textContent).toBe('•');
+  });
+
+  it('only reveals the most recent char, earlier ones are already masked', async () => {
+    const input = hiddenInput(el);
+    fireInput(input, '1');
+    await ready(el);
+    fireInput(input, '12');
+    await ready(el);
+    const content = Array.from(el.shadowRoot?.querySelectorAll('.box-content') ?? [])
+      .map((s) => s.textContent ?? '');
+    expect(content[0]).toBe('•');
+    expect(content[1]).toBe('2');
+  });
+
+  it('does not reveal chars when content arrives via paste', async () => {
+    const input = hiddenInput(el);
+    firePaste(input, '123456');
+    await ready(el);
+    const content = Array.from(el.shadowRoot?.querySelectorAll('.box-content') ?? [])
+      .map((s) => s.textContent ?? '');
+    expect(content.every((c) => c === '•')).toBe(true);
+  });
+
+  it('masks immediately on complete regardless of the timer', async () => {
+    const input = hiddenInput(el);
+    for (const c of '12345') {
+      fireInput(input, input.value + c);
+      await ready(el);
+    }
+    fireInput(input, '123456'); // triggers complete
+    await ready(el);
+    const content = Array.from(el.shadowRoot?.querySelectorAll('.box-content') ?? [])
+      .map((s) => s.textContent ?? '');
+    expect(content[5]).toBe('•');
+  });
+});
+
+describe('mp-otp-input — Scenario 9: reactive groups change', () => {
+  let el: MintOtpInputElement;
+
+  beforeEach(async () => { el = makeElement(); await ready(el); });
+  afterEach(() => { el.remove(); });
+
+  it('truncates the current value when groups shrinks the total length', async () => {
+    const input = hiddenInput(el);
+    fireInput(input, '123456');
+    await ready(el);
+    expect(el.value).toBe('123456');
+
+    el.groups = [1, 1, 1, 1];
+    await ready(el);
+    expect(el.value).toBe('1234');
+  });
+
+  it('keeps the current value when groups grows the total', async () => {
+    const input = hiddenInput(el);
+    fireInput(input, '123456');
+    await ready(el);
+
+    el.groups = [1, 1, 1, 1, 1, 1, 1, 1];
+    await ready(el);
+    expect(el.value).toBe('123456');
+    expect(boxes(el)).toHaveLength(8);
+  });
+});
+
+describe('mp-otp-input — Scenario 10: groups validation', () => {
+  it('clamps elements above MAX_GROUP_SIZE and warns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const el = makeElement();
+    el.groups = [15];
+    await ready(el);
+    expect(el.groups).toEqual([10]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    el.remove();
+  });
+
+  it('drops trailing groups when total exceeds MAX_TOTAL and warns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const el = makeElement();
+    el.groups = [10, 10, 10, 10, 10]; // total = 50, max = 40
+    await ready(el);
+    expect(el.groups.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(40);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    el.remove();
+  });
+
+  it('falls back to default groups when given empty array or null', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const el = makeElement();
+    el.groups = [];
+    await ready(el);
+    expect(el.groups).toEqual([1, 1, 1, 1, 1, 1]);
+    warn.mockRestore();
+    el.remove();
+  });
+
+  it('clamps zero and negative entries to 1', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const el = makeElement();
+    el.groups = [0, -3, 2];
+    await ready(el);
+    expect(el.groups).toEqual([1, 1, 2]);
+    warn.mockRestore();
+    el.remove();
+  });
+});
+
+describe('mp-otp-input — case handling for alphanumeric', () => {
+  it('uppercases input when case=upper (default)', async () => {
+    const el = makeElement();
+    el.type = 'alphanumeric';
+    await ready(el);
+    fireInput(hiddenInput(el), 'abc');
+    await ready(el);
+    expect(el.value).toBe('ABC');
+    el.remove();
+  });
+
+  it('lowercases when case=lower', async () => {
+    const el = makeElement();
+    el.type = 'alphanumeric';
+    el.case = 'lower';
+    await ready(el);
+    fireInput(hiddenInput(el), 'AbC');
+    await ready(el);
+    expect(el.value).toBe('abc');
+    el.remove();
+  });
+
+  it('preserves case when case=preserve', async () => {
+    const el = makeElement();
+    el.type = 'alphanumeric';
+    el.case = 'preserve';
+    await ready(el);
+    fireInput(hiddenInput(el), 'AbC');
+    await ready(el);
+    expect(el.value).toBe('AbC');
+    el.remove();
+  });
+
+  it('ignores case for numeric type', async () => {
+    const el = makeElement();
+    el.case = 'lower';
+    await ready(el);
+    fireInput(hiddenInput(el), '123');
+    await ready(el);
+    expect(el.value).toBe('123');
+    el.remove();
+  });
+});
+
+describe('mp-otp-input — programmatic value setter', () => {
+  it('does not fire complete on writeValue with a complete string', async () => {
+    const el = makeElement();
+    const completes: string[] = [];
+    el.addEventListener('complete', (e) => completes.push((e as CustomEvent<string>).detail));
+    await ready(el);
+
+    el.value = '123456';
+    await ready(el);
+    expect(el.value).toBe('123456');
+    expect(completes).toEqual([]);
+    el.remove();
+  });
+
+  it('normalises programmatic value through the same filter', async () => {
+    const el = makeElement();
+    await ready(el);
+    el.value = 'a1b2c3' as unknown as string;
+    await ready(el);
+    expect(el.value).toBe('123'); // numeric filter strips letters
+    el.remove();
+  });
+});
+
+describe('mp-otp-input — focus() delegates to hidden input', () => {
+  it('focuses the hidden input', async () => {
+    const el = makeElement();
+    await ready(el);
+    el.focus();
+    expect(document.activeElement === el || el.shadowRoot?.activeElement?.classList.contains('hidden-input')).toBe(true);
+    el.remove();
+  });
+});
+
+describe('mp-otp-input — clear()', () => {
+  it('resets the value and emits value-change', async () => {
+    const el = makeElement();
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    await ready(el);
+
+    fireInput(hiddenInput(el), '123');
+    await ready(el);
+    el.clear();
+    await ready(el);
+    expect(el.value).toBe('');
+    expect(events).toEqual(['123', '']);
+    el.remove();
+  });
+
+  it('is a no-op when already empty', async () => {
+    const el = makeElement();
+    const events: string[] = [];
+    el.addEventListener('value-change', (e) => events.push((e as CustomEvent<string>).detail));
+    await ready(el);
+    el.clear();
+    expect(events).toEqual([]);
+    el.remove();
+  });
+});
+
+describe('mp-otp-input — autocomplete heuristic', () => {
+  it('uses one-time-code only for numeric + all-single-char groups', async () => {
+    const el = makeElement();
+    await ready(el);
+    expect(hiddenInput(el).getAttribute('autocomplete')).toBe('one-time-code');
+
+    el.type = 'alphanumeric';
+    await ready(el);
+    expect(hiddenInput(el).getAttribute('autocomplete')).toBe('off');
+
+    el.type = 'numeric';
+    el.groups = [3, 3];
+    await ready(el);
+    expect(hiddenInput(el).getAttribute('autocomplete')).toBe('off');
+    el.remove();
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.spec.ts
@@ -455,6 +455,39 @@ describe('mp-otp-input — clear()', () => {
   });
 });
 
+describe('mp-otp-input — active-box highlight only while focused', () => {
+  let el: MintOtpInputElement;
+
+  beforeEach(async () => { el = makeElement(); await ready(el); });
+  afterEach(() => { el.remove(); });
+
+  function hasActiveBox(): boolean {
+    return Array.from(el.shadowRoot?.querySelectorAll('.box') ?? [])
+      .some((b) => b.classList.contains('box-active'));
+  }
+
+  it('does not render any box as active when the component is not focused', () => {
+    expect(hasActiveBox()).toBe(false);
+  });
+
+  it('highlights the next box once the hidden input gains focus', async () => {
+    const input = hiddenInput(el);
+    input.dispatchEvent(new Event('focus', { bubbles: true }));
+    await ready(el);
+    expect(hasActiveBox()).toBe(true);
+  });
+
+  it('removes the highlight on blur', async () => {
+    const input = hiddenInput(el);
+    input.dispatchEvent(new Event('focus', { bubbles: true }));
+    await ready(el);
+    expect(hasActiveBox()).toBe(true);
+    input.dispatchEvent(new Event('blur', { bubbles: true }));
+    await ready(el);
+    expect(hasActiveBox()).toBe(false);
+  });
+});
+
 describe('mp-otp-input — autocomplete heuristic', () => {
   it('uses one-time-code only for numeric + all-single-char groups', async () => {
     const el = makeElement();

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.ts
@@ -1,0 +1,427 @@
+import { LitElement, html, type TemplateResult } from 'lit';
+import { styles } from './mint-otp-input.element.template';
+import { OtpInputType } from '../types/otp-input-type';
+import { OtpInputCase } from '../types/otp-input-case';
+import { OtpInputSize } from '../types/otp-input-size';
+
+/**
+ * Bootstrap-flavoured OTP / segmented-code input.
+ *
+ * Architecture: one hidden full-width `<input>` owns focus / paste / IME /
+ * SMS autofill; decorative `<span>` boxes render slices of the value at fixed
+ * positions. Boxes are `aria-hidden`; screen readers see one text input.
+ *
+ * Layout via `groups: number[]` — each array element is the character capacity
+ * of one visual box. `[1,1,1,1,1,1]` (default) is the classic 6-digit OTP;
+ * `[6,6,4,4,6,6]` is the MS Office product-key shape.
+ *
+ * Events:
+ *  - `value-change` fires on every keystroke, paste, and clear, payload is the
+ *    current (possibly partial) value string.
+ *  - `complete` fires once when the value transitions from incomplete to
+ *    `length === sum(groups)` via user interaction. Re-fires on re-completion.
+ *    Does NOT fire on programmatic writes via the `value` setter.
+ *
+ * Both bubble and compose so an Angular wrapper's host listeners pick them up.
+ */
+export class MintOtpInputElement extends LitElement {
+  static override styles = [styles];
+
+  static override get observedAttributes(): string[] {
+    return [
+      ...(super.observedAttributes ?? []),
+      'type',
+      'case',
+      'size',
+      'disabled',
+      'label',
+      'invalid',
+      'groups',
+    ];
+  }
+
+  static override properties = {
+    value: { attribute: false },
+    groups: {
+      attribute: 'groups',
+      converter: {
+        fromAttribute: (s: string | null): number[] => {
+          if (!s) return [...MintOtpInputElement.DEFAULT_GROUPS];
+          const parsed = s.split(',').map(p => Number(p.trim())).filter(n => Number.isFinite(n));
+          return parsed.length > 0 ? parsed : [...MintOtpInputElement.DEFAULT_GROUPS];
+        },
+        toAttribute: (v: number[] | null): string | null =>
+          Array.isArray(v) ? v.join(',') : null,
+      },
+      reflect: false,
+    },
+    type: { attribute: 'type', type: String, reflect: true },
+    case: { attribute: 'case', type: String, reflect: true },
+    size: { attribute: 'size', type: String, reflect: true },
+    disabled: { attribute: 'disabled', type: Boolean, reflect: true },
+    label: { attribute: 'label', type: String, reflect: false },
+    invalid: { attribute: 'invalid', type: Boolean, reflect: true },
+  };
+
+  type: OtpInputType = 'numeric';
+  case: OtpInputCase = 'upper';
+  size: OtpInputSize = 'md';
+  disabled = false;
+  label: string | null = null;
+  invalid = false;
+
+  static readonly MAX_GROUP_SIZE = 10;
+  static readonly MAX_TOTAL = 40;
+  static readonly DEFAULT_GROUPS: readonly number[] = Object.freeze([1, 1, 1, 1, 1, 1]);
+  static readonly REVEAL_MS = 700;
+  static readonly MASK_CHAR = '•';
+
+  private _value = '';
+  private _groups: number[] = [...MintOtpInputElement.DEFAULT_GROUPS];
+  private _revealedIndex: number | null = null;
+  private _revealedUntil = 0;
+  private _revealTimer: ReturnType<typeof setTimeout> | null = null;
+  private _inputEl: HTMLInputElement | null = null;
+
+  get value(): string {
+    return this._value;
+  }
+
+  set value(next: string | null | undefined) {
+    const old = this._value;
+    const normalised = this.normaliseValue(next ?? '');
+    if (old === normalised) return;
+    this._value = normalised;
+    this.clearReveal();
+    this.requestUpdate('value', old);
+  }
+
+  get groups(): number[] {
+    return this._groups;
+  }
+
+  set groups(next: number[] | null | undefined) {
+    const old = this._groups;
+    const normalised = this.normaliseGroups(next);
+    if (this.arraysEqual(old, normalised)) return;
+    this._groups = normalised;
+    const total = this.totalLength();
+    if (this._value.length > total) this._value = this._value.slice(0, total);
+    this.requestUpdate('groups', old);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._revealTimer) {
+      clearTimeout(this._revealTimer);
+      this._revealTimer = null;
+    }
+  }
+
+  protected override firstUpdated(): void {
+    this._inputEl = this.renderRoot.querySelector<HTMLInputElement>('.hidden-input');
+  }
+
+  override focus(options?: FocusOptions): void {
+    const el = this._inputEl ?? this.renderRoot.querySelector<HTMLInputElement>('.hidden-input');
+    el?.focus(options);
+  }
+
+  clear(): void {
+    if (this._value === '') return;
+    this._value = '';
+    this.clearReveal();
+    if (this._inputEl) this._inputEl.value = '';
+    this.requestUpdate();
+    this.dispatchValueChange();
+  }
+
+  // ------- internals -------
+
+  private totalLength(): number {
+    return this._groups.reduce((sum, n) => sum + n, 0);
+  }
+
+  private boundaries(): number[] {
+    const out: number[] = [0];
+    for (const n of this._groups) out.push(out[out.length - 1] + n);
+    return out;
+  }
+
+  private normaliseGroups(input: number[] | null | undefined): number[] {
+    if (!input || !Array.isArray(input) || input.length === 0) {
+      console.warn('[mp-otp-input] groups must be a non-empty array; falling back to default.');
+      return [...MintOtpInputElement.DEFAULT_GROUPS];
+    }
+    let didClamp = false;
+    const cleaned: number[] = input.map(n => {
+      const i = Math.round(Number(n));
+      if (!Number.isFinite(i) || i < 1) { didClamp = true; return 1; }
+      if (i > MintOtpInputElement.MAX_GROUP_SIZE) { didClamp = true; return MintOtpInputElement.MAX_GROUP_SIZE; }
+      return i;
+    });
+    while (cleaned.reduce((a, b) => a + b, 0) > MintOtpInputElement.MAX_TOTAL && cleaned.length > 1) {
+      cleaned.pop();
+      didClamp = true;
+    }
+    if (cleaned.length === 1 && cleaned[0] > MintOtpInputElement.MAX_TOTAL) {
+      cleaned[0] = MintOtpInputElement.MAX_TOTAL;
+      didClamp = true;
+    }
+    if (didClamp) {
+      console.warn(`[mp-otp-input] groups clamped to ${JSON.stringify(cleaned)} (per-element max ${MintOtpInputElement.MAX_GROUP_SIZE}, total max ${MintOtpInputElement.MAX_TOTAL}).`);
+    }
+    return cleaned;
+  }
+
+  private arraysEqual(a: number[], b: number[]): boolean {
+    if (a === b) return true;
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => v === b[i]);
+  }
+
+  /** Filter to allowed chars per `type`, normalise per `case`, truncate. */
+  private normaliseValue(input: string): string {
+    const filtered = this.type === 'numeric'
+      ? input.replace(/[^0-9]/g, '')
+      : input.replace(/[^a-zA-Z0-9]/g, '');
+    const cased = this.type === 'numeric'
+      ? filtered
+      : this.case === 'upper'
+        ? filtered.toUpperCase()
+        : this.case === 'lower'
+          ? filtered.toLowerCase()
+          : filtered;
+    return cased.slice(0, this.totalLength());
+  }
+
+  // ------- event handlers -------
+
+  private onInput = (ev: Event): void => {
+    const target = ev.target as HTMLInputElement;
+    const rawIn = target.value;
+    const oldValue = this._value;
+    const wasComplete = oldValue.length === this.totalLength() && oldValue.length > 0;
+    const normalised = this.normaliseValue(rawIn);
+
+    // Single-char keystrokes (length grew by exactly 1) trigger the password reveal
+    // window. Multi-char inserts (paste-via-input, IME commit, autofill) and any
+    // shrink (delete) do not reveal — paste and autofill have their own paths
+    // that explicitly clear; deletions shouldn't show a "•" → real-char flash.
+    const sizeDelta = normalised.length - oldValue.length;
+    if (this.type === 'password' && sizeDelta === 1) {
+      this.scheduleReveal(normalised.length - 1);
+    } else if (sizeDelta !== 1) {
+      // Multi-char insert or any delete: clear any pending reveal so we don't
+      // leak a previously-revealed char into a new state.
+      this.clearReveal();
+    }
+
+    this._value = normalised;
+    // Re-sync the input's value to the normalised form (strips junk the user
+    // might have typed, e.g. a letter into a numeric field). Setting .value
+    // collapses caret to end which is the correct UX for fill-from-end.
+    if (target.value !== normalised) target.value = normalised;
+    this.requestUpdate();
+    this.dispatchValueChange();
+
+    const nowComplete = normalised.length === this.totalLength();
+    if (nowComplete && !wasComplete) {
+      this.clearReveal();
+      this.dispatchComplete();
+    }
+  };
+
+  private onPaste = (ev: ClipboardEvent): void => {
+    if (this.disabled) return;
+    ev.preventDefault();
+    const text = ev.clipboardData?.getData('text') ?? '';
+    const oldValue = this._value;
+    const wasComplete = oldValue.length === this.totalLength() && oldValue.length > 0;
+    // Paste fills from index 0 regardless of caret position. This avoids the
+    // iOS gotcha where a user taps a non-first box then pastes the full code.
+    const normalised = this.normaliseValue(text);
+    this._value = normalised;
+    if (this._inputEl) this._inputEl.value = normalised;
+    this.clearReveal(); // paste NEVER reveals (shoulder-surf risk on a code the user already knows)
+    this.requestUpdate();
+    this.dispatchValueChange();
+    const nowComplete = normalised.length === this.totalLength();
+    if (nowComplete && !wasComplete) this.dispatchComplete();
+  };
+
+  private onBlur = (): void => {
+    // Mask immediately on blur regardless of timer state.
+    this.clearReveal();
+    this.requestUpdate();
+  };
+
+  private onCaretMove = (): void => {
+    // Re-render so the active-box highlight follows caret movement (e.g. user
+    // clicked into the input or used arrow keys).
+    this.requestUpdate();
+  };
+
+  // ------- reveal helpers -------
+
+  private scheduleReveal(index: number): void {
+    if (this._revealTimer) clearTimeout(this._revealTimer);
+    this._revealedIndex = index;
+    this._revealedUntil = performance.now() + MintOtpInputElement.REVEAL_MS;
+    this._revealTimer = setTimeout(() => {
+      this._revealedIndex = null;
+      this._revealedUntil = 0;
+      this._revealTimer = null;
+      this.requestUpdate();
+    }, MintOtpInputElement.REVEAL_MS);
+  }
+
+  private clearReveal(): void {
+    if (this._revealTimer) {
+      clearTimeout(this._revealTimer);
+      this._revealTimer = null;
+    }
+    this._revealedIndex = null;
+    this._revealedUntil = 0;
+  }
+
+  // ------- event dispatch -------
+
+  private dispatchValueChange(): void {
+    this.dispatchEvent(new CustomEvent<string>('value-change', {
+      detail: this._value,
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private dispatchComplete(): void {
+    this.dispatchEvent(new CustomEvent<string>('complete', {
+      detail: this._value,
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  // ------- render -------
+
+  protected override render(): TemplateResult {
+    const groups = this._groups;
+    const value = this._value;
+    const bounds = this.boundaries();
+    const total = bounds[bounds.length - 1];
+    const caretPos = this._inputEl?.selectionEnd ?? value.length;
+    const activeBoxIndex = this.activeBoxIndex(caretPos, value.length, bounds);
+    const isClassicOtp = this.type === 'numeric' && groups.every(g => g === 1);
+    const autocomplete = isClassicOtp ? 'one-time-code' : 'off';
+    const inputMode = this.type === 'numeric' ? 'numeric' : 'text';
+    const labelText = this.label ?? 'One-time code';
+
+    return html`
+      <div class="container" part="container">
+        <input
+          class="hidden-input"
+          part="input"
+          .value=${value}
+          autocomplete=${autocomplete}
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          inputmode=${inputMode}
+          maxlength=${total}
+          ?disabled=${this.disabled}
+          aria-label=${labelText}
+          aria-invalid=${this.invalid ? 'true' : 'false'}
+          @input=${this.onInput}
+          @paste=${this.onPaste}
+          @blur=${this.onBlur}
+          @keyup=${this.onCaretMove}
+          @click=${this.onCaretMove}
+        />
+        ${groups.map((groupLen, i) =>
+          this.renderBox(i, groupLen, bounds, value, activeBoxIndex),
+        )}
+      </div>
+    `;
+  }
+
+  private renderBox(
+    boxIndex: number,
+    groupLen: number,
+    bounds: number[],
+    value: string,
+    activeBoxIndex: number | null,
+  ): TemplateResult {
+    const start = bounds[boxIndex];
+    const end = bounds[boxIndex + 1];
+    const slice = value.slice(start, Math.min(end, value.length));
+    const filled = value.length >= end;
+    const partial = !filled && slice.length > 0;
+    const active = activeBoxIndex === boxIndex;
+    const displayContent = this.renderSliceContent(slice, start);
+    const partsList = ['box'];
+    if (filled || partial) partsList.push('box-filled');
+    if (active) partsList.push('box-active');
+    if (this.invalid) partsList.push('box-invalid');
+    const classes = partsList.join(' ');
+    // The hidden spacer reserves width for groupLen monospace characters so
+    // the box doesn't reflow as the user types into it. Use repeat('M') as a
+    // wide reference char (M is wider than digits in most non-monospace fonts,
+    // so this is conservative if the monospace font falls back).
+    const spacer = 'M'.repeat(groupLen);
+    return html`
+      <span class=${classes} part=${partsList.join(' ')} aria-hidden="true">
+        <span class="box-spacer">${spacer}</span>
+        <span class="box-content">${displayContent}</span>
+      </span>
+    `;
+  }
+
+  /** Build the displayed string for a slice, applying password reveal. */
+  private renderSliceContent(slice: string, startIndex: number): string {
+    if (this.type !== 'password' || slice.length === 0) return slice;
+    const now = performance.now();
+    let out = '';
+    for (let i = 0; i < slice.length; i++) {
+      const globalIdx = startIndex + i;
+      if (globalIdx === this._revealedIndex && now < this._revealedUntil) {
+        out += slice[i];
+      } else {
+        out += MintOtpInputElement.MASK_CHAR;
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Returns the index of the visual box that should be highlighted as "active"
+   * given the caret position and current value length.
+   *
+   * Rules:
+   *  - Caret before all boxes (rare): first box.
+   *  - Caret at the end of a filled value with more boxes to fill: the next
+   *    box (the one the user is about to type into).
+   *  - Caret at totalLength (everything filled): last box.
+   *  - Otherwise: the box whose [start, end) range contains caretPos.
+   */
+  private activeBoxIndex(caretPos: number, valueLen: number, bounds: number[]): number | null {
+    if (this._groups.length === 0) return null;
+    const total = bounds[bounds.length - 1];
+    const effective = Math.min(caretPos, total);
+    if (effective >= total) return this._groups.length - 1;
+    for (let i = 0; i < bounds.length - 1; i++) {
+      if (effective >= bounds[i] && effective < bounds[i + 1]) return i;
+    }
+    return this._groups.length - 1;
+  }
+}
+
+if (typeof customElements !== 'undefined' && !customElements.get('mp-otp-input')) {
+  customElements.define('mp-otp-input', MintOtpInputElement);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mp-otp-input': MintOtpInputElement;
+  }
+}

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.ts
@@ -72,7 +72,11 @@ export class MintOtpInputElement extends LitElement {
 
   static readonly MAX_GROUP_SIZE = 10;
   static readonly MAX_TOTAL = 40;
-  static readonly DEFAULT_GROUPS: readonly number[] = Object.freeze([1, 1, 1, 1, 1, 1]);
+  // Read-only array contract via type; callers spread to copy. Don't Object.freeze
+  // — the spread already protects against mutation in the only consumer path
+  // (normaliseGroups' fallback), and freeze would throw on accidental mutation
+  // by external WC consumers rather than silently letting their copy diverge.
+  static readonly DEFAULT_GROUPS: readonly number[] = [1, 1, 1, 1, 1, 1];
   static readonly REVEAL_MS = 700;
   static readonly MASK_CHAR = '•';
 
@@ -82,6 +86,7 @@ export class MintOtpInputElement extends LitElement {
   private _revealedUntil = 0;
   private _revealTimer: ReturnType<typeof setTimeout> | null = null;
   private _inputEl: HTMLInputElement | null = null;
+  private _isFocused = false;
 
   get value(): string {
     return this._value;
@@ -250,8 +255,19 @@ export class MintOtpInputElement extends LitElement {
     if (nowComplete && !wasComplete) this.dispatchComplete();
   };
 
+  private onFocus = (): void => {
+    // Track focus so the active-box highlight only renders while the hidden
+    // input is actually focused. Without this every instance on the page shows
+    // a blue ring on the "next" box at all times, which makes side-by-side
+    // demos look like every box is competing for input.
+    this._isFocused = true;
+    this.requestUpdate();
+  };
+
   private onBlur = (): void => {
-    // Mask immediately on blur regardless of timer state.
+    // Mask immediately on blur regardless of timer state, and drop the
+    // active-box highlight along with focus.
+    this._isFocused = false;
     this.clearReveal();
     this.requestUpdate();
   };
@@ -311,7 +327,10 @@ export class MintOtpInputElement extends LitElement {
     const bounds = this.boundaries();
     const total = bounds[bounds.length - 1];
     const caretPos = this._inputEl?.selectionEnd ?? value.length;
-    const activeBoxIndex = this.activeBoxIndex(caretPos, value.length, bounds);
+    // Active-box highlight only renders while the hidden input has focus;
+    // otherwise every demo / unfocused instance lights up its next-to-fill box
+    // even though it's not accepting input.
+    const activeBoxIndex = this._isFocused ? this.activeBoxIndex(caretPos, value.length, bounds) : null;
     const isClassicOtp = this.type === 'numeric' && groups.every(g => g === 1);
     const autocomplete = isClassicOtp ? 'one-time-code' : 'off';
     const inputMode = this.type === 'numeric' ? 'numeric' : 'text';
@@ -334,6 +353,7 @@ export class MintOtpInputElement extends LitElement {
           aria-invalid=${this.invalid ? 'true' : 'false'}
           @input=${this.onInput}
           @paste=${this.onPaste}
+          @focus=${this.onFocus}
           @blur=${this.onBlur}
           @keyup=${this.onCaretMove}
           @click=${this.onCaretMove}

--- a/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.ts
+++ b/libs/mintplayer-ng-bootstrap/otp-input/src/lib/web-components/mint-otp-input.element.ts
@@ -111,8 +111,17 @@ export class MintOtpInputElement extends LitElement {
     if (this.arraysEqual(old, normalised)) return;
     this._groups = normalised;
     const total = this.totalLength();
-    if (this._value.length > total) this._value = this._value.slice(0, total);
+    let valueMutated = false;
+    if (this._value.length > total) {
+      this._value = this._value.slice(0, total);
+      valueMutated = true;
+    }
     this.requestUpdate('groups', old);
+    // When the new groups shape shortens the total length, the canonical value
+    // must drop the overflow characters — and the consumer needs to know,
+    // otherwise an Angular FormControl bound via the wrapper's CVA would
+    // remain at the stale longer value.
+    if (valueMutated) this.dispatchValueChange();
   }
 
   override disconnectedCallback(): void {
@@ -120,6 +129,25 @@ export class MintOtpInputElement extends LitElement {
     if (this._revealTimer) {
       clearTimeout(this._revealTimer);
       this._revealTimer = null;
+    }
+  }
+
+  protected override willUpdate(changedProperties: Map<string, unknown>): void {
+    super.willUpdate(changedProperties);
+    // When `type` or `case` changes, re-run the filter/normalisation against
+    // the current value. Without this, switching from `alphanumeric` to
+    // `numeric` while the field holds "ABC123" would leave "ABC123" in place
+    // — type says digits-only but the rendered value disagrees. Doing this
+    // in `willUpdate` (rather than `updated`) folds the value mutation into
+    // the same update cycle that already runs for the type/case change, so
+    // we don't trigger Lit's "scheduled an update from updated()" warning.
+    if (changedProperties.has('type') || changedProperties.has('case')) {
+      const next = this.normaliseValue(this._value);
+      if (next !== this._value) {
+        this._value = next;
+        this.clearReveal();
+        this.dispatchValueChange();
+      }
     }
   }
 
@@ -165,8 +193,12 @@ export class MintOtpInputElement extends LitElement {
       if (i > MintOtpInputElement.MAX_GROUP_SIZE) { didClamp = true; return MintOtpInputElement.MAX_GROUP_SIZE; }
       return i;
     });
-    while (cleaned.reduce((a, b) => a + b, 0) > MintOtpInputElement.MAX_TOTAL && cleaned.length > 1) {
-      cleaned.pop();
+    // Maintain a running sum so the trim loop is O(N) instead of O(N²) —
+    // arrays are tiny in practice, but the linear form also reads more
+    // honestly (the loop variable is the live total, not a re-computed one).
+    let sum = cleaned.reduce((a, b) => a + b, 0);
+    while (sum > MintOtpInputElement.MAX_TOTAL && cleaned.length > 1) {
+      sum -= cleaned.pop()!;
       didClamp = true;
     }
     if (cleaned.length === 1 && cleaned[0] > MintOtpInputElement.MAX_TOTAL) {

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "21.38.0",
+  "version": "21.39.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/MintPlayer/mintplayer-ng-bootstrap",


### PR DESCRIPTION
- Closes #333.

## Summary

A new `bs-otp-input` Angular component backed by a `mp-otp-input` Lit web component, following the same WC + Angular wrapper + `ControlValueAccessor` pattern as `bs-multi-range`. One API (`groups: number[]`) covers classic 6-digit OTP, 4-digit PIN, and non-uniform license keys (MS Office `[6,6,4,4,6,6]`, Windows product key `[5,5,5,5,5]`, …).

```html
<!-- Classic 6-digit OTP -->
<bs-otp-input [formControl]="code" (complete)="login($event)"></bs-otp-input>

<!-- 4-digit PIN -->
<bs-otp-input [groups]="[1,1,1,1]" type="password" autofocus></bs-otp-input>

<!-- MS Office product key -->
<bs-otp-input [groups]="[6,6,4,4,6,6]" type="alphanumeric" case="upper" size="lg"></bs-otp-input>
```

## Architecture — the load-bearing decisions

- **One hidden full-width `<input autocomplete="one-time-code">` + decorative `<span>` boxes**, not N real inputs. SMS autofill / paste / IME / screen readers route through the platform without per-box state machines. Rejected: N-input array — leaks on Safari's autofill heuristics.
- **Value shape `string`, streams partials**, with `valueChange` on every keystroke and `complete` once on the incomplete→complete transition via user interaction (re-fires on re-completion; suppressed for programmatic `writeValue`). Rejected: `string[]`, `{value,isComplete}` envelope, and `valueInput`+`valueChange` parity with multi-range.
- **`groups: number[]`** where each element is the char-count of one visual box. Rejected: `length: number` (breaks for non-uniform license keys), `groupCount`+`groupSize` (same limit), `pattern: string` mask.
- **Focus delegation via `Object.defineProperty(host, 'focus', …)`** in the wrapper constructor so the existing `FocusOnLoadDirective` (`*[autofocus]`) routes into the hidden input. Rejected: dedicated `[autofocus]` input on the wrapper — duplicates an existing primitive. This pattern is now codified for future input-shaped components.
- **Active-box highlight only while the hidden input is focused** — added after smoke-testing caught every demo instance lit up.

Full decision trail in [`docs/issue_333_PRD.md`](docs/issue_333_PRD.md).

## Tests

1229 pass (+57 new):
- **38 WC unit tests** (`mint-otp-input.element.spec.ts`) — covers all 10 plan scenarios: typed digit-by-digit, paste with junk, non-uniform groups, backspace shrinks, password reveal window, programmatic value setter, focus-gated highlight, `groups` validation/clamping, autocomplete heuristic, case handling.
- **7 ARIA tests** (`mint-otp-input.aria.spec.ts`) — one focusable input, boxes `aria-hidden`, default + custom `aria-label`, `aria-invalid` reflection, `disabled` propagation.
- **12 wrapper integration tests** (`otp-input.component.spec.ts`) — template-driven (`[(ngModel)]`), reactive forms (`[formControl]`), `setDisabledState`, `writeValue`, `focusout`→touched, invalid-state derivation, focus delegation, `(complete)` Output forwarding.

## Test plan

- [x] `nx test mintplayer-ng-bootstrap` — green (1229 pass)
- [x] `nx build mintplayer-ng-bootstrap` — green
- [x] `nx build ng-bootstrap-demo` — green (108 static routes including `/enterprise/otp-input`)
- [ ] Smoke-test demo page in browser: classic OTP, paste with separator junk, password reveal, MS Office key, Windows key, size variants, invalid state via reactive forms, autofocus
- [ ] Smoke-test the focus-highlight fix specifically — boxes should stay quiet until tab/click into a field

## Traps a reviewer should keep in mind

- `value-change` is **not** `stopPropagation`'d (CVA needs the bubble); `complete` **is** (Output named `complete` collides with the DOM event name and Angular's `(complete)` catches both channels).
- `complete` fires on user-interaction transitions only — programmatic `writeValue` with a complete string deliberately suppresses it (otherwise form rehydrate would loop auto-submit).
- After each input event, `target.value = normalised` collapses the caret to end. For non-uniform license keys, mid-string editing puts the user at the end of the value, not the box they clicked. Accepted limitation of the hidden-input architecture; documented.
- The wrapper's host-element `.focus` override is set up in the constructor. If a future host directive overwrites it, focus delegation breaks silently.

## Out of scope (deferred to consumer-written directives per the directive-composition principle)

- Floating-label / `bs-form` integration
- Visible separator character between groups
- Animation on `groups` change
- Per-character custom validation hooks
- Configurable `revealMs`
- Custom paste pre-processing

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)