### PR TITLE
refactor(ci): adopt MintPlayer/github-actions/publish-npm-packages

### DIFF
--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -39,11 +39,6 @@ jobs:
       with:
         node-version: 22
 
-    # - name: Print GitHub
-    #   run: echo $JSON
-    #   env:
-    #     JSON: ${{ toJson(github) }}
-
     - name: Install dependencies
       run: npm ci
     
@@ -54,205 +49,16 @@ jobs:
     - name: Test
       run: npx nx affected --target=test --watch=false --parallel=true
 
-    ## ng-animations
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
+    # Hand dist/ off to the publish-libs / publish-snippets jobs. The
+    # snippets package publishes from libs/ (source, not dist/) so the
+    # snippets job checks the repo out separately — no need to bundle
+    # that dir into this artifact.
+    - name: Upload dist artifact
+      uses: actions/upload-artifact@v4
       with:
-        package: 'dist/libs/mintplayer-ng-animations/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-animations/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## ng-click-outside
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-click-outside/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-click-outside/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## ng-focus-on-load
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-focus-on-load/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-focus-on-load/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## encode-utf8
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-encode-utf8/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-encode-utf8/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## dijkstra
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-dijkstra/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-dijkstra/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## qr-code
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-qr-code/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-qr-code/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## pagination
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-pagination/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-pagination/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## ng-qr-code
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-qr-code/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-qr-code/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## ng-swiper
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-swiper/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-swiper/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-
-    ## ng-bootstrap
-    - name: Push to NPM
-      id: publish_ng_bootstrap
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-bootstrap/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
-
-    - name: Push to Github
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'dist/libs/mintplayer-ng-bootstrap/package.json'
-        registry: 'https://npm.pkg.github.com'
-        token: ${{ github.token }}
-        access: 'public'
-        provenance: true
-        
-    - name: Push to NPM
-      uses: JS-DevTools/npm-publish@v4
-      with:
-        package: 'libs/mintplayer-ng-bootstrap-snippets/package.json'
-        registry: 'https://registry.npmjs.org'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        access: 'public'
-        provenance: true
+        name: dist
+        path: dist/
+        retention-days: 1
 
     - name: Publish to Visual Studio Marketplace
       # uses: MintPlayer/publish-vscode-extension@v4.0.3
@@ -332,19 +138,77 @@ jobs:
         subject-digest: ${{ steps.push-api.outputs.digest }}
         push-to-registry: true
 
-    # - name: Publish through FTP
-    #   uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-    #   if: ${{ steps.publish_ng_bootstrap.outputs.type }}
-    #   with:
-    #     server: mintplayer.com
-    #     username: ${{ secrets.PUBLISH_FTP_USER }}
-    #     password: ${{ secrets.PUBLISH_FTP_PWD }}
-    #     local-dir: ./dist/apps/ng-bootstrap-demo/browser/
-    #     server-dir: ./
+  # ----------------------------------------------------------------------
+  # NPM publishing
+  #
+  # MintPlayer/github-actions/publish-npm-packages scans the given folder,
+  # topo-sorts the discovered libs by peerDependencies, and fans out to
+  # every registry it's given. Replaces what previously needed 18 hand-
+  # listed JS-DevTools/npm-publish steps (9 libs × 2 registries) plus the
+  # snippets publish.
+  #
+  # ng-bootstrap-snippets is unusual: it publishes from libs/ (source,
+  # not dist/) and only goes to NPM, never to GitHub Packages — so it
+  # gets its own action invocation with a different `folder` root.
+  # ----------------------------------------------------------------------
+
+  publish-libs:
+    name: publish-libs
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to NPM + GitHub Packages
+        # Pinned to b08fbdd (v1.1.0) — the v1.1.0 tag isn't pushed yet on
+        # MintPlayer/github-actions. Promote to @v1 once that tag lands.
+        uses: MintPlayer/github-actions/publish-npm-packages@b08fbddf0b285a8633ac138b89d79ceb8cc8c888
+        with:
+          folder: dist/libs
+          registries: |
+            [
+              { "url": "https://registry.npmjs.org", "token": "${{ secrets.PUBLISH_TO_NPMJS }}" },
+              { "url": "https://npm.pkg.github.com", "token": "${{ github.token }}" }
+            ]
+
+  publish-snippets:
+    name: publish-snippets
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Publish snippets to NPM
+        uses: MintPlayer/github-actions/publish-npm-packages@b08fbddf0b285a8633ac138b89d79ceb8cc8c888
+        with:
+          folder: libs/mintplayer-ng-bootstrap-snippets
+          registries: |
+            [
+              { "url": "https://registry.npmjs.org", "token": "${{ secrets.PUBLISH_TO_NPMJS }}" }
+            ]
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, publish-libs, publish-snippets]
     if: github.ref == 'refs/heads/master'
 
     permissions:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,11 +44,6 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
-    # - name: Print GitHub
-    #   run: echo $JSON
-    #   env:
-    #     JSON: ${{ toJson(github) }}
-
     - name: Install dependencies
       run: npm ci
 
@@ -77,73 +72,55 @@ jobs:
       timeout-minutes: 15
       run: npx nx run ng-bootstrap-demo-e2e:e2e-live --output-style=stream
 
-    ## Dry-run publish to verify package.json files exist in dist
-    - name: Dry-run publish ng-animations
-      uses: JS-DevTools/npm-publish@v3
+    # Hand dist/ off to the dry-run-publish-libs job. Snippets publishes
+    # from libs/ (source); the dry-run job checks the repo out so we don't
+    # need to bundle it into this artifact.
+    - name: Upload dist artifact
+      uses: actions/upload-artifact@v4
       with:
-        package: 'dist/libs/mintplayer-ng-animations/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
+        name: dist
+        path: dist/
+        retention-days: 1
 
-    - name: Dry-run publish ng-click-outside
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-ng-click-outside/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
+  # Single dry-run sweep covering both folder roots (dist/libs + the
+  # snippets source dir). The action handles discovery, topo-sort and
+  # the per-package npm publish --dry-run internally; no need for the
+  # 9 hand-listed JS-DevTools/npm-publish dry-run steps that used to
+  # live in the build job.
+  dry-run-publish-libs:
+    name: dry-run-publish-libs
+    needs: build
+    runs-on: ubuntu-latest
 
-    - name: Dry-run publish ng-focus-on-load
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-ng-focus-on-load/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
+    permissions:
+      contents: read
 
-    - name: Dry-run publish encode-utf8
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-encode-utf8/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Dry-run publish dijkstra
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-dijkstra/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
 
-    - name: Dry-run publish qr-code
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-qr-code/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
+      - name: Dry-run publish (dist/libs)
+        uses: MintPlayer/github-actions/publish-npm-packages@b08fbddf0b285a8633ac138b89d79ceb8cc8c888
+        with:
+          folder: dist/libs
+          dry-run: true
+          registries: |
+            [
+              { "url": "https://registry.npmjs.org", "token": "${{ secrets.PUBLISH_TO_NPMJS }}", "provenance": false }
+            ]
 
-    - name: Dry-run publish pagination
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-pagination/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
-
-    - name: Dry-run publish ng-qr-code
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-ng-qr-code/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
-
-    - name: Dry-run publish ng-swiper
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-ng-swiper/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
-
-    - name: Dry-run publish ng-bootstrap
-      uses: JS-DevTools/npm-publish@v3
-      with:
-        package: 'dist/libs/mintplayer-ng-bootstrap/package.json'
-        token: ${{ secrets.PUBLISH_TO_NPMJS }}
-        dry-run: true
+      - name: Dry-run publish (snippets source)
+        uses: MintPlayer/github-actions/publish-npm-packages@b08fbddf0b285a8633ac138b89d79ceb8cc8c888
+        with:
+          folder: libs/mintplayer-ng-bootstrap-snippets
+          dry-run: true
+          registries: |
+            [
+              { "url": "https://registry.npmjs.org", "token": "${{ secrets.PUBLISH_TO_NPMJS }}", "provenance": false }
+            ]


### PR DESCRIPTION
## Summary

Swap the hand-listed `JS-DevTools/npm-publish` matrices in the two workflows for a single action that auto-discovers `package.json` files under a folder, topo-sorts them by `peerDependencies`, and fans out to every registry it's given.

- **publish-master.yml**: build job uploads `dist/` as an artifact; two new dependent jobs (`publish-libs`, `publish-snippets`) consume it and call the action. `deploy` now waits on both. Replaces 18 inline `JS-DevTools/npm-publish` steps + 1 snippets publish.
- **pull-request.yml**: inline dry-run steps replaced by a single `dry-run-publish-libs` job calling the action twice (one per folder root). Build job uploads the `dist/` artifact for it to consume.
- Also drops two dead commented blocks (FTP deploy + "Print GitHub" debug).

Pinned to `b08fbddf0b285a8633ac138b89d79ceb8cc8c888` because the `v1.1.0` tag on `MintPlayer/github-actions` isn't pushed yet — promote to `@v1` once it lands.

**Net diff**: 2 files, +126 / −285. Adding a new lib under `dist/libs` now requires zero workflow edits — the action's discovery picks it up.

## Test plan

- [ ] `pull-request` workflow on this PR turns green (build + tests + dry-run-publish-libs).
- [ ] The `dry-run-publish-libs` job logs the topo-sorted package list and a successful `npm publish --dry-run` per package on npmjs.
- [ ] Manual review of the YAML diff confirms the two yml files are the only changes.

After merge, the first push to `master` exercises `publish-libs` + `publish-snippets` + `deploy` for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)