### PR TITLE
fix(scheduler): stop week-view resetting to day after drag in React

### DIFF
--- a/apps/react-bootstrap-demo/src/app/pages/enterprise/SchedulerPage.tsx
+++ b/apps/react-bootstrap-demo/src/app/pages/enterprise/SchedulerPage.tsx
@@ -4,6 +4,7 @@ import { BsCodeSnippet } from '@mintplayer/react-bootstrap/code-snippet';
 import {
   generateEventId,
   type SchedulerEvent,
+  type ViewType,
 } from '@mintplayer/web-components/scheduler-core';
 import type { MpScheduler } from '@mintplayer/web-components/scheduler';
 
@@ -20,9 +21,16 @@ const SEED: SchedulerEvent[] = [
   { id: '3', title: 'Lunch',         start: at(12), end: at(13),    color: '#198754' },
 ];
 
-const SOURCE = `<BsScheduler
+const SOURCE = `// \`view\` is a controlled prop: @lit/react re-asserts element
+// properties on every render, so pair it with onViewChange (the
+// React equivalent of Angular's [view]/(viewChange)) — otherwise a
+// re-render would clobber a WC-driven view switch back to the literal.
+const [view, setView] = useState<ViewType>('day');
+
+<BsScheduler
   events={events}
-  view="day"
+  view={view}
+  onViewChange={e => setView(e.detail.view)}
   onEventCreate={e => {
     setEvents([...events, {
       id: generateEventId(), title: 'New Event',
@@ -35,6 +43,11 @@ const SOURCE = `<BsScheduler
 
 export function SchedulerPage() {
   const [events, setEvents] = useState<SchedulerEvent[]>(SEED);
+  // Controlled view. @lit/react re-applies element properties on every
+  // render without dirty-checking, so `view` must track the WC's own
+  // view changes (via onViewChange) — otherwise a re-render after a drag
+  // would re-assert a stale literal and snap the scheduler back.
+  const [view, setView] = useState<ViewType>('day');
 
   return (
     <div className="demo-page">
@@ -51,7 +64,8 @@ export function SchedulerPage() {
       <section style={{ height: 540 }}>
         <h2>Today's agenda</h2>
         <BsScheduler
-          {...{ events, view: 'day' } as React.ComponentProps<typeof BsScheduler>}
+          {...{ events, view } as React.ComponentProps<typeof BsScheduler>}
+          onViewChange={(e) => setView(e.detail.view)}
           onEventUpdate={(e) => {
             setEvents((current) =>
               current.map((ev) => (ev.id === e.detail.event.id ? e.detail.event : ev)),

--- a/apps/vue-bootstrap-demo/src/views/enterprise/SchedulerView.vue
+++ b/apps/vue-bootstrap-demo/src/views/enterprise/SchedulerView.vue
@@ -5,6 +5,7 @@ import { BsCodeSnippet } from '@mintplayer/vue-bootstrap/code-snippet';
 import {
   generateEventId,
   type SchedulerEvent,
+  type ViewType,
 } from '@mintplayer/web-components/scheduler-core';
 import type { MpScheduler } from '@mintplayer/web-components/scheduler';
 
@@ -22,6 +23,11 @@ const events = ref<SchedulerEvent[]>([
   { id: '2', title: 'Design review', start: at(11), end: at(12),    color: '#6f42c1' },
   { id: '3', title: 'Lunch',         start: at(12), end: at(13),    color: '#198754' },
 ]);
+
+// `v-model:view` keeps the bound ref in sync with the WC's own view
+// switcher — the scheduler emits `view-change`, the wrapper writes it
+// back into this ref, so it always reflects the active view.
+const view = ref<ViewType>('day');
 
 function onEventUpdate(e: Event) {
   const detail = (e as CustomEvent<{ event: SchedulerEvent }>).detail;
@@ -52,9 +58,10 @@ function onEventDelete(e: Event) {
   events.value = events.value.filter((ev) => ev.id !== detail.event.id);
 }
 
-const SOURCE = `<BsScheduler
+const SOURCE = `<!-- v-model:view tracks the WC's own view switcher both ways -->
+<BsScheduler
   :events="events"
-  view="day"
+  v-model:view="view"
   @event-create="(e) => {
     events = [...events, {
       id: generateEventId(), title: 'New Event',
@@ -82,7 +89,7 @@ const SOURCE = `<BsScheduler
       <h2>Today's agenda</h2>
       <BsScheduler
         :events="events"
-        view="day"
+        v-model:view="view"
         style="display: block; height: 100%"
         @event-update="onEventUpdate"
         @event-create="onEventCreate"

--- a/libs/mintplayer-vue-bootstrap/package.json
+++ b/libs/mintplayer-vue-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintplayer/vue-bootstrap",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Vue 3.5 SFC adapters around @mintplayer/web-components. Each sub-entry maps one-to-one with a WC sub-entry and exposes typed Vue components with v-model support for input WCs.",
   "license": "MIT",
   "repository": {

--- a/libs/mintplayer-vue-bootstrap/scheduler/src/BsScheduler.vue
+++ b/libs/mintplayer-vue-bootstrap/scheduler/src/BsScheduler.vue
@@ -4,6 +4,7 @@ import { MpScheduler } from '@mintplayer/web-components/scheduler';
 import type {
   SchedulerEvent,
   Resource,
+  ViewType,
 } from '@mintplayer/web-components/scheduler-core';
 import { ref, watch, onMounted } from 'vue';
 
@@ -16,6 +17,12 @@ const props = defineProps<{
   resources?: Resource[];
 }>();
 
+// `view` flows through `defineModel` for two-way `v-model:view` binding:
+// the WC owns its own view switcher, so we mirror its `view-change` back
+// into the model. Without this, a bound view would only flow one way and
+// a WC-driven switch would be lost on the next re-render.
+const view = defineModel<ViewType>('view');
+
 const el = ref<MpScheduler | null>(null);
 
 const syncProps = () => {
@@ -24,17 +31,30 @@ const syncProps = () => {
   if (props.resources) el.value.resources = props.resources;
 };
 
+const syncView = () => {
+  if (el.value && view.value) el.value.view = view.value;
+};
+
 // Reference-equality watches only. Lit's reactive property system also
 // uses === for change detection, so deep watching here would do the
 // expensive recursive Proxy traversal but still not re-render the WC
 // when a consumer mutates an event in place. The contract is: consumers
 // pass NEW arrays (immutable update) to trigger a re-sync — matches the
 // canonical Vue pattern for large lists.
-onMounted(syncProps);
+onMounted(() => {
+  syncProps();
+  syncView();
+});
 watch(() => props.events, syncProps);
 watch(() => props.resources, syncProps);
+watch(view, syncView);
+
+function onViewChange(e: Event) {
+  const detail = (e as CustomEvent<{ view: ViewType }>).detail;
+  if (detail) view.value = detail.view;
+}
 </script>
 
 <template>
-  <mp-scheduler ref="el" v-bind="$attrs" />
+  <mp-scheduler ref="el" v-bind="$attrs" @view-change="onViewChange" />
 </template>


### PR DESCRIPTION
## Problem

In the **React** scheduler demo, in **week view**, dragging to create a new event or moving an existing event caused the scheduler to snap back to **day view** after mouseup. Angular and Vue did not show this.

## Root cause

`@lit/react`'s `createComponent` re-applies element **properties** on every render via a dependency-array-less `useLayoutEffect`, and deliberately does **not** dirty-check property writes. The React demo passed `view` as a hardcoded `'day'` literal with no `onViewChange` handler, so:

1. The user switches to week via the WC's own header switcher → the WC's internal state becomes `'week'` (React doesn't know).
2. A drag commit fires `event-create` / `event-update` → the demo's handler calls `setEvents(...)` → **re-render**.
3. On re-render, `@lit/react` re-asserts `el.view = 'day'` → the WC setter calls `setView('day')` → snaps back to day.

It's effectively the same footgun as a controlled `<input value>` without `onChange`, except `@lit/react` doesn't warn.

## Fix

- **React demo** (`SchedulerPage.tsx`): use the controlled-component pattern — `view` state + `onViewChange={e => setView(e.detail.view)}`, mirroring the Angular demo's `[view]`/`(viewChange)` pair. Updated the source snippet to match.
- **Vue wrapper** (`BsScheduler.vue`): added a proper two-way `v-model:view` binding via `defineModel` + an `onViewChange` handler that mirrors the WC's `view-change` event (following the `BsTreeview` precedent). Vue was not *breaking* (it dirty-checks attributes) but never tracked the WC's own view switcher — now it does, both ways.
- **Vue demo** (`SchedulerView.vue`): switched to `v-model:view`.
- Bumped `@mintplayer/vue-bootstrap` to **3.4.1** for the additive `v-model:view` API.

The **React library wrapper is unchanged** (the bug was demo-side), so `@mintplayer/react-bootstrap` is left as-is. Angular was already correct — no change.

## Verification

- Manually verified by the author: week-view drag-create and drag-move no longer revert to day.
- `nx build mintplayer-vue-bootstrap` passes; IDE diagnostics clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)