### PR TITLE
feat(datatable)!: lazy windowed fetch + WC-owned fetch callback (#385, #386)

### DIFF
--- a/apps/ng-bootstrap-demo-e2e/e2e/datatable-virtual.spec.ts
+++ b/apps/ng-bootstrap-demo-e2e/e2e/datatable-virtual.spec.ts
@@ -35,18 +35,24 @@ async function mockArtistApi(page: Page) {
 
 // Read rows out of the mp-datatable's shadow DOM. The Lit WC renders a single
 // <table> inside shadow root, so we have to reach in via evaluate().
-async function countBodyRows(page: Page): Promise<number> {
+// Count only the *materialized* rows — placeholders (rows whose page hasn't
+// been fetched yet) are excluded. In lazy virtual mode this stays a small
+// viewport-sized window, never the full result set.
+async function countRealRows(page: Page): Promise<number> {
   return await page.evaluate(() => {
     const wc = document.querySelector('mp-datatable');
     if (!wc?.shadowRoot) return 0;
-    return wc.shadowRoot.querySelectorAll('tbody tr[data-row-key]').length;
+    return wc.shadowRoot.querySelectorAll('tbody tr[data-row-key]:not([data-placeholder="true"])').length;
   });
 }
 
-async function totalDataLength(page: Page): Promise<number> {
+// totalRecords is now DERIVED from the fetch response by the WC itself — the
+// consumer never sets it. Reading it back proves the fetch loop ran and the
+// virtualizer knows the full size without having drained every page.
+async function totalRecords(page: Page): Promise<number> {
   return await page.evaluate(() => {
-    const wc = document.querySelector('mp-datatable') as (HTMLElement & { data?: unknown[] }) | null;
-    return wc?.data?.length ?? 0;
+    const wc = document.querySelector('mp-datatable') as (HTMLElement & { totalRecords?: number | null }) | null;
+    return wc?.totalRecords ?? 0;
   });
 }
 
@@ -59,20 +65,22 @@ test.describe('bs-datatable virtual mode', () => {
     await page.waitForLoadState('networkidle');
   });
 
-  test('virtual mode preloads every record and scrolls them', async ({ page }) => {
+  test('virtual mode lazily fetches only the viewport window, never the full set', async ({ page }) => {
     await page.locator('bs-select select').selectOption('virtualScroll');
 
-    // The wrapper drains every page from the fetcher in virtual mode, so
-    // mp-datatable.data should hold all 200 mocked artists.
-    await expect.poll(() => totalDataLength(page), {
+    // The WC owns the fetch loop: it fetches page 1, derives totalRecords from
+    // the response (200), and reserves scroll space for all of them — WITHOUT
+    // draining every page. The consumer never sets totalRecords.
+    await expect.poll(() => totalRecords(page), {
       timeout: 5000,
-      message: 'wrapper should preload every page into mp-datatable.data',
+      message: 'WC should derive totalRecords from the first fetch response',
     }).toBe(200);
 
-    // The viewport-driven virtualizer renders a subset of those 200 rows.
-    const rendered = await countBodyRows(page);
-    expect(rendered).toBeGreaterThan(0);
-    expect(rendered).toBeLessThanOrEqual(200);
+    // Lazy proof: only a viewport-sized window of rows is materialized. If the
+    // table had eager-drained all 200 pages, every row would be real.
+    const real = await countRealRows(page);
+    expect(real).toBeGreaterThan(0);
+    expect(real).toBeLessThan(200);
   });
 
   test('paginated mode renders the mp-pagination footer with the correct total pages', async ({ page }) => {
@@ -97,15 +105,19 @@ test.describe('bs-datatable virtual mode', () => {
 
     // virtual → pagination → virtual: this used to hit a CDK viewport
     // re-query bug; with a single-table WC it just needs to keep rendering.
+    // totalRecords stays 200 (server-derived) across both modes; what changes
+    // is how many rows are materialized.
     await select.selectOption('virtualScroll');
-    await expect.poll(() => totalDataLength(page), { timeout: 5000 }).toBe(200);
+    await expect.poll(() => totalRecords(page), { timeout: 5000 }).toBe(200);
+    expect(await countRealRows(page)).toBeGreaterThan(0);
 
+    // Pagination renders exactly one page worth of rows (perPage = 20).
     await select.selectOption('pagination');
-    await expect.poll(() => totalDataLength(page), { timeout: 5000 }).toBe(20);
+    await expect.poll(() => countRealRows(page), { timeout: 5000 }).toBe(20);
+    expect(await totalRecords(page)).toBe(200);
 
     await select.selectOption('virtualScroll');
-    await expect.poll(() => totalDataLength(page), { timeout: 5000 }).toBe(200);
-
-    expect(await countBodyRows(page)).toBeGreaterThan(0);
+    await expect.poll(() => totalRecords(page), { timeout: 5000 }).toBe(200);
+    expect(await countRealRows(page)).toBeGreaterThan(0);
   });
 });

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.html
@@ -56,19 +56,17 @@
 
 <p>
   With <code>[virtualScroll]</code> + <code>[fetch]</code> the table fetches
-  only the pages whose rows are in (or near) the viewport. Scroll through this
-  {{ windowedTotal }}-row list and watch the fetch log below: it never drains
-  all {{ windowedTotalPages() }} pages up front &mdash; placeholder rows hold
-  the scroll position until each window arrives. Sorting or changing settings
-  drops the cached windows and refetches the visible range. The public
-  <code>[fetch]</code> contract is unchanged &mdash; the same page/perPage
-  callback as paginated mode.
+  only the pages whose rows are in (or near) the viewport &mdash; against the
+  same real, server-paged artist endpoint as the basic section. Scroll and
+  watch the fetch log below: it never drains the whole result set up front;
+  placeholder rows hold the scroll position until each window arrives. Sorting
+  or changing settings drops the cached windows and refetches the visible range.
 </p>
 
 <p class="small text-muted flex-shrink-0">
   Pages fetched:
   <span class="font-monospace">{{ windowedFetchedPages().join(', ') || '&mdash;' }}</span>
-  ({{ windowedFetchedPages().length }} of {{ windowedTotalPages() }})
+  ({{ windowedFetchedPages().length }} so far)
 </p>
 
 <bs-datatable class="windowed-table flex-shrink-0"

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.html
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.html
@@ -52,6 +52,51 @@
 <bs-code-snippet [codeToCopy]="snippetSelectionHtml" [language]="'html'"></bs-code-snippet>
 <bs-code-snippet [codeToCopy]="snippetSelectionTs" [language]="'ts'"></bs-code-snippet>
 
+<h2>Virtual scrolling &mdash; lazy windowed fetch</h2>
+
+<p>
+  With <code>[virtualScroll]</code> + <code>[fetch]</code> the table fetches
+  only the pages whose rows are in (or near) the viewport. Scroll through this
+  {{ windowedTotal }}-row list and watch the fetch log below: it never drains
+  all {{ windowedTotalPages() }} pages up front &mdash; placeholder rows hold
+  the scroll position until each window arrives. Sorting or changing settings
+  drops the cached windows and refetches the visible range. The public
+  <code>[fetch]</code> contract is unchanged &mdash; the same page/perPage
+  callback as paginated mode.
+</p>
+
+<p class="small text-muted flex-shrink-0">
+  Pages fetched:
+  <span class="font-monospace">{{ windowedFetchedPages().join(', ') || '&mdash;' }}</span>
+  ({{ windowedFetchedPages().length }} of {{ windowedTotalPages() }})
+</p>
+
+<bs-datatable class="windowed-table flex-shrink-0"
+  [virtualScroll]="true"
+  [itemSize]="40"
+  [isResponsive]="true"
+  [fetch]="fetchWindowedArtists"
+  [(settings)]="windowedSettings"
+  [rowKey]="rowKey">
+
+  <div *bsDatatableColumn="'Name'">Artist</div>
+  <div *bsDatatableColumn="'YearStarted'">Year started</div>
+  <div *bsDatatableColumn="'YearQuit'">Year quit</div>
+
+  <ng-container *bsRowTemplate="let artist; let isPlaceholder = isPlaceholder">
+    @if (isPlaceholder) {
+      <td colspan="3" class="text-muted small fst-italic">Loading&hellip;</td>
+    } @else {
+      <td class="text-nowrap">{{ $any(artist)?.name }}</td>
+      <td class="text-nowrap">{{ $any(artist)?.yearStarted }}</td>
+      <td class="text-nowrap">{{ $any(artist)?.yearQuit }}</td>
+    }
+  </ng-container>
+</bs-datatable>
+
+<bs-code-snippet [codeToCopy]="snippetWindowedHtml" [language]="'html'"></bs-code-snippet>
+<bs-code-snippet [codeToCopy]="snippetWindowedTs" [language]="'ts'"></bs-code-snippet>
+
 <h2>Tree mode &mdash; expandable rows</h2>
 
 <p>

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.scss
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.scss
@@ -3,3 +3,9 @@
   flex-direction: column;
   height: 100%;
 }
+
+// Bounded viewport so the windowed-fetch demo actually scrolls (the toggled
+// basic-usage and tree tables fill the page via flex-grow instead).
+.windowed-table {
+  height: 360px;
+}

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.ts
@@ -53,6 +53,55 @@ export class DatatablesComponent {
 
   rowKey = (a: Artist) => String(a.id);
 
+  // ─── Lazy windowed-fetch demo ──────────────────────────────────────────
+  // A large synthetic dataset with simulated server latency so the windowing
+  // is visible: only the pages near the viewport are ever fetched, and
+  // placeholder rows hold the scroll position until each window arrives.
+
+  protected readonly windowedTotal = 5000;
+
+  windowedSettings = signal(new DatatableSettings({
+    sortColumns: [],
+    perPage: { values: [25, 50, 100], selected: 25 },
+    page: { values: [1], selected: 1 },
+  }));
+
+  /** Pages actually fetched — proof that scrolling drives O(visible/perPage) requests, not a full drain. */
+  windowedFetchedPages = signal<number[]>([]);
+
+  protected readonly windowedTotalPages = computed(() =>
+    Math.ceil(this.windowedTotal / this.windowedSettings().perPage.selected),
+  );
+
+  private makeArtist(id: number): Artist {
+    const yearStarted = 1960 + (id % 60);
+    return <Artist>{
+      id,
+      name: `Artist #${id}`,
+      yearStarted,
+      yearQuit: id % 3 === 0 ? null : yearStarted + 5 + (id % 20),
+    };
+  }
+
+  fetchWindowedArtists: BsDatatableFetch<Artist> = async (req: PaginationRequest) => {
+    const perPage = req.perPage ?? 25;
+    const page = req.page ?? 1;
+    this.windowedFetchedPages.update((pages) =>
+      pages.includes(page) ? pages : [...pages, page].sort((a, b) => a - b),
+    );
+    // Simulated server latency so placeholder rows render before they fill.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const start = (page - 1) * perPage;
+    const data = Array.from(
+      { length: Math.max(0, Math.min(perPage, this.windowedTotal - start)) },
+      (_, i) => this.makeArtist(start + i + 1),
+    );
+    return <PaginationResponse<Artist>>{
+      data, totalRecords: this.windowedTotal, page, perPage,
+      totalPages: Math.ceil(this.windowedTotal / perPage),
+    };
+  };
+
   // ─── Tree-mode demo ────────────────────────────────────────────────────
 
   treeSettings = signal(new DatatableSettings({
@@ -158,6 +207,47 @@ export class DatatablesComponent {
   protected readonly snippetSelectionTs = dedent`
     selection = signal<Artist[]>([]);
     rowKey = (a: Artist) => String(a.id);
+  `;
+
+  protected readonly snippetWindowedHtml = dedent`
+    <!-- Virtual + fetch: the table fetches only the pages whose rows are in
+         (or near) the viewport, keyed by settings.perPage. Placeholder rows
+         (isPlaceholder) hold the scroll position until each window arrives.
+         The public [fetch] contract is unchanged — no new callback. -->
+    <bs-datatable
+      [virtualScroll]="true"
+      [itemSize]="40"
+      [fetch]="fetchWindowedArtists"
+      [(settings)]="windowedSettings"
+      [rowKey]="rowKey">
+
+      <div *bsDatatableColumn="'Name'">Artist</div>
+      <div *bsDatatableColumn="'YearStarted'">Year started</div>
+      <div *bsDatatableColumn="'YearQuit'">Year quit</div>
+
+      <ng-container *bsRowTemplate="let artist; let isPlaceholder = isPlaceholder">
+        @if (isPlaceholder) {
+          <td colspan="3" class="text-muted small fst-italic">Loading…</td>
+        } @else {
+          <td>{{ artist?.name }}</td>
+          <td>{{ artist?.yearStarted }}</td>
+          <td>{{ artist?.yearQuit }}</td>
+        }
+      </ng-container>
+    </bs-datatable>
+  `;
+
+  protected readonly snippetWindowedTs = dedent`
+    // The same [fetch] callback as paginated/non-virtual mode — page + perPage.
+    // In flat virtual mode the table calls it once per *needed page* as the
+    // user scrolls, instead of draining every page up front.
+    windowedSettings = signal(new DatatableSettings({
+      perPage: { values: [25, 50, 100], selected: 25 },
+      page: { values: [1], selected: 1 },
+    }));
+
+    fetchWindowedArtists: BsDatatableFetch<Artist> = (req: PaginationRequest) =>
+      this.artistService.pageArtists(req); // resolves PaginationResponse<Artist>
   `;
 
   protected readonly snippetTreeHtml = dedent`

--- a/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.ts
+++ b/apps/ng-bootstrap-demo/src/app/pages/enterprise/datatables/datatables.component.ts
@@ -53,12 +53,10 @@ export class DatatablesComponent {
 
   rowKey = (a: Artist) => String(a.id);
 
-  // ─── Lazy windowed-fetch demo ──────────────────────────────────────────
-  // A large synthetic dataset with simulated server latency so the windowing
-  // is visible: only the pages near the viewport are ever fetched, and
-  // placeholder rows hold the scroll position until each window arrives.
-
-  protected readonly windowedTotal = 5000;
+  // ─── Lazy windowed-fetch demo (real artist API, server-paged) ──────────
+  // Reuses the same real, server-paged artist endpoint as the basic section.
+  // The WC fetches only the pages near the viewport; the log proves it never
+  // drains the whole result set.
 
   windowedSettings = signal(new DatatableSettings({
     sortColumns: [],
@@ -69,37 +67,12 @@ export class DatatablesComponent {
   /** Pages actually fetched — proof that scrolling drives O(visible/perPage) requests, not a full drain. */
   windowedFetchedPages = signal<number[]>([]);
 
-  protected readonly windowedTotalPages = computed(() =>
-    Math.ceil(this.windowedTotal / this.windowedSettings().perPage.selected),
-  );
-
-  private makeArtist(id: number): Artist {
-    const yearStarted = 1960 + (id % 60);
-    return <Artist>{
-      id,
-      name: `Artist #${id}`,
-      yearStarted,
-      yearQuit: id % 3 === 0 ? null : yearStarted + 5 + (id % 20),
-    };
-  }
-
   fetchWindowedArtists: BsDatatableFetch<Artist> = async (req: PaginationRequest) => {
-    const perPage = req.perPage ?? 25;
-    const page = req.page ?? 1;
     this.windowedFetchedPages.update((pages) =>
-      pages.includes(page) ? pages : [...pages, page].sort((a, b) => a - b),
+      pages.includes(req.page) ? pages : [...pages, req.page].sort((a, b) => a - b),
     );
-    // Simulated server latency so placeholder rows render before they fill.
-    await new Promise((resolve) => setTimeout(resolve, 400));
-    const start = (page - 1) * perPage;
-    const data = Array.from(
-      { length: Math.max(0, Math.min(perPage, this.windowedTotal - start)) },
-      (_, i) => this.makeArtist(start + i + 1),
-    );
-    return <PaginationResponse<Artist>>{
-      data, totalRecords: this.windowedTotal, page, perPage,
-      totalPages: Math.ceil(this.windowedTotal / perPage),
-    };
+    const response = await this.artistService.pageArtists(req);
+    return response ?? <PaginationResponse<Artist>>{ data: [], totalRecords: 0, totalPages: 1, page: req.page, perPage: req.perPage };
   };
 
   // ─── Tree-mode demo ────────────────────────────────────────────────────

--- a/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
+++ b/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
@@ -71,6 +71,73 @@ async function fetchTreeItems(parentId: number | null | undefined, page = 1, per
   return r.json();
 }
 
+// ─── Lazy windowed-fetch demo ───────────────────────────────────────────────
+// A large synthetic dataset with simulated latency so the windowing is visible:
+// only the pages near the viewport are fetched, with placeholder rows holding
+// the scroll position until each window arrives. The React wrapper is a thin
+// passthrough, so the consumer orchestrates: seed page 1 into `data`, bridge
+// `onFetchRequest` (parentId null = a flat window) to setFetchResponse, and
+// call invalidateData() on the ref to drop the cache.
+
+const WINDOWED_TOTAL = 5000;
+const WINDOWED_PER_PAGE = 25;
+const GENRES = ['Alternative', 'Electronic', 'Psychedelic', 'Progressive', 'Jazz', 'Hip-Hop'];
+
+const WINDOWED_COLUMNS: DatatableColumnDef[] = [
+  { name: 'name',    label: 'Name',    cellRenderer: (row) => (row as Artist)?.name ?? '' },
+  { name: 'genre',   label: 'Genre',   cellRenderer: (row) => (row as Artist)?.genre ?? '' },
+  { name: 'founded', label: 'Founded', cellRenderer: (row) => String((row as Artist)?.founded ?? '') },
+];
+
+function makeWindowedRow(id: number): Artist {
+  return { id, name: `Artist #${id}`, genre: GENRES[id % GENRES.length], founded: 1960 + (id % 60) };
+}
+
+async function fetchWindowedPage(page: number, perPage: number): Promise<PagedResult<Artist>> {
+  await new Promise((resolve) => setTimeout(resolve, 400)); // simulated server latency
+  const start = (page - 1) * perPage;
+  const items = Array.from(
+    { length: Math.max(0, Math.min(perPage, WINDOWED_TOTAL - start)) },
+    (_, i) => makeWindowedRow(start + i + 1),
+  );
+  return { items, totalCount: WINDOWED_TOTAL, page, pageSize: perPage };
+}
+
+const WINDOWED_SOURCE = `// Flat virtual + windowed fetch. The wrapper is a passthrough, so the
+// consumer seeds page 1, bridges the flat fetch-request, and invalidates.
+const ref = useRef<MpDatatable | null>(null);
+const [page1, setPage1] = useState<Artist[]>([]);
+const [total, setTotal] = useState(0);
+
+useEffect(() => {
+  fetchPage(1, 25).then((r) => { setPage1(r.items); setTotal(r.totalCount); });
+}, []);
+
+// parentId === null is a flat window (page >= 2). Key setFetchResponse on the
+// REQUESTED page (detail.page), not the server-echoed page, so a normalising
+// server can't leave the placeholder unresolved.
+const onFetchRequest = useCallback((e: CustomEvent<TreeFetchRequestDetail>) => {
+  const { parentId, page, perPage } = e.detail;
+  if (parentId != null || page <= 1) return;
+  fetchPage(page, perPage).then((r) =>
+    ref.current?.setFetchResponse(null, {
+      data: r.items, totalRecords: r.totalCount, page, perPage: r.pageSize,
+    }),
+  );
+}, []);
+
+<BsDatatable
+  ref={ref}
+  columns={COLUMNS}
+  data={page1}
+  totalRecords={total}
+  virtualScroll
+  itemSize={40}
+  perPage={25}
+  rowKey={(row) => String((row as Artist).id)}
+  onFetchRequest={onFetchRequest}
+/>`;
+
 const TREE_SOURCE = `// Tree mode: virtual scroll + lazy children + cascading selection.
 // The WC fires \`onFetchRequest\` when a row is expanded without cached
 // children; the consumer resolves it and calls \`setFetchResponse(parentId, response)\`
@@ -101,6 +168,43 @@ export function DatatablePage() {
   const [expandedIds, setExpandedIds] = useState<Set<unknown>>(() => new Set());
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const datatableRef = useRef<MpDatatable | null>(null);
+
+  // Windowed-fetch state
+  const [windowedPage1, setWindowedPage1] = useState<Artist[]>([]);
+  const [windowedTotal, setWindowedTotal] = useState(0);
+  const [fetchedPages, setFetchedPages] = useState<number[]>([]);
+  const windowedRef = useRef<MpDatatable | null>(null);
+  const windowedTotalPages = Math.ceil(WINDOWED_TOTAL / WINDOWED_PER_PAGE);
+
+  const loadWindowedPage1 = useCallback(async () => {
+    setFetchedPages([1]);
+    const result = await fetchWindowedPage(1, WINDOWED_PER_PAGE);
+    setWindowedPage1(result.items);
+    setWindowedTotal(result.totalCount);
+  }, []);
+
+  useEffect(() => { void loadWindowedPage1(); }, [loadWindowedPage1]);
+
+  // Bridge the flat window fetch-request (parentId null, page >= 2) to the
+  // page fetch, keyed by the REQUESTED page so a normalising server can't
+  // deadlock the window.
+  const onWindowedFetchRequest = useCallback(async (e: CustomEvent<TreeFetchRequestDetail>) => {
+    const { parentId, page, perPage } = e.detail;
+    if (parentId != null || page <= 1) return;
+    setFetchedPages((prev) => (prev.includes(page) ? prev : [...prev, page].sort((a, b) => a - b)));
+    const result = await fetchWindowedPage(page, perPage);
+    windowedRef.current?.setFetchResponse(null, {
+      data: result.items,
+      totalRecords: result.totalCount,
+      page,
+      perPage: result.pageSize,
+    });
+  }, []);
+
+  const refreshWindowed = useCallback(() => {
+    windowedRef.current?.invalidateData(); // drop the cached pages…
+    void loadWindowedPage1();               // …and re-seed page 1
+  }, [loadWindowedPage1]);
 
   // Initial root fetch.
   useEffect(() => {
@@ -145,6 +249,46 @@ export function DatatablePage() {
         <h2>Simple in-memory table</h2>
         <BsDatatable columns={COLUMNS} data={ARTISTS} />
         <BsCodeSnippet code={SIMPLE_SOURCE} language="tsx" />
+      </section>
+
+      <section>
+        <h2>Virtual scrolling &mdash; lazy windowed fetch</h2>
+        <p>
+          With <code>virtualScroll</code> + a server-paged source the table
+          fetches only the pages whose rows are in (or near) the viewport.
+          Scroll through this {WINDOWED_TOTAL}-row list and watch the fetch
+          log: it never drains all {windowedTotalPages} pages up front &mdash;
+          placeholder rows hold the scroll position until each window arrives.
+          The React wrapper is a thin passthrough, so the consumer seeds page 1,
+          bridges <code>onFetchRequest</code> for flat windows
+          (<code>parentId === null</code>), and calls{' '}
+          <code>invalidateData()</code> on the ref to drop the cache.
+        </p>
+
+        <p className="text-body-secondary">
+          <small>
+            Pages fetched: <code>{fetchedPages.join(', ') || '—'}</code>{' '}
+            ({fetchedPages.length} of {windowedTotalPages}){' '}
+          </small>
+          <button type="button" className="btn btn-sm btn-outline-secondary" onClick={refreshWindowed}>
+            Refresh (invalidateData)
+          </button>
+        </p>
+
+        <BsDatatable
+          ref={windowedRef}
+          className="windowed-table"
+          columns={WINDOWED_COLUMNS}
+          data={windowedPage1}
+          totalRecords={windowedTotal}
+          virtualScroll
+          itemSize={40}
+          perPage={WINDOWED_PER_PAGE}
+          rowKey={(row: unknown) => String((row as Artist).id)}
+          onFetchRequest={onWindowedFetchRequest}
+        />
+
+        <BsCodeSnippet code={WINDOWED_SOURCE} language="tsx" />
       </section>
 
       <section>

--- a/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
+++ b/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
@@ -56,7 +56,10 @@ const ORDER_COLUMNS: DatatableColumnDef[] = [
   { name: 'id',        label: 'Order',  cellRenderer: (r) => `#${(r as Order)?.id}` },
   { name: 'total',     label: 'Total',  cellRenderer: (r) => `€${((r as Order)?.total ?? 0).toFixed(2)}` },
   { name: 'status',    label: 'Status', cellRenderer: (r) => (r as Order)?.status ?? '' },
-  { name: 'orderDate', label: 'Date',   cellRenderer: (r) => new Date((r as Order)?.orderDate).toLocaleDateString() },
+  { name: 'orderDate', label: 'Date',   cellRenderer: (r) => {
+    const d = (r as Order)?.orderDate;
+    return d ? new Date(d).toLocaleDateString() : '';
+  } },
 ];
 
 async function fetchOrders(req: DatatableFetchRequest): Promise<DatatableFetchResponse<Order>> {

--- a/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
+++ b/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
@@ -53,6 +53,10 @@ interface PagedResult<T> {
   pageSize: number;
 }
 
+// The WC's perPage must equal the fetch perPage, or its root-page math
+// misaligns with the loaded rows. One constant drives both.
+const TREE_PER_PAGE = 100;
+
 const TREE_COLUMNS: DatatableColumnDef[] = [
   { name: 'name',      label: 'Name',      sortable: true,
     cellRenderer: (row) => (row as TreeItem)?.name ?? '' },
@@ -165,6 +169,7 @@ const TREE_SOURCE = `// Tree mode: virtual scroll + lazy children + cascading se
 export function DatatablePage() {
   // Tree mode state
   const [roots, setRoots] = useState<TreeItem[]>([]);
+  const [rootTotal, setRootTotal] = useState(0);
   const [expandedIds, setExpandedIds] = useState<Set<unknown>>(() => new Set());
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const datatableRef = useRef<MpDatatable | null>(null);
@@ -206,25 +211,32 @@ export function DatatablePage() {
     void loadWindowedPage1();               // …and re-seed page 1
   }, [loadWindowedPage1]);
 
-  // Initial root fetch.
+  // Initial root page-1 fetch. `rootTotal` enables lazy root windowing when
+  // there are more roots than one page.
   useEffect(() => {
     let cancelled = false;
-    fetchTreeItems(null)
-      .then((result) => { if (!cancelled) setRoots(result.items); })
+    fetchTreeItems(null, 1, TREE_PER_PAGE)
+      .then((result) => {
+        if (cancelled) return;
+        setRoots(result.items);
+        setRootTotal(result.totalCount);
+      })
       .catch(() => { /* surfaced via the page when needed; demo is best-effort */ });
     return () => { cancelled = true; };
   }, []);
 
-  // Bridge `mp-datatable-fetch-request` → fetch + setFetchResponse.
+  // Bridge `mp-datatable-fetch-request` → fetch + setFetchResponse. This fires
+  // for tree children (non-null parentId) AND lazy root windows (parentId
+  // null, page ≥ 2). Page 1 is seeded by the effect above, so only pages ≥ 2
+  // reach here for the root level. Key on the REQUESTED page (detail.page).
   const onFetchRequest = useCallback(async (e: CustomEvent<TreeFetchRequestDetail>) => {
     const detail = e.detail;
-    if (detail.parentId == null) return; // root fetch is handled by the useEffect above
     try {
-      const result = await fetchTreeItems(detail.parentId as number, detail.page, detail.perPage);
+      const result = await fetchTreeItems(detail.parentId as number | null, detail.page, detail.perPage);
       datatableRef.current?.setFetchResponse(detail.parentId, {
         data: result.items,
         totalRecords: result.totalCount,
-        page: result.page,
+        page: detail.page,
         perPage: result.pageSize,
       });
     } catch (err) {
@@ -305,6 +317,8 @@ export function DatatablePage() {
           ref={datatableRef}
           columns={TREE_COLUMNS}
           data={roots}
+          totalRecords={rootTotal}
+          perPage={TREE_PER_PAGE}
           virtualScroll
           itemSize={40}
           tree

--- a/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
+++ b/apps/react-bootstrap-demo/src/app/pages/DatatablePage.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { BsDatatable } from '@mintplayer/react-bootstrap/datatable';
 import { BsCodeSnippet } from '@mintplayer/react-bootstrap/code-snippet';
 import type {
   DatatableColumnDef,
-  MpDatatable,
-  TreeFetchRequestDetail,
-  TreeExpandedIdsChangeDetail,
+  DatatableFetchRequest,
+  DatatableFetchResponse,
   SelectionChangeEventDetail,
 } from '@mintplayer/web-components/datatable';
 
@@ -27,15 +26,65 @@ const COLUMNS: DatatableColumnDef[] = [
 ];
 
 const ARTISTS: Artist[] = [
-  { id: 1, name: 'Radiohead',     genre: 'Alternative', founded: 1985 },
-  { id: 2, name: 'Daft Punk',     genre: 'Electronic',  founded: 1993 },
-  { id: 3, name: 'Tame Impala',   genre: 'Psychedelic', founded: 2007 },
-  { id: 4, name: 'Pink Floyd',    genre: 'Progressive', founded: 1965 },
+  { id: 1, name: 'Radiohead',   genre: 'Alternative', founded: 1985 },
+  { id: 2, name: 'Daft Punk',   genre: 'Electronic',  founded: 1993 },
+  { id: 3, name: 'Tame Impala', genre: 'Psychedelic', founded: 2007 },
+  { id: 4, name: 'Pink Floyd',  genre: 'Progressive', founded: 1965 },
 ];
 
 const SIMPLE_SOURCE = `<BsDatatable columns={COLUMNS} data={ARTISTS} />`;
 
-// ─── Tree-mode demo ────────────────────────────────────────────────────────
+// ─── Lazy windowed-fetch demo (real API: 1000 seeded orders) ─────────────────
+// One `fetch` callback drives the whole table: the WC calls it for page 1 and
+// each window as the user scrolls, reading the grand total from the response.
+// No totalRecords prop, no event bridge, no page-1 seeding.
+
+const WINDOWED_PER_PAGE = 25;
+
+interface Order {
+  id: number;
+  total: number;
+  status: string;
+  orderDate: string;
+}
+
+// The orders endpoint is the query-builder search (the same shape ng-spark
+// query-pages use). A match-all = an empty `and` group; the id must be a UUID.
+const MATCH_ALL = { kind: 'group', id: '00000000-0000-4000-8000-000000000000', logic: 'and', children: [] };
+
+const ORDER_COLUMNS: DatatableColumnDef[] = [
+  { name: 'id',        label: 'Order',  cellRenderer: (r) => `#${(r as Order)?.id}` },
+  { name: 'total',     label: 'Total',  cellRenderer: (r) => `€${((r as Order)?.total ?? 0).toFixed(2)}` },
+  { name: 'status',    label: 'Status', cellRenderer: (r) => (r as Order)?.status ?? '' },
+  { name: 'orderDate', label: 'Date',   cellRenderer: (r) => new Date((r as Order)?.orderDate).toLocaleDateString() },
+];
+
+async function fetchOrders(req: DatatableFetchRequest): Promise<DatatableFetchResponse<Order>> {
+  const res = await fetch(`${API_BASE}/api/orders/search`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: MATCH_ALL,
+      page: req.page,
+      pageSize: req.perPage,
+      sort: req.sortColumns.map((s) => ({ field: s.property, direction: s.direction === 'descending' ? 'desc' : 'asc' })),
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  return { data: json.items, totalRecords: json.totalCount };
+}
+
+const WINDOWED_SOURCE = `// One callback. The WC owns page 1, every window, the total, and the scrollbar.
+const fetchOrders = useCallback(
+  async (req: DatatableFetchRequest): Promise<DatatableFetchResponse<Order>> => {
+    const res = await api.searchOrders(req.page, req.perPage, req.sortColumns);
+    return { data: res.items, totalRecords: res.totalCount };
+  }, []);
+
+<BsDatatable columns={ORDER_COLUMNS} fetch={fetchOrders} virtualScroll itemSize={40} perPage={25} />`;
+
+// ─── Tree-mode demo ──────────────────────────────────────────────────────────
 
 interface TreeItem {
   id: number;
@@ -53,20 +102,13 @@ interface PagedResult<T> {
   pageSize: number;
 }
 
-// The WC's perPage must equal the fetch perPage, or its root-page math
-// misaligns with the loaded rows. One constant drives both.
-const TREE_PER_PAGE = 100;
-
 const TREE_COLUMNS: DatatableColumnDef[] = [
-  { name: 'name',      label: 'Name',      sortable: true,
-    cellRenderer: (row) => (row as TreeItem)?.name ?? '' },
-  { name: 'code',      label: 'Code',      sortable: true,
-    cellRenderer: (row) => (row as TreeItem)?.code ?? '' },
-  { name: 'headcount', label: 'Headcount', sortable: true,
-    cellRenderer: (row) => String((row as TreeItem)?.headcount ?? '') },
+  { name: 'name',      label: 'Name',      sortable: true, cellRenderer: (r) => (r as TreeItem)?.name ?? '' },
+  { name: 'code',      label: 'Code',      sortable: true, cellRenderer: (r) => (r as TreeItem)?.code ?? '' },
+  { name: 'headcount', label: 'Headcount', sortable: true, cellRenderer: (r) => String((r as TreeItem)?.headcount ?? '') },
 ];
 
-async function fetchTreeItems(parentId: number | null | undefined, page = 1, perPage = 100): Promise<PagedResult<TreeItem>> {
+async function fetchTreeItems(parentId: number | null, page: number, perPage: number): Promise<PagedResult<TreeItem>> {
   const url = parentId == null
     ? `${API_BASE}/api/treeItems?page=${page}&perPage=${perPage}`
     : `${API_BASE}/api/treeItems/${parentId}/children?page=${page}&perPage=${perPage}`;
@@ -75,182 +117,46 @@ async function fetchTreeItems(parentId: number | null | undefined, page = 1, per
   return r.json();
 }
 
-// ─── Lazy windowed-fetch demo ───────────────────────────────────────────────
-// A large synthetic dataset with simulated latency so the windowing is visible:
-// only the pages near the viewport are fetched, with placeholder rows holding
-// the scroll position until each window arrives. The React wrapper is a thin
-// passthrough, so the consumer orchestrates: seed page 1 into `data`, bridge
-// `onFetchRequest` (parentId null = a flat window) to setFetchResponse, and
-// call invalidateData() on the ref to drop the cache.
-
-const WINDOWED_TOTAL = 5000;
-const WINDOWED_PER_PAGE = 25;
-const GENRES = ['Alternative', 'Electronic', 'Psychedelic', 'Progressive', 'Jazz', 'Hip-Hop'];
-
-const WINDOWED_COLUMNS: DatatableColumnDef[] = [
-  { name: 'name',    label: 'Name',    cellRenderer: (row) => (row as Artist)?.name ?? '' },
-  { name: 'genre',   label: 'Genre',   cellRenderer: (row) => (row as Artist)?.genre ?? '' },
-  { name: 'founded', label: 'Founded', cellRenderer: (row) => String((row as Artist)?.founded ?? '') },
-];
-
-function makeWindowedRow(id: number): Artist {
-  return { id, name: `Artist #${id}`, genre: GENRES[id % GENRES.length], founded: 1960 + (id % 60) };
-}
-
-async function fetchWindowedPage(page: number, perPage: number): Promise<PagedResult<Artist>> {
-  await new Promise((resolve) => setTimeout(resolve, 400)); // simulated server latency
-  const start = (page - 1) * perPage;
-  const items = Array.from(
-    { length: Math.max(0, Math.min(perPage, WINDOWED_TOTAL - start)) },
-    (_, i) => makeWindowedRow(start + i + 1),
-  );
-  return { items, totalCount: WINDOWED_TOTAL, page, pageSize: perPage };
-}
-
-const WINDOWED_SOURCE = `// Flat virtual + windowed fetch. The wrapper is a passthrough, so the
-// consumer seeds page 1, bridges the flat fetch-request, and invalidates.
-const ref = useRef<MpDatatable | null>(null);
-const [page1, setPage1] = useState<Artist[]>([]);
-const [total, setTotal] = useState(0);
-
-useEffect(() => {
-  fetchPage(1, 25).then((r) => { setPage1(r.items); setTotal(r.totalCount); });
-}, []);
-
-// parentId === null is a flat window (page >= 2). Key setFetchResponse on the
-// REQUESTED page (detail.page), not the server-echoed page, so a normalising
-// server can't leave the placeholder unresolved.
-const onFetchRequest = useCallback((e: CustomEvent<TreeFetchRequestDetail>) => {
-  const { parentId, page, perPage } = e.detail;
-  if (parentId != null || page <= 1) return;
-  fetchPage(page, perPage).then((r) =>
-    ref.current?.setFetchResponse(null, {
-      data: r.items, totalRecords: r.totalCount, page, perPage: r.pageSize,
-    }),
-  );
-}, []);
+const TREE_SOURCE = `// Same single callback; it branches on req.parentId for roots vs children.
+// The WC lazily paginates roots AND loads children on expand.
+const fetchTree = useCallback(
+  async (req: DatatableFetchRequest): Promise<DatatableFetchResponse<TreeItem>> => {
+    const r = await treeApi.list(req.parentId, req.page, req.perPage);
+    return { data: r.items, totalRecords: r.totalCount };
+  }, []);
 
 <BsDatatable
-  ref={ref}
-  columns={COLUMNS}
-  data={page1}
-  totalRecords={total}
-  virtualScroll
-  itemSize={40}
-  perPage={25}
-  rowKey={(row) => String((row as Artist).id)}
-  onFetchRequest={onFetchRequest}
-/>`;
-
-const TREE_SOURCE = `// Tree mode: virtual scroll + lazy children + cascading selection.
-// The WC fires \`onFetchRequest\` when a row is expanded without cached
-// children; the consumer resolves it and calls \`setFetchResponse(parentId, response)\`
-// on the element ref. \`childCount\` on each row drives chevron visibility
-// AND placeholder reservation for not-yet-loaded subtrees.
-<BsDatatable
-  ref={datatableRef}
   columns={TREE_COLUMNS}
-  data={roots}
-  virtualScroll
-  itemSize={40}
-  tree
-  idKey="id"
-  childCountKey="childCount"
-  rowKey={(row) => String((row as TreeItem).id)}
-  expandedIds={expandedIds}
-  selectionMode="multiple"
-  selectionStrategy="cascading"
-  selectedIds={selectedIds}
-  onFetchRequest={onFetchRequest}
-  onExpandedIdsChange={onExpandedIdsChange}
-  onSelectionChange={onSelectionChange}
+  fetch={fetchTree}
+  virtualScroll itemSize={40}
+  tree idKey="id" childCountKey="childCount"
+  selectionMode="multiple" selectionStrategy="cascading"
+  onSelectionChange={(e) => setSelected(e.detail.selectedRows)}
 />`;
 
 export function DatatablePage() {
-  // Tree mode state
-  const [roots, setRoots] = useState<TreeItem[]>([]);
-  const [rootTotal, setRootTotal] = useState(0);
-  const [expandedIds, setExpandedIds] = useState<Set<unknown>>(() => new Set());
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const datatableRef = useRef<MpDatatable | null>(null);
-
-  // Windowed-fetch state
-  const [windowedPage1, setWindowedPage1] = useState<Artist[]>([]);
-  const [windowedTotal, setWindowedTotal] = useState(0);
   const [fetchedPages, setFetchedPages] = useState<number[]>([]);
-  const windowedRef = useRef<MpDatatable | null>(null);
-  const windowedTotalPages = Math.ceil(WINDOWED_TOTAL / WINDOWED_PER_PAGE);
+  const [selectedRows, setSelectedRows] = useState<TreeItem[]>([]);
 
-  const loadWindowedPage1 = useCallback(async () => {
-    setFetchedPages([1]);
-    const result = await fetchWindowedPage(1, WINDOWED_PER_PAGE);
-    setWindowedPage1(result.items);
-    setWindowedTotal(result.totalCount);
-  }, []);
+  // Real orders source (1000 seeded rows) + a live fetch log.
+  const fetchWindowed = useCallback(
+    async (req: DatatableFetchRequest): Promise<DatatableFetchResponse<Order>> => {
+      setFetchedPages((prev) => (prev.includes(req.page) ? prev : [...prev, req.page].sort((a, b) => a - b)));
+      return fetchOrders(req);
+    },
+    [],
+  );
 
-  useEffect(() => { void loadWindowedPage1(); }, [loadWindowedPage1]);
-
-  // Bridge the flat window fetch-request (parentId null, page >= 2) to the
-  // page fetch, keyed by the REQUESTED page so a normalising server can't
-  // deadlock the window.
-  const onWindowedFetchRequest = useCallback(async (e: CustomEvent<TreeFetchRequestDetail>) => {
-    const { parentId, page, perPage } = e.detail;
-    if (parentId != null || page <= 1) return;
-    setFetchedPages((prev) => (prev.includes(page) ? prev : [...prev, page].sort((a, b) => a - b)));
-    const result = await fetchWindowedPage(page, perPage);
-    windowedRef.current?.setFetchResponse(null, {
-      data: result.items,
-      totalRecords: result.totalCount,
-      page,
-      perPage: result.pageSize,
-    });
-  }, []);
-
-  const refreshWindowed = useCallback(() => {
-    windowedRef.current?.invalidateData(); // drop the cached pages…
-    void loadWindowedPage1();               // …and re-seed page 1
-  }, [loadWindowedPage1]);
-
-  // Initial root page-1 fetch. `rootTotal` enables lazy root windowing when
-  // there are more roots than one page.
-  useEffect(() => {
-    let cancelled = false;
-    fetchTreeItems(null, 1, TREE_PER_PAGE)
-      .then((result) => {
-        if (cancelled) return;
-        setRoots(result.items);
-        setRootTotal(result.totalCount);
-      })
-      .catch(() => { /* surfaced via the page when needed; demo is best-effort */ });
-    return () => { cancelled = true; };
-  }, []);
-
-  // Bridge `mp-datatable-fetch-request` → fetch + setFetchResponse. This fires
-  // for tree children (non-null parentId) AND lazy root windows (parentId
-  // null, page ≥ 2). Page 1 is seeded by the effect above, so only pages ≥ 2
-  // reach here for the root level. Key on the REQUESTED page (detail.page).
-  const onFetchRequest = useCallback(async (e: CustomEvent<TreeFetchRequestDetail>) => {
-    const detail = e.detail;
-    try {
-      const result = await fetchTreeItems(detail.parentId as number | null, detail.page, detail.perPage);
-      datatableRef.current?.setFetchResponse(detail.parentId, {
-        data: result.items,
-        totalRecords: result.totalCount,
-        page: detail.page,
-        perPage: result.pageSize,
-      });
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('[BsDatatable] tree fetch failed', err);
-    }
-  }, []);
-
-  const onExpandedIdsChange = useCallback((e: CustomEvent<TreeExpandedIdsChangeDetail>) => {
-    setExpandedIds(new Set(e.detail.expandedIds));
-  }, []);
+  const fetchTree = useCallback(
+    async (req: DatatableFetchRequest): Promise<DatatableFetchResponse<TreeItem>> => {
+      const r = await fetchTreeItems(req.parentId as number | null, req.page, req.perPage);
+      return { data: r.items, totalRecords: r.totalCount };
+    },
+    [],
+  );
 
   const onSelectionChange = useCallback((e: CustomEvent<SelectionChangeEventDetail>) => {
-    setSelectedIds(e.detail.selectedIds);
+    setSelectedRows(e.detail.selectedRows as TreeItem[]);
   }, []);
 
   return (
@@ -266,38 +172,28 @@ export function DatatablePage() {
       <section>
         <h2>Virtual scrolling &mdash; lazy windowed fetch</h2>
         <p>
-          With <code>virtualScroll</code> + a server-paged source the table
-          fetches only the pages whose rows are in (or near) the viewport.
-          Scroll through this {WINDOWED_TOTAL}-row list and watch the fetch
-          log: it never drains all {windowedTotalPages} pages up front &mdash;
-          placeholder rows hold the scroll position until each window arrives.
-          The React wrapper is a thin passthrough, so the consumer seeds page 1,
-          bridges <code>onFetchRequest</code> for flat windows
-          (<code>parentId === null</code>), and calls{' '}
-          <code>invalidateData()</code> on the ref to drop the cache.
+          Set one <code>fetch</code> callback and the web component owns the
+          whole loop: it loads page 1, derives the total from the response, and
+          fetches each window only as its rows scroll into view. This list is
+          the 1000 seeded orders from <code>apps/api</code>; scroll it and watch
+          the fetch log — it never drains every page. No <code>totalRecords</code>{' '}
+          prop, no event bridge.
         </p>
-
         <p className="text-body-secondary">
           <small>
             Pages fetched: <code>{fetchedPages.join(', ') || '—'}</code>{' '}
-            ({fetchedPages.length} of {windowedTotalPages}){' '}
+            ({fetchedPages.length} so far)
           </small>
-          <button type="button" className="btn btn-sm btn-outline-secondary" onClick={refreshWindowed}>
-            Refresh (invalidateData)
-          </button>
         </p>
 
         <BsDatatable
-          ref={windowedRef}
           className="windowed-table"
-          columns={WINDOWED_COLUMNS}
-          data={windowedPage1}
-          totalRecords={windowedTotal}
+          columns={ORDER_COLUMNS}
+          fetch={fetchWindowed}
           virtualScroll
           itemSize={40}
           perPage={WINDOWED_PER_PAGE}
-          rowKey={(row: unknown) => String((row as Artist).id)}
-          onFetchRequest={onWindowedFetchRequest}
+          rowKey={(row: unknown) => String((row as Order).id)}
         />
 
         <BsCodeSnippet code={WINDOWED_SOURCE} language="tsx" />
@@ -306,36 +202,28 @@ export function DatatablePage() {
       <section>
         <h2>Tree mode &mdash; expandable rows</h2>
         <p>
-          Click a chevron to expand a row. Children load lazily on first
-          expand and stay cached for subsequent collapse/expand cycles.
-          Placeholder rows reserve viewport space while the fetch is in
-          flight so the scrollbar stays accurate. Cascading selection:
-          checking a parent selects all currently-loaded descendants.
+          The same single <code>fetch</code> callback, branching on{' '}
+          <code>req.parentId</code> for roots vs. children. The WC paginates
+          roots lazily and loads children on expand; selected row objects arrive
+          on <code>onSelectionChange</code> as <code>detail.selectedRows</code>.
         </p>
 
         <BsDatatable
-          ref={datatableRef}
+          className="windowed-table"
           columns={TREE_COLUMNS}
-          data={roots}
-          totalRecords={rootTotal}
-          perPage={TREE_PER_PAGE}
+          fetch={fetchTree}
           virtualScroll
           itemSize={40}
           tree
           idKey="id"
           childCountKey="childCount"
           rowKey={(row: unknown) => String((row as TreeItem).id)}
-          expandedIds={expandedIds}
           selectionMode="multiple"
           selectionStrategy="cascading"
-          selectedIds={selectedIds}
-          onFetchRequest={onFetchRequest}
-          onExpandedIdsChange={onExpandedIdsChange}
           onSelectionChange={onSelectionChange}
-          style={{ height: 480, display: 'block' }}
         />
-        {selectedIds.length > 0 && (
-          <small className="text-body-secondary">Selected {selectedIds.length} item(s).</small>
+        {selectedRows.length > 0 && (
+          <small className="text-body-secondary">Selected {selectedRows.length} item(s).</small>
         )}
 
         <BsCodeSnippet code={TREE_SOURCE} language="tsx" />

--- a/apps/react-bootstrap-demo/src/styles.css
+++ b/apps/react-bootstrap-demo/src/styles.css
@@ -121,3 +121,9 @@ body {
   font-size: 1.25rem;
   margin-bottom: 1rem;
 }
+
+/* Bounded viewport so the windowed-fetch datatable demo actually scrolls. */
+.windowed-table {
+  display: block;
+  height: 360px;
+}

--- a/apps/vue-bootstrap-demo/src/views/DatatableView.vue
+++ b/apps/vue-bootstrap-demo/src/views/DatatableView.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref } from 'vue';
 import { BsDatatable } from '@mintplayer/vue-bootstrap/datatable';
 import { BsCodeSnippet } from '@mintplayer/vue-bootstrap/code-snippet';
 import type {
   DatatableColumnDef,
-  TreeFetchRequestDetail,
+  DatatableFetchRequest,
+  DatatableFetchResponse,
+  SelectionChangeEventDetail,
 } from '@mintplayer/web-components/datatable';
 
 // Dev: /api is proxied to localhost:5000 by vite.config; prod hits the API
@@ -25,13 +27,60 @@ const COLUMNS: DatatableColumnDef[] = [
 ];
 
 const ARTISTS: Artist[] = [
-  { id: 1, name: 'Radiohead',     genre: 'Alternative', founded: 1985 },
-  { id: 2, name: 'Daft Punk',     genre: 'Electronic',  founded: 1993 },
-  { id: 3, name: 'Tame Impala',   genre: 'Psychedelic', founded: 2007 },
-  { id: 4, name: 'Pink Floyd',    genre: 'Progressive', founded: 1965 },
+  { id: 1, name: 'Radiohead',   genre: 'Alternative', founded: 1985 },
+  { id: 2, name: 'Daft Punk',   genre: 'Electronic',  founded: 1993 },
+  { id: 3, name: 'Tame Impala', genre: 'Psychedelic', founded: 2007 },
+  { id: 4, name: 'Pink Floyd',  genre: 'Progressive', founded: 1965 },
 ];
 
 const SIMPLE_SOURCE = `<BsDatatable :columns="COLUMNS" :data="ARTISTS" />`;
+
+// ─── Lazy windowed-fetch demo (real API: 1000 seeded orders) ──────────────
+// One `fetch` callback drives the whole table: the WC calls it for page 1 and
+// each window as the user scrolls, reading the grand total from the response.
+const WINDOWED_PER_PAGE = 25;
+
+interface Order {
+  id: number;
+  total: number;
+  status: string;
+  orderDate: string;
+}
+
+// The orders endpoint is the query-builder search (the same shape ng-spark
+// query-pages use). A match-all = an empty `and` group; the id must be a UUID.
+const MATCH_ALL = { kind: 'group', id: '00000000-0000-4000-8000-000000000000', logic: 'and', children: [] };
+
+const ORDER_COLUMNS: DatatableColumnDef[] = [
+  { name: 'id',        label: 'Order',  cellRenderer: (r) => `#${(r as Order)?.id}` },
+  { name: 'total',     label: 'Total',  cellRenderer: (r) => `€${((r as Order)?.total ?? 0).toFixed(2)}` },
+  { name: 'status',    label: 'Status', cellRenderer: (r) => (r as Order)?.status ?? '' },
+  { name: 'orderDate', label: 'Date',   cellRenderer: (r) => new Date((r as Order)?.orderDate).toLocaleDateString() },
+];
+
+const fetchedPages = ref<number[]>([]);
+
+async function fetchWindowed(req: DatatableFetchRequest): Promise<DatatableFetchResponse<Order>> {
+  if (!fetchedPages.value.includes(req.page)) {
+    fetchedPages.value = [...fetchedPages.value, req.page].sort((a, b) => a - b);
+  }
+  const res = await fetch(`${API_BASE}/api/orders/search`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: MATCH_ALL,
+      page: req.page,
+      pageSize: req.perPage,
+      sort: req.sortColumns.map((s) => ({ field: s.property, direction: s.direction === 'descending' ? 'desc' : 'asc' })),
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = await res.json();
+  return { data: json.items, totalRecords: json.totalCount };
+}
+
+const WINDOWED_SOURCE = `<!-- One callback; the WC owns page 1, every window, the total + scrollbar. -->
+<BsDatatable :columns="ORDER_COLUMNS" :fetch="fetchWindowed" :virtualScroll="true" :itemSize="40" :perPage="25" />`;
 
 // ─── Tree-mode demo ──────────────────────────────────────────────────────
 
@@ -52,15 +101,12 @@ interface PagedResult<T> {
 }
 
 const TREE_COLUMNS: DatatableColumnDef[] = [
-  { name: 'name',      label: 'Name',      sortable: true,
-    cellRenderer: (row) => (row as TreeItem)?.name ?? '' },
-  { name: 'code',      label: 'Code',      sortable: true,
-    cellRenderer: (row) => (row as TreeItem)?.code ?? '' },
-  { name: 'headcount', label: 'Headcount', sortable: true,
-    cellRenderer: (row) => String((row as TreeItem)?.headcount ?? '') },
+  { name: 'name',      label: 'Name',      sortable: true, cellRenderer: (r) => (r as TreeItem)?.name ?? '' },
+  { name: 'code',      label: 'Code',      sortable: true, cellRenderer: (r) => (r as TreeItem)?.code ?? '' },
+  { name: 'headcount', label: 'Headcount', sortable: true, cellRenderer: (r) => String((r as TreeItem)?.headcount ?? '') },
 ];
 
-async function fetchTreeItems(parentId: number | null, page = 1, perPage = 100): Promise<PagedResult<TreeItem>> {
+async function fetchTreeItems(parentId: number | null, page: number, perPage: number): Promise<PagedResult<TreeItem>> {
   const url = parentId == null
     ? `${API_BASE}/api/treeItems?page=${page}&perPage=${perPage}`
     : `${API_BASE}/api/treeItems/${parentId}/children?page=${page}&perPage=${perPage}`;
@@ -69,157 +115,26 @@ async function fetchTreeItems(parentId: number | null, page = 1, perPage = 100):
   return r.json();
 }
 
-// The WC's perPage must equal the fetch perPage, or its root-page math
-// misaligns with the loaded rows. One constant drives both.
-const TREE_PER_PAGE = 100;
-
-const roots = ref<TreeItem[]>([]);
-const rootTotal = ref(0);
-const expandedIds = ref<Set<unknown>>(new Set());
-const selectedIds = ref<string[]>([]);
-const tableRef = ref<InstanceType<typeof BsDatatable> | null>(null);
-
-onMounted(async () => {
-  try {
-    const result = await fetchTreeItems(null, 1, TREE_PER_PAGE);
-    roots.value = result.items;
-    rootTotal.value = result.totalCount; // enables lazy root windowing past page 1
-  } catch {
-    // Best-effort demo — surfaces the empty table if the api isn't up.
-  }
-});
-
-// Fires for tree children (non-null parentId) AND lazy root windows (parentId
-// null, page ≥ 2). Page 1 is seeded by onMounted, so only pages ≥ 2 reach here
-// for the root level. Key on the REQUESTED page (detail.page).
-async function onFetchRequest(detail: TreeFetchRequestDetail) {
-  try {
-    const result = await fetchTreeItems(detail.parentId as number | null, detail.page, detail.perPage);
-    tableRef.value?.setFetchResponse(detail.parentId, {
-      data: result.items,
-      totalRecords: result.totalCount,
-      page: detail.page,
-      perPage: result.pageSize,
-    });
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('[BsDatatable] tree fetch failed', e);
-  }
+async function fetchTree(req: DatatableFetchRequest): Promise<DatatableFetchResponse<TreeItem>> {
+  const r = await fetchTreeItems(req.parentId as number | null, req.page, req.perPage);
+  return { data: r.items, totalRecords: r.totalCount };
 }
 
 const rowKey = (row: unknown) => String((row as TreeItem).id);
+const selectedRows = ref<TreeItem[]>([]);
 
-// ─── Lazy windowed-fetch demo ────────────────────────────────────────────
-// A large synthetic dataset with simulated latency so the windowing is
-// visible: only the pages near the viewport are fetched, with placeholder
-// rows holding the scroll position until each window arrives. The Vue wrapper
-// is a thin passthrough, so the consumer orchestrates: seed page 1 into
-// `data`, bridge `@fetchRequest` (parentId null = a flat window), and call
-// `invalidateData()` on the ref to drop the cache.
-
-interface WindowedArtist { id: number; name: string; genre: string; founded: number; }
-
-const WINDOWED_TOTAL = 5000;
-const WINDOWED_PER_PAGE = 25;
-const GENRES = ['Alternative', 'Electronic', 'Psychedelic', 'Progressive', 'Jazz', 'Hip-Hop'];
-
-const WINDOWED_COLUMNS: DatatableColumnDef[] = [
-  { name: 'name',    label: 'Name',    cellRenderer: (row) => (row as WindowedArtist)?.name ?? '' },
-  { name: 'genre',   label: 'Genre',   cellRenderer: (row) => (row as WindowedArtist)?.genre ?? '' },
-  { name: 'founded', label: 'Founded', cellRenderer: (row) => String((row as WindowedArtist)?.founded ?? '') },
-];
-
-function makeWindowedRow(id: number): WindowedArtist {
-  return { id, name: `Artist #${id}`, genre: GENRES[id % GENRES.length], founded: 1960 + (id % 60) };
+function onSelectionChange(detail: SelectionChangeEventDetail) {
+  selectedRows.value = detail.selectedRows as TreeItem[];
 }
 
-async function fetchWindowedPage(page: number, perPage: number): Promise<PagedResult<WindowedArtist>> {
-  await new Promise((resolve) => setTimeout(resolve, 400)); // simulated server latency
-  const start = (page - 1) * perPage;
-  const items = Array.from(
-    { length: Math.max(0, Math.min(perPage, WINDOWED_TOTAL - start)) },
-    (_, i) => makeWindowedRow(start + i + 1),
-  );
-  return { items, totalCount: WINDOWED_TOTAL, page, pageSize: perPage };
-}
-
-const windowedPage1 = ref<WindowedArtist[]>([]);
-const windowedTotal = ref(0);
-const fetchedPages = ref<number[]>([]);
-const windowedRef = ref<InstanceType<typeof BsDatatable> | null>(null);
-const windowedTotalPages = Math.ceil(WINDOWED_TOTAL / WINDOWED_PER_PAGE);
-
-async function loadWindowedPage1() {
-  fetchedPages.value = [1];
-  const result = await fetchWindowedPage(1, WINDOWED_PER_PAGE);
-  windowedPage1.value = result.items;
-  windowedTotal.value = result.totalCount;
-}
-
-onMounted(loadWindowedPage1);
-
-// Flat window fetch-request (parentId null, page >= 2). Key setFetchResponse
-// on the REQUESTED page so a normalising server can't deadlock the window.
-async function onWindowedFetchRequest(detail: TreeFetchRequestDetail) {
-  if (detail.parentId != null || detail.page <= 1) return;
-  if (!fetchedPages.value.includes(detail.page)) {
-    fetchedPages.value = [...fetchedPages.value, detail.page].sort((a, b) => a - b);
-  }
-  const result = await fetchWindowedPage(detail.page, detail.perPage);
-  windowedRef.value?.setFetchResponse(null, {
-    data: result.items,
-    totalRecords: result.totalCount,
-    page: detail.page,
-    perPage: result.pageSize,
-  });
-}
-
-function refreshWindowed() {
-  windowedRef.value?.invalidateData(); // drop the cached pages…
-  void loadWindowedPage1();             // …and re-seed page 1
-}
-
-const WINDOWED_SOURCE = `<!-- Flat virtual + windowed fetch. The wrapper is a passthrough, so the
-     consumer seeds page 1, bridges the flat fetch-request, and invalidates. -->
+const TREE_SOURCE = `<!-- The same callback, branching on req.parentId for roots vs children. -->
 <BsDatatable
-  ref="windowedRef"
-  :columns="WINDOWED_COLUMNS"
-  :data="windowedPage1"
-  :totalRecords="windowedTotal"
-  :virtualScroll="true"
-  :itemSize="40"
-  :perPage="25"
-  :rowKey="rowKey"
-  @fetchRequest="onWindowedFetchRequest"
-/>
-
-// In <script setup>: parentId === null is a flat window (page >= 2). Key
-// setFetchResponse on the REQUESTED page (detail.page), not the server-echoed
-// page, so a normalising server can't deadlock the window.
-async function onWindowedFetchRequest(detail) {
-  if (detail.parentId != null || detail.page <= 1) return;
-  const r = await fetchPage(detail.page, detail.perPage);
-  windowedRef.value?.setFetchResponse(null, {
-    data: r.items, totalRecords: r.totalCount, page: detail.page, perPage: r.pageSize,
-  });
-}`;
-
-const TREE_SOURCE = `<!-- Tree mode: virtual scroll + lazy children + cascading selection. -->
-<BsDatatable
-  ref="tableRef"
   :columns="TREE_COLUMNS"
-  :data="roots"
-  :virtualScroll="true"
-  :itemSize="40"
-  :tree="true"
-  idKey="id"
-  childCountKey="childCount"
-  :rowKey="rowKey"
-  v-model:expandedIds="expandedIds"
-  selectionMode="multiple"
-  selectionStrategy="cascading"
-  v-model:selectedIds="selectedIds"
-  @fetchRequest="onFetchRequest"
+  :fetch="fetchTree"
+  :virtualScroll="true" :itemSize="40"
+  :tree="true" idKey="id" childCountKey="childCount"
+  selectionMode="multiple" selectionStrategy="cascading"
+  @selectionChange="onSelectionChange"
 />`;
 </script>
 
@@ -236,38 +151,28 @@ const TREE_SOURCE = `<!-- Tree mode: virtual scroll + lazy children + cascading 
     <section>
       <h2>Virtual scrolling &mdash; lazy windowed fetch</h2>
       <p>
-        With <code>virtualScroll</code> + a server-paged source the table
-        fetches only the pages whose rows are in (or near) the viewport.
-        Scroll through this {{ WINDOWED_TOTAL }}-row list and watch the fetch
-        log: it never drains all {{ windowedTotalPages }} pages up front
-        &mdash; placeholder rows hold the scroll position until each window
-        arrives. The Vue wrapper is a thin passthrough, so the consumer seeds
-        page 1, bridges <code>@fetchRequest</code> for flat windows
-        (<code>parentId === null</code>), and calls <code>invalidateData()</code>
-        on the ref to drop the cache.
+        Set one <code>fetch</code> callback and the web component owns the whole
+        loop: it loads page 1, derives the total from the response, and fetches
+        each window only as its rows scroll into view. This list is the 1000
+        seeded orders from <code>apps/api</code>; scroll it and watch the fetch
+        log — it never drains every page. No <code>totalRecords</code> prop, no
+        event bridge.
       </p>
-
       <p class="text-body-secondary">
         <small>
           Pages fetched: <code>{{ fetchedPages.join(', ') || '—' }}</code>
-          ({{ fetchedPages.length }} of {{ windowedTotalPages }})
+          ({{ fetchedPages.length }} so far)
         </small>
-        <button type="button" class="btn btn-sm btn-outline-secondary ms-2" @click="refreshWindowed">
-          Refresh (invalidateData)
-        </button>
       </p>
 
       <BsDatatable
-        ref="windowedRef"
         class="windowed-table"
-        :columns="WINDOWED_COLUMNS"
-        :data="windowedPage1"
-        :totalRecords="windowedTotal"
+        :columns="ORDER_COLUMNS"
+        :fetch="fetchWindowed"
         :virtualScroll="true"
         :itemSize="40"
         :perPage="WINDOWED_PER_PAGE"
         :rowKey="rowKey"
-        @fetchRequest="onWindowedFetchRequest"
       />
 
       <BsCodeSnippet :code="WINDOWED_SOURCE" language="html" />
@@ -276,34 +181,28 @@ const TREE_SOURCE = `<!-- Tree mode: virtual scroll + lazy children + cascading 
     <section>
       <h2>Tree mode &mdash; expandable rows</h2>
       <p>
-        Click a chevron to expand a row. Children load lazily on first
-        expand and stay cached for subsequent collapse/expand cycles.
-        Placeholder rows reserve viewport space while the fetch is in
-        flight so the scrollbar stays accurate. Cascading selection:
-        checking a parent selects all currently-loaded descendants.
+        The same single <code>fetch</code> callback, branching on
+        <code>req.parentId</code> for roots vs. children. The WC paginates roots
+        lazily and loads children on expand; selected row objects arrive on
+        <code>@selectionChange</code> as <code>detail.selectedRows</code>.
       </p>
 
       <BsDatatable
-        ref="tableRef"
+        class="windowed-table"
         :columns="TREE_COLUMNS"
-        :data="roots"
-        :totalRecords="rootTotal"
-        :perPage="TREE_PER_PAGE"
+        :fetch="fetchTree"
         :virtualScroll="true"
         :itemSize="40"
         :tree="true"
         idKey="id"
         childCountKey="childCount"
         :rowKey="rowKey"
-        v-model:expandedIds="expandedIds"
         selectionMode="multiple"
         selectionStrategy="cascading"
-        v-model:selectedIds="selectedIds"
-        @fetchRequest="onFetchRequest"
-        style="height: 480px; display: block"
+        @selectionChange="onSelectionChange"
       />
-      <small v-if="selectedIds.length" class="text-body-secondary">
-        Selected {{ selectedIds.length }} item(s).
+      <small v-if="selectedRows.length" class="text-body-secondary">
+        Selected {{ selectedRows.length }} item(s).
       </small>
 
       <BsCodeSnippet :code="TREE_SOURCE" language="html" />

--- a/apps/vue-bootstrap-demo/src/views/DatatableView.vue
+++ b/apps/vue-bootstrap-demo/src/views/DatatableView.vue
@@ -101,6 +101,101 @@ async function onFetchRequest(detail: TreeFetchRequestDetail) {
 
 const rowKey = (row: unknown) => String((row as TreeItem).id);
 
+// ─── Lazy windowed-fetch demo ────────────────────────────────────────────
+// A large synthetic dataset with simulated latency so the windowing is
+// visible: only the pages near the viewport are fetched, with placeholder
+// rows holding the scroll position until each window arrives. The Vue wrapper
+// is a thin passthrough, so the consumer orchestrates: seed page 1 into
+// `data`, bridge `@fetchRequest` (parentId null = a flat window), and call
+// `invalidateData()` on the ref to drop the cache.
+
+interface WindowedArtist { id: number; name: string; genre: string; founded: number; }
+
+const WINDOWED_TOTAL = 5000;
+const WINDOWED_PER_PAGE = 25;
+const GENRES = ['Alternative', 'Electronic', 'Psychedelic', 'Progressive', 'Jazz', 'Hip-Hop'];
+
+const WINDOWED_COLUMNS: DatatableColumnDef[] = [
+  { name: 'name',    label: 'Name',    cellRenderer: (row) => (row as WindowedArtist)?.name ?? '' },
+  { name: 'genre',   label: 'Genre',   cellRenderer: (row) => (row as WindowedArtist)?.genre ?? '' },
+  { name: 'founded', label: 'Founded', cellRenderer: (row) => String((row as WindowedArtist)?.founded ?? '') },
+];
+
+function makeWindowedRow(id: number): WindowedArtist {
+  return { id, name: `Artist #${id}`, genre: GENRES[id % GENRES.length], founded: 1960 + (id % 60) };
+}
+
+async function fetchWindowedPage(page: number, perPage: number): Promise<PagedResult<WindowedArtist>> {
+  await new Promise((resolve) => setTimeout(resolve, 400)); // simulated server latency
+  const start = (page - 1) * perPage;
+  const items = Array.from(
+    { length: Math.max(0, Math.min(perPage, WINDOWED_TOTAL - start)) },
+    (_, i) => makeWindowedRow(start + i + 1),
+  );
+  return { items, totalCount: WINDOWED_TOTAL, page, pageSize: perPage };
+}
+
+const windowedPage1 = ref<WindowedArtist[]>([]);
+const windowedTotal = ref(0);
+const fetchedPages = ref<number[]>([]);
+const windowedRef = ref<InstanceType<typeof BsDatatable> | null>(null);
+const windowedTotalPages = Math.ceil(WINDOWED_TOTAL / WINDOWED_PER_PAGE);
+
+async function loadWindowedPage1() {
+  fetchedPages.value = [1];
+  const result = await fetchWindowedPage(1, WINDOWED_PER_PAGE);
+  windowedPage1.value = result.items;
+  windowedTotal.value = result.totalCount;
+}
+
+onMounted(loadWindowedPage1);
+
+// Flat window fetch-request (parentId null, page >= 2). Key setFetchResponse
+// on the REQUESTED page so a normalising server can't deadlock the window.
+async function onWindowedFetchRequest(detail: TreeFetchRequestDetail) {
+  if (detail.parentId != null || detail.page <= 1) return;
+  if (!fetchedPages.value.includes(detail.page)) {
+    fetchedPages.value = [...fetchedPages.value, detail.page].sort((a, b) => a - b);
+  }
+  const result = await fetchWindowedPage(detail.page, detail.perPage);
+  windowedRef.value?.setFetchResponse(null, {
+    data: result.items,
+    totalRecords: result.totalCount,
+    page: detail.page,
+    perPage: result.pageSize,
+  });
+}
+
+function refreshWindowed() {
+  windowedRef.value?.invalidateData(); // drop the cached pages…
+  void loadWindowedPage1();             // …and re-seed page 1
+}
+
+const WINDOWED_SOURCE = `<!-- Flat virtual + windowed fetch. The wrapper is a passthrough, so the
+     consumer seeds page 1, bridges the flat fetch-request, and invalidates. -->
+<BsDatatable
+  ref="windowedRef"
+  :columns="WINDOWED_COLUMNS"
+  :data="windowedPage1"
+  :totalRecords="windowedTotal"
+  :virtualScroll="true"
+  :itemSize="40"
+  :perPage="25"
+  :rowKey="rowKey"
+  @fetchRequest="onWindowedFetchRequest"
+/>
+
+// In <script setup>: parentId === null is a flat window (page >= 2). Key
+// setFetchResponse on the REQUESTED page (detail.page), not the server-echoed
+// page, so a normalising server can't deadlock the window.
+async function onWindowedFetchRequest(detail) {
+  if (detail.parentId != null || detail.page <= 1) return;
+  const r = await fetchPage(detail.page, detail.perPage);
+  windowedRef.value?.setFetchResponse(null, {
+    data: r.items, totalRecords: r.totalCount, page: detail.page, perPage: r.pageSize,
+  });
+}`;
+
 const TREE_SOURCE = `<!-- Tree mode: virtual scroll + lazy children + cascading selection. -->
 <BsDatatable
   ref="tableRef"
@@ -128,6 +223,46 @@ const TREE_SOURCE = `<!-- Tree mode: virtual scroll + lazy children + cascading 
       <h2>Simple in-memory table</h2>
       <BsDatatable :columns="COLUMNS" :data="ARTISTS" />
       <BsCodeSnippet :code="SIMPLE_SOURCE" language="html" />
+    </section>
+
+    <section>
+      <h2>Virtual scrolling &mdash; lazy windowed fetch</h2>
+      <p>
+        With <code>virtualScroll</code> + a server-paged source the table
+        fetches only the pages whose rows are in (or near) the viewport.
+        Scroll through this {{ WINDOWED_TOTAL }}-row list and watch the fetch
+        log: it never drains all {{ windowedTotalPages }} pages up front
+        &mdash; placeholder rows hold the scroll position until each window
+        arrives. The Vue wrapper is a thin passthrough, so the consumer seeds
+        page 1, bridges <code>@fetchRequest</code> for flat windows
+        (<code>parentId === null</code>), and calls <code>invalidateData()</code>
+        on the ref to drop the cache.
+      </p>
+
+      <p class="text-body-secondary">
+        <small>
+          Pages fetched: <code>{{ fetchedPages.join(', ') || '—' }}</code>
+          ({{ fetchedPages.length }} of {{ windowedTotalPages }})
+        </small>
+        <button type="button" class="btn btn-sm btn-outline-secondary ms-2" @click="refreshWindowed">
+          Refresh (invalidateData)
+        </button>
+      </p>
+
+      <BsDatatable
+        ref="windowedRef"
+        class="windowed-table"
+        :columns="WINDOWED_COLUMNS"
+        :data="windowedPage1"
+        :totalRecords="windowedTotal"
+        :virtualScroll="true"
+        :itemSize="40"
+        :perPage="WINDOWED_PER_PAGE"
+        :rowKey="rowKey"
+        @fetchRequest="onWindowedFetchRequest"
+      />
+
+      <BsCodeSnippet :code="WINDOWED_SOURCE" language="html" />
     </section>
 
     <section>
@@ -165,3 +300,11 @@ const TREE_SOURCE = `<!-- Tree mode: virtual scroll + lazy children + cascading 
     </section>
   </div>
 </template>
+
+<style scoped>
+/* Bounded viewport so the windowed-fetch datatable demo actually scrolls. */
+.windowed-table {
+  display: block;
+  height: 360px;
+}
+</style>

--- a/apps/vue-bootstrap-demo/src/views/DatatableView.vue
+++ b/apps/vue-bootstrap-demo/src/views/DatatableView.vue
@@ -55,7 +55,10 @@ const ORDER_COLUMNS: DatatableColumnDef[] = [
   { name: 'id',        label: 'Order',  cellRenderer: (r) => `#${(r as Order)?.id}` },
   { name: 'total',     label: 'Total',  cellRenderer: (r) => `€${((r as Order)?.total ?? 0).toFixed(2)}` },
   { name: 'status',    label: 'Status', cellRenderer: (r) => (r as Order)?.status ?? '' },
-  { name: 'orderDate', label: 'Date',   cellRenderer: (r) => new Date((r as Order)?.orderDate).toLocaleDateString() },
+  { name: 'orderDate', label: 'Date',   cellRenderer: (r) => {
+    const d = (r as Order)?.orderDate;
+    return d ? new Date(d).toLocaleDateString() : '';
+  } },
 ];
 
 const fetchedPages = ref<number[]>([]);

--- a/apps/vue-bootstrap-demo/src/views/DatatableView.vue
+++ b/apps/vue-bootstrap-demo/src/views/DatatableView.vue
@@ -69,28 +69,36 @@ async function fetchTreeItems(parentId: number | null, page = 1, perPage = 100):
   return r.json();
 }
 
+// The WC's perPage must equal the fetch perPage, or its root-page math
+// misaligns with the loaded rows. One constant drives both.
+const TREE_PER_PAGE = 100;
+
 const roots = ref<TreeItem[]>([]);
+const rootTotal = ref(0);
 const expandedIds = ref<Set<unknown>>(new Set());
 const selectedIds = ref<string[]>([]);
 const tableRef = ref<InstanceType<typeof BsDatatable> | null>(null);
 
 onMounted(async () => {
   try {
-    const result = await fetchTreeItems(null);
+    const result = await fetchTreeItems(null, 1, TREE_PER_PAGE);
     roots.value = result.items;
+    rootTotal.value = result.totalCount; // enables lazy root windowing past page 1
   } catch {
     // Best-effort demo — surfaces the empty table if the api isn't up.
   }
 });
 
+// Fires for tree children (non-null parentId) AND lazy root windows (parentId
+// null, page ≥ 2). Page 1 is seeded by onMounted, so only pages ≥ 2 reach here
+// for the root level. Key on the REQUESTED page (detail.page).
 async function onFetchRequest(detail: TreeFetchRequestDetail) {
-  if (detail.parentId == null) return; // root fetch handled by onMounted above
   try {
-    const result = await fetchTreeItems(detail.parentId as number, detail.page, detail.perPage);
+    const result = await fetchTreeItems(detail.parentId as number | null, detail.page, detail.perPage);
     tableRef.value?.setFetchResponse(detail.parentId, {
       data: result.items,
       totalRecords: result.totalCount,
-      page: result.page,
+      page: detail.page,
       perPage: result.pageSize,
     });
   } catch (e) {
@@ -279,6 +287,8 @@ const TREE_SOURCE = `<!-- Tree mode: virtual scroll + lazy children + cascading 
         ref="tableRef"
         :columns="TREE_COLUMNS"
         :data="roots"
+        :totalRecords="rootTotal"
+        :perPage="TREE_PER_PAGE"
         :virtualScroll="true"
         :itemSize="40"
         :tree="true"

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -1,0 +1,177 @@
+# Product Requirements Document: Lazy windowed fetch for flat `[fetch]` + `[virtualScroll]`
+
+**Issue**: #385
+**Title**: feat(datatable): lazy windowed fetch for `[fetch]` + `[virtualScroll]` (flat mode eager-loads all pages)
+**Status**: Draft
+**Created**: 2026-06-07
+**Last Updated**: 2026-06-07
+
+---
+
+## Summary
+
+Flat (non-tree) datatables that combine server-side `[fetch]` with `[virtualScroll]` currently eager-load the entire result set (`runVirtualFetchAll` drains every page into memory before virtualizing) — a behavior regression versus the removed `virtual-datatable`. This work makes that path **lazy and windowed**: fetch page 1 for the total, then fetch additional pages only as their rows scroll into view, rendering placeholders for unloaded ranges and sizing the scrollbar from `totalRecords`. The chosen approach **reuses the existing tree lazy-fetch machinery** (`mp-datatable-fetch-request` / `setFetchResponse` / placeholder rows) keyed by **page** instead of `parentId`, with the window size equal to `settings.perPage`. The public `[fetch]` contract is **unchanged** — consumers (notably MintPlayer.Spark #178, which this unblocks) need zero changes. The load-bearing trade-off: reusing page/perPage keeps the contract stable but means request count scales with `1/perPage`; consumers tune it by raising `perPage`.
+
+---
+
+## Overview
+
+Add a lazy, scroll-driven windowed-fetch path for **flat virtual + external `[fetch]`** datatables, mirroring the tree-mode lazy-children path. The web component owns virtualization, placeholder rendering, viewport→page detection, and the page cache; the Angular wrapper bridges the WC's fetch-request event to the consumer's existing `[fetch]` callback and seeds page 1.
+
+---
+
+## Goals & Objectives
+
+### Primary Goals
+- Replace eager `runVirtualFetchAll` with on-demand, viewport-driven page fetching for flat virtual mode.
+- Render placeholders for unloaded ranges; size the scroll region from `totalRecords`.
+- Invalidate + refetch on sort/settings change.
+- Keep the public `[fetch]` contract and all existing consumers unchanged.
+
+### Success Metrics
+- Opening a virtual list of N rows issues `O(visible/perPage)` fetches, not `⌈N/perPage⌉`.
+- No full-dataset materialization in memory for flat virtual lists.
+- Tree mode and non-virtual flat fetch behavior unchanged (regression-guarded by tests).
+
+---
+
+## Chosen Design
+
+**Reuse the tree lazy-fetch machinery for flat virtual mode, keyed by page; the public `[fetch]` contract is UNCHANGED.** (Design fan-out **not run** — the public interface is settled in the issue handoff; the remaining work is internal to a single component, `mp-datatable.ts`, constrained by the existing `setFetchResponse`/`mp-datatable-fetch-request` contract, with no plausible second *public* shape. The internal cache-mechanics decisions below were resolved by grilling instead.)
+
+### Public interface (unchanged)
+```ts
+// libs/mintplayer-ng-bootstrap/datatable/src/datatable-fetch.ts — UNCHANGED
+type BsDatatableFetch<T> =
+  (req: PaginationRequest /* { page, perPage, sortColumns } */) => Promise<PaginationResponse<T>>;
+```
+In flat virtual mode the datatable calls this once per *needed page* instead of draining all pages.
+
+### Internal mechanics (resolved by grilling)
+- **Window size = `settings.perPage`.** The WC's `_perPage` drives both the fetch request and the index→page math, so the WC page index equals the fetch page identity:
+  ```
+  page   = Math.floor(i / perPage) + 1
+  offset = i % perPage
+  ```
+- **Page-1 source mirrors tree mode.** The wrapper sets `el.data = page-1 rows` + `el.totalRecords` (via `runVirtualFetchFirst`); pages ≥2 arrive through `setFetchResponse(null, resp)` into a new page-keyed cache. Analogous to tree (roots = `_data`, children = `_childCache`).
+  ```ts
+  // getFlatList flat-window branch, index i:
+  page = Math.floor(i / perPage) + 1;
+  const row = page === 1 ? _data[i] : _pageCache.get(page)?.[i % perPage];
+  // → real row, or placeholder { row: undefined, parentId: null, page, isPlaceholder: true }
+
+  // setFetchResponse(null, resp), flat-window (!_tree) branch:
+  _pendingPageFetches.delete(resp.page);
+  _pageCache.set(resp.page, [...resp.data]);
+  ```
+- **`parentId: null` disambiguation.** The existing `setFetchResponse(null, …)` early-returns with tree-root semantics, and `requestChildrenFetch` skips `_pendingFetches` for null parents. Flat windows therefore use **separate page-keyed storage** (`_pageCache: Map<number, rows[]>`, `_pendingPageFetches: Set<number>`) branched on `!this._tree`. Tree and flat are mutually exclusive, so branching on `_tree` is safe.
+- **`invalidateData()`** — new public WC method clearing `_pageCache` + `_pendingPageFetches`; the wrapper calls it on sort/settings change before refetching page 1 (mirrors `invalidateChildren()`).
+- **Cache eviction** — none in v1; keep all loaded pages. Add LRU only if a real memory problem surfaces.
+
+### Usage example (consumer — no change required)
+```ts
+// Consumer code is identical to today's [fetch] + [virtualScroll]:
+fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
+  this.api.getUsers(req.page, req.perPage, req.sortColumns);
+```
+```html
+<bs-datatable [fetch]="fetchUsers" [virtualScroll]="true" [(settings)]="settings">
+  ...
+</bs-datatable>
+<!-- Now fetches page-by-page as the user scrolls, instead of draining all pages on open. -->
+```
+
+### What complexity this hides
+- Viewport→page mapping, placeholder reservation, in-flight dedup, and the page cache live entirely in the WC.
+- The wrapper only seeds page 1, bridges the fetch-request event to `[fetch]`, and invalidates on sort.
+- Consumers see no new API and no behavioral surprise beyond "it's lazy now".
+
+### Designs considered (and rejected)
+- **New `{skip,take}` callback (`BsDatatableFetchWindow`)** — breaks every consumer's `[fetch]`; page/perPage windowing reuses the existing contract. *(The issue body floated `{skip,take}` as one option; rejected to preserve the contract.)*
+- **Keep `runVirtualFetchAll`** — that *is* the bug.
+- **Infinite-scroll append** — no random-access jump, can't size the scrollbar to the true total, degrades to eager on fast scroll.
+- **Per-row fetch** — too chatty; page granularity matches server paging.
+- **Wrapper-only fix** — the wrapper can't render placeholders or know the viewport; virtualization lives in the WC.
+- **Dedicated virtual window size (≠ perPage)** — fewer requests for tiny `perPage`, but the WC page index would diverge from the fetch page, needing a second divisor and a cache key disjoint from the contract. Rejected for complexity.
+- **Single `_pageCache` source (page 1 also via `setFetchResponse`)** — one source of truth, but diverges from how tree mode + the `el.data` effect already work and forces the wrapper to suppress its `el.data` sync. Rejected; mirroring tree is lower-risk.
+
+---
+
+## Out of Scope
+
+- **Tree mode** — already lazy; only regression-guarded here. *Rationale: the lazy-children path already does on-demand fetch; this issue is exclusively the flat path.*
+- **React / Vue datatable ports of this behavior** — *Rationale: separate follow-up; this issue ships the WC + Angular wrapper, which is what unblocks Spark #178.*
+- **Changing the public `[fetch]` signature** — *Rationale: a contract change would break every consumer; the whole design reuses page/perPage to avoid it.*
+- **Non-virtual flat fetch** — *Rationale: already correct (single-page `runFetch`); untouched.*
+- **Cache eviction / LRU** — *Rationale: v1 keeps all loaded pages; LRU is deferred until a real memory problem is observed (see Open Questions).*
+
+---
+
+## Functional Requirements
+
+### Must Have (P0)
+- [ ] **FR-1**: Flat virtual + external `[fetch]` fetches page 1 on open (one fetch), not all pages.
+- [ ] **FR-2**: Pages ≥2 are fetched only when their rows enter the viewport (+ buffer), via `mp-datatable-fetch-request { parentId: null, page, perPage, sortColumns }`.
+- [ ] **FR-3**: Unloaded ranges render placeholder rows (`isPlaceholder: true`), replaced by real rows on response.
+- [ ] **FR-4**: The virtual scroll region / spacers are sized from `totalRecords`, not `_data.length`.
+- [ ] **FR-5**: In-flight pages are deduped via `_pendingPageFetches` (no duplicate request for a page already loading).
+- [ ] **FR-6**: `setFetchResponse(null, resp)` populates the page cache (keyed by `resp.page`) and clears the corresponding placeholders.
+- [ ] **FR-7**: `invalidateData()` clears the page cache + pending set; the wrapper calls it on sort/settings change, then refetches page 1.
+- [ ] **FR-8**: The public `[fetch]` contract is unchanged; existing consumers compile and behave identically.
+- [ ] **FR-9**: Tree mode and non-virtual flat fetch behavior are unchanged.
+
+### Should Have (P1)
+- [ ] **FR-10**: `aria-rowcount` reflects `totalRecords` (full virtual list) in flat-windowed mode.
+- [ ] **FR-11**: A "Virtual scroll + server-side fetch" demo example on the ng datatable demo page (demo before snippet).
+
+---
+
+## Timeline & Milestones
+
+### Milestone 1: WC flat-window data model
+- [ ] Add `_pageCache` + `_pendingPageFetches` fields and `page?: number` on the placeholder row shape.
+- [ ] `isFlatWindowed()` helper; rewrite the flat `getFlatList` branch to build the sparse length-`totalRecords` list.
+- [ ] `getEffectiveData()` + `aria-rowcount` use the sparse length in flat-windowed mode.
+
+### Milestone 2: WC on-demand fetch + cache writes
+- [ ] Call `maybeFetchPlaceholdersInViewport()` for flat-windowed mode; handle `parentId == null` page placeholders.
+- [ ] `requestPageFetch(page)`; extend `setFetchResponse` for the `!_tree` page-cache branch.
+- [ ] `invalidateData()`.
+
+### Milestone 3: Angular wrapper
+- [ ] Replace `runVirtualFetchAll` with `runVirtualFetchFirst` (page-1 only + totalRecords).
+- [ ] `el.invalidateData()` on sort/settings change before refetch.
+- [ ] Extend `onFetchRequest` for `parentId == null` flat windows.
+
+### Milestone 4: Tests + demo
+- [ ] WC unit tests (placeholder render, window-request dedup, cache populate, invalidation, spacer sizing).
+- [ ] Wrapper unit tests (page-1-first, `parentId == null` bridge, invalidation).
+- [ ] Virtual + fetch demo example.
+
+### Milestone 5: Publish + cross-repo handoff
+- [ ] Build all libs + run tests; bump + publish `@mintplayer/ng-bootstrap`.
+- [ ] Notify so MintPlayer.Spark #178 bumps ng-bootstrap and resumes.
+
+---
+
+## Open Questions
+
+> Recorded as v1 assumptions (resolved by grilling); revisit only if reality contradicts them.
+
+- [ ] **Cache eviction for very large scrolls** — *Assumption: keep all loaded pages in v1; add LRU only if memory becomes a measured problem.*
+- [ ] **Window page size** — *Assumption: reuse `settings.perPage`; consumers needing fewer requests raise `perPage`. No dedicated virtual window size in v1.*
+
+---
+
+## Technical Notes (Issue-Specific)
+
+- The WC distinguishes flat-window mode by `_virtualScroll && !_tree && isExternallyPaged()` (`isExternallyPaged()` = `_totalRecords > _data.length`). When `totalRecords ≤ perPage` it falls back to the existing trivial flat mapping (no placeholders).
+- `el.autoSort` is already `false` in fetch mode (wrapper `:286`), so the flat-window branch does **not** client-sort — server-side sort owns ordering. Sort changes go through `invalidateData()` + page-1 refetch.
+- The `mp-datatable-fetch-request` event already carries `{ parentId, page, perPage, sortColumns }`; flat windows set `parentId: null` + a real `page`. The wrapper's `onFetchRequest` already maps `parentId ?? undefined` into the `[fetch]` request, so the bridge needs only the page-cache forwarding branch.
+
+---
+
+## Related
+- Issue #385
+- Blocks: MintPlayer.Spark #178 (`docs/issue_178_PRD.md` in the Spark repo, Status: Blocked by ngbootstrap#385)
+- See CLAUDE.md for: WC authoring (`observedAttributes` static getter, codegen-wc after SCSS edits), hand-written framework wrappers, `CUSTOM_ELEMENTS_SCHEMA` bridging.

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -146,11 +146,13 @@ fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
 ### Milestone 4: Tests + demo
 - [x] WC unit tests (placeholder render, window-request dedup, cache populate, invalidation, aria-rowcount/spacer sizing, single-page fallback) — `mp-datatable.windowed-fetch.spec.ts` (7 tests).
 - [x] Wrapper unit tests (page-1-first, `parentId == null` bridge, requested-page-key lock, invalidation) — `datatable.windowed-fetch.spec.ts` (4 tests).
-- [ ] Virtual + fetch demo example (→ Milestone 5, with build/publish).
+- [x] Virtual + fetch demo example — dedicated "Virtual scrolling — lazy windowed fetch" section on the ng datatable demo page (5000-row synthetic source, simulated latency, live fetch-page log, placeholder-aware rows).
 
 ### Milestone 5: Publish + cross-repo handoff
-- [ ] Build all libs + run tests; bump + publish `@mintplayer/ng-bootstrap`.
-- [ ] Notify so MintPlayer.Spark #178 bumps ng-bootstrap and resumes.
+- [x] Build all libs + run tests (WC + wrapper + demo all green).
+- [x] Bump versions: `@mintplayer/web-components` 1.6.0 → 1.7.0 (the fix), `@mintplayer/ng-bootstrap` 22.2.0 → 22.3.0, and raise ng-bootstrap's `@mintplayer/web-components` peer floor to `^1.7.0` (the new wrapper requires the new WC flat-window API).
+- [ ] Publish — automatic via `publish-master.yml` on merge to `master` (`skipDuplicate`); no manual publish.
+- [ ] Notify so MintPlayer.Spark #178 bumps ng-bootstrap and resumes (post-merge).
 
 ---
 

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -129,14 +129,14 @@ fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
 ## Timeline & Milestones
 
 ### Milestone 1: WC flat-window data model
-- [ ] Add `_pageCache` + `_pendingPageFetches` fields and `page?: number` on the placeholder row shape.
-- [ ] `isFlatWindowed()` helper; rewrite the flat `getFlatList` branch to build the sparse length-`totalRecords` list.
-- [ ] `getEffectiveData()` + `aria-rowcount` use the sparse length in flat-windowed mode.
+- [x] Add `_pageCache` + `_pendingPageFetches` fields and `page?: number` on the placeholder row shape.
+- [x] `isFlatWindowed()` helper; rewrite the flat `getFlatList` branch to build the sparse length-`totalRecords` list.
+- [x] `getEffectiveData()` + `aria-rowcount` use the sparse length in flat-windowed mode.
 
 ### Milestone 2: WC on-demand fetch + cache writes
-- [ ] Call `maybeFetchPlaceholdersInViewport()` for flat-windowed mode; handle `parentId == null` page placeholders.
-- [ ] `requestPageFetch(page)`; extend `setFetchResponse` for the `!_tree` page-cache branch.
-- [ ] `invalidateData()`.
+- [x] Call the viewport scan for flat-windowed mode (`maybeFetchPagesInViewport()`, sibling of the tree path); handle `parentId == null` page placeholders.
+- [x] `requestPageFetch(page)`; extend `setFetchResponse` for the `!_tree` page-cache branch.
+- [x] `invalidateData()`.
 
 ### Milestone 3: Angular wrapper
 - [ ] Replace `runVirtualFetchAll` with `runVirtualFetchFirst` (page-1 only + totalRecords).

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -144,9 +144,9 @@ fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
 - [x] Extend `onFetchRequest` for `parentId == null` flat windows (key the page cache on the requested `detail.page`, not `response.page`, so a server that normalises page numbers can't deadlock the window).
 
 ### Milestone 4: Tests + demo
-- [ ] WC unit tests (placeholder render, window-request dedup, cache populate, invalidation, spacer sizing).
-- [ ] Wrapper unit tests (page-1-first, `parentId == null` bridge, invalidation).
-- [ ] Virtual + fetch demo example.
+- [x] WC unit tests (placeholder render, window-request dedup, cache populate, invalidation, aria-rowcount/spacer sizing, single-page fallback) — `mp-datatable.windowed-fetch.spec.ts` (7 tests).
+- [x] Wrapper unit tests (page-1-first, `parentId == null` bridge, requested-page-key lock, invalidation) — `datatable.windowed-fetch.spec.ts` (4 tests).
+- [ ] Virtual + fetch demo example (→ Milestone 5, with build/publish).
 
 ### Milestone 5: Publish + cross-repo handoff
 - [ ] Build all libs + run tests; bump + publish `@mintplayer/ng-bootstrap`.

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -2,7 +2,7 @@
 
 **Issue**: #385
 **Title**: feat(datatable): lazy windowed fetch for `[fetch]` + `[virtualScroll]` (flat mode eager-loads all pages)
-**Status**: Draft
+**Status**: Complete
 **Created**: 2026-06-07
 **Last Updated**: 2026-06-07
 
@@ -10,7 +10,13 @@
 
 ## Summary
 
-Flat (non-tree) datatables that combine server-side `[fetch]` with `[virtualScroll]` currently eager-load the entire result set (`runVirtualFetchAll` drains every page into memory before virtualizing) — a behavior regression versus the removed `virtual-datatable`. This work makes that path **lazy and windowed**: fetch page 1 for the total, then fetch additional pages only as their rows scroll into view, rendering placeholders for unloaded ranges and sizing the scrollbar from `totalRecords`. The chosen approach **reuses the existing tree lazy-fetch machinery** (`mp-datatable-fetch-request` / `setFetchResponse` / placeholder rows) keyed by **page** instead of `parentId`, with the window size equal to `settings.perPage`. The public `[fetch]` contract is **unchanged** — consumers (notably MintPlayer.Spark #178, which this unblocks) need zero changes. The load-bearing trade-off: reusing page/perPage keeps the contract stable but means request count scales with `1/perPage`; consumers tune it by raising `perPage`.
+**As built.** Flat (non-tree) datatables that combine server-side `[fetch]` with `[virtualScroll]` previously eager-loaded the entire result set (`runVirtualFetchAll` drained every page into memory before virtualizing) — a behavior regression versus the removed `virtual-datatable`. That path is now **lazy and windowed**: the wrapper fetches page 1 for the total (`runVirtualFetchFirst`), then the WC fetches additional pages only as their rows scroll into view, rendering placeholders for unloaded ranges and sizing the scroll region from `totalRecords`. The implementation **reuses the tree lazy-fetch machinery** (`mp-datatable-fetch-request` / `setFetchResponse` / placeholder rows) keyed by **page** instead of `parentId`: a dedicated `_pageCache`/`_pendingPageFetches` pair plus a sibling viewport scanner `maybeFetchPagesInViewport()` (the tree `maybeFetchPlaceholdersInViewport` stays parentId-keyed), all disambiguated by `!this._tree`. Window size = `settings.perPage`, so the WC page index equals the fetch page identity. The public `[fetch]` contract is **unchanged** — consumers (notably MintPlayer.Spark #178, which this unblocks) need zero changes.
+
+**Load-bearing decisions:** (1) page/perPage windowing over a new `{skip,take}` callback — keeps the contract stable; request count scales with `1/perPage`, tuned by raising `perPage`. (2) Page-keyed storage branched on `!this._tree` rather than reusing the `parentId: null` tree-root path, which has its own early-return semantics. (3) `onFetchRequest` keys `setFetchResponse` on the **requested** `detail.page`, not `response.page`, so a server that normalises page numbers can't deadlock the window (guarded by a test). (4) Page-1 mirrors tree roots in `_data`; pages ≥2 in `_pageCache`.
+
+**Restoration parity:** this closes the only capability the #306 `virtual-datatable` merge dropped — the old `VirtualDatatableDataSource`'s lazy `(skip,take)` windowing with placeholder fill, multi-page viewport fetch, and `reset()`-immediate-refetch. All of those are restored (`reset()` ↔ `invalidateData()` + the `updated()`→`refreshVirtualRange()`→rescan that re-fetches the visible window with no scroll; proven by test). Everything else the old `bs-virtual-datatable` exposed — `isResponsive`, `itemSize`, sorting, row template, ARIA rowcount — was already present in the merged datatable.
+
+**Tests:** 8 WC tests (`mp-datatable.windowed-fetch.spec.ts`) + 4 wrapper tests (`datatable.windowed-fetch.spec.ts`); full suites green (758 WC / 519 wrapper). Reviewed via the DCG gate — verdict passes-with-fixes; the one should-fix (plan doc drift) is resolved, residual items are benign nits.
 
 ---
 
@@ -110,19 +116,19 @@ fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
 ## Functional Requirements
 
 ### Must Have (P0)
-- [ ] **FR-1**: Flat virtual + external `[fetch]` fetches page 1 on open (one fetch), not all pages.
-- [ ] **FR-2**: Pages ≥2 are fetched only when their rows enter the viewport (+ buffer), via `mp-datatable-fetch-request { parentId: null, page, perPage, sortColumns }`.
-- [ ] **FR-3**: Unloaded ranges render placeholder rows (`isPlaceholder: true`), replaced by real rows on response.
-- [ ] **FR-4**: The virtual scroll region / spacers are sized from `totalRecords`, not `_data.length`.
-- [ ] **FR-5**: In-flight pages are deduped via `_pendingPageFetches` (no duplicate request for a page already loading).
-- [ ] **FR-6**: `setFetchResponse(null, resp)` populates the page cache (keyed by `resp.page`) and clears the corresponding placeholders.
-- [ ] **FR-7**: `invalidateData()` clears the page cache + pending set; the wrapper calls it on sort/settings change, then refetches page 1.
-- [ ] **FR-8**: The public `[fetch]` contract is unchanged; existing consumers compile and behave identically.
-- [ ] **FR-9**: Tree mode and non-virtual flat fetch behavior are unchanged.
+- [x] **FR-1**: Flat virtual + external `[fetch]` fetches page 1 on open (one fetch), not all pages.
+- [x] **FR-2**: Pages ≥2 are fetched only when their rows enter the viewport (+ buffer), via `mp-datatable-fetch-request { parentId: null, page, perPage, sortColumns }`.
+- [x] **FR-3**: Unloaded ranges render placeholder rows (`isPlaceholder: true`), replaced by real rows on response.
+- [x] **FR-4**: The virtual scroll region / spacers are sized from `totalRecords`, not `_data.length`.
+- [x] **FR-5**: In-flight pages are deduped via `_pendingPageFetches` (no duplicate request for a page already loading).
+- [x] **FR-6**: `setFetchResponse(null, resp)` populates the page cache (keyed by `resp.page`) and clears the corresponding placeholders.
+- [x] **FR-7**: `invalidateData()` clears the page cache + pending set; the wrapper calls it on sort/settings change, then refetches page 1.
+- [x] **FR-8**: The public `[fetch]` contract is unchanged; existing consumers compile and behave identically.
+- [x] **FR-9**: Tree mode and non-virtual flat fetch behavior are unchanged.
 
 ### Should Have (P1)
-- [ ] **FR-10**: `aria-rowcount` reflects `totalRecords` (full virtual list) in flat-windowed mode.
-- [ ] **FR-11**: A "Virtual scroll + server-side fetch" demo example on the ng datatable demo page (demo before snippet).
+- [x] **FR-10**: `aria-rowcount` reflects `totalRecords` (full virtual list) in flat-windowed mode.
+- [x] **FR-11**: A "Virtual scroll + server-side fetch" demo example on the ng datatable demo page (demo before snippet).
 
 ---
 

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -106,7 +106,7 @@ fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
 ## Out of Scope
 
 - **Tree mode** — already lazy; only regression-guarded here. *Rationale: the lazy-children path already does on-demand fetch; this issue is exclusively the flat path.*
-- **React / Vue datatable ports of this behavior** — *Rationale: separate follow-up; this issue ships the WC + Angular wrapper, which is what unblocks Spark #178.*
+- ~~**React / Vue datatable ports of this behavior**~~ — *Originally deferred; **brought into scope** mid-implementation ("no half jobs"). The WC change is framework-agnostic, so React needed no wrapper change (its `@lit/react` ref already exposes `setFetchResponse`/`invalidateData`), Vue's wrapper now exposes `invalidateData`, and both demo apps gained a lazy windowed-fetch section showing the consumer-side orchestration. See Milestones 6–8.*
 - **Changing the public `[fetch]` signature** — *Rationale: a contract change would break every consumer; the whole design reuses page/perPage to avoid it.*
 - **Non-virtual flat fetch** — *Rationale: already correct (single-page `runFetch`); untouched.*
 - **Cache eviction / LRU** — *Rationale: v1 keeps all loaded pages; LRU is deferred until a real memory problem is observed (see Open Questions).*
@@ -159,6 +159,13 @@ fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
 - [x] Bump versions: `@mintplayer/web-components` 1.6.0 → 1.7.0 (the fix), `@mintplayer/ng-bootstrap` 22.2.0 → 22.3.0, and raise ng-bootstrap's `@mintplayer/web-components` peer floor to `^1.7.0` (the new wrapper requires the new WC flat-window API).
 - [ ] Publish — automatic via `publish-master.yml` on merge to `master` (`skipDuplicate`); no manual publish.
 - [ ] Notify so MintPlayer.Spark #178 bumps ng-bootstrap and resumes (post-merge).
+
+### Milestone 6: React/Vue wrapper parity (added mid-implementation)
+- [x] Vue `BsDatatable` exposes `invalidateData()`; bump `@mintplayer/vue-bootstrap` 3.5.0 → 3.6.0 + peer floor `^1.7.0`.
+- [x] React needs no wrapper change — `@lit/react`'s ref is the `MpDatatable` instance, so `setFetchResponse`/`invalidateData` are already callable and `TreeFetchRequestDetail` already covers the flat `{ parentId: null, page }` shape.
+
+### Milestone 7–8: React + Vue demos
+- [x] "Virtual scrolling — lazy windowed fetch" section in both demo apps: 5000-row synthetic source, simulated latency, live fetch-page log, `invalidateData()` Refresh button, consumer-side flat-window orchestration (seed page 1, bridge the flat `fetch-request`, key on the requested page).
 
 ---
 

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -8,9 +8,18 @@
 
 ---
 
+> ⚠️ **Superseded by #386 (same branch).** This PRD documents #385 *as it was
+> built* — a consumer/wrapper-driven design using the `mp-datatable-fetch-request`
+> event, `setFetchResponse()`, `invalidateData()`, and a consumer-set
+> `totalRecords`. #386 replaced that **driving mechanism** with a WC-owned `fetch`
+> callback (those APIs are removed; `totalRecords` is derived from the response).
+> The **windowing internals** described here (placeholders, `_pageCache`, sparse
+> `getFlatList`, tree-root windowing) still stand. For the current contract see
+> **`docs/issue_386_PRD.md`**. The mechanics below are retained as the #385 record.
+
 ## Summary
 
-**As built.** Flat (non-tree) datatables that combine server-side `[fetch]` with `[virtualScroll]` previously eager-loaded the entire result set (`runVirtualFetchAll` drained every page into memory before virtualizing) — a behavior regression versus the removed `virtual-datatable`. That path is now **lazy and windowed**: the wrapper fetches page 1 for the total (`runVirtualFetchFirst`), then the WC fetches additional pages only as their rows scroll into view, rendering placeholders for unloaded ranges and sizing the scroll region from `totalRecords`. The implementation **reuses the tree lazy-fetch machinery** (`mp-datatable-fetch-request` / `setFetchResponse` / placeholder rows) keyed by **page** instead of `parentId`: a dedicated `_pageCache`/`_pendingPageFetches` pair plus a sibling viewport scanner `maybeFetchPagesInViewport()` (the tree `maybeFetchPlaceholdersInViewport` stays parentId-keyed), all disambiguated by `!this._tree`. Window size = `settings.perPage`, so the WC page index equals the fetch page identity. The public `[fetch]` contract is **unchanged** — consumers (notably MintPlayer.Spark #178, which this unblocks) need zero changes.
+**As built (pre-#386).** Flat (non-tree) datatables that combine server-side `[fetch]` with `[virtualScroll]` previously eager-loaded the entire result set (`runVirtualFetchAll` drained every page into memory before virtualizing) — a behavior regression versus the removed `virtual-datatable`. That path is now **lazy and windowed**: the wrapper fetches page 1 for the total (`runVirtualFetchFirst`), then the WC fetches additional pages only as their rows scroll into view, rendering placeholders for unloaded ranges and sizing the scroll region from `totalRecords`. The implementation **reuses the tree lazy-fetch machinery** (`mp-datatable-fetch-request` / `setFetchResponse` / placeholder rows) keyed by **page** instead of `parentId`: a dedicated `_pageCache`/`_pendingPageFetches` pair plus a sibling viewport scanner `maybeFetchPagesInViewport()` (the tree `maybeFetchPlaceholdersInViewport` stays parentId-keyed), all disambiguated by `!this._tree`. Window size = `settings.perPage`, so the WC page index equals the fetch page identity. The public `[fetch]` contract is **unchanged** — consumers (notably MintPlayer.Spark #178, which this unblocks) need zero changes.
 
 **Load-bearing decisions:** (1) page/perPage windowing over a new `{skip,take}` callback — keeps the contract stable; request count scales with `1/perPage`, tuned by raising `perPage`. (2) Page-keyed storage branched on `!this._tree` rather than reusing the `parentId: null` tree-root path, which has its own early-return semantics. (3) `onFetchRequest` keys `setFetchResponse` on the **requested** `detail.page`, not `response.page`, so a server that normalises page numbers can't deadlock the window (guarded by a test). (4) Page-1 mirrors tree roots in `_data`; pages ≥2 in `_pageCache`.
 

--- a/docs/issue_385_PRD.md
+++ b/docs/issue_385_PRD.md
@@ -139,9 +139,9 @@ fetchUsers = (req: PaginationRequest): Promise<PaginationResponse<User>> =>
 - [x] `invalidateData()`.
 
 ### Milestone 3: Angular wrapper
-- [ ] Replace `runVirtualFetchAll` with `runVirtualFetchFirst` (page-1 only + totalRecords).
-- [ ] `el.invalidateData()` on sort/settings change before refetch.
-- [ ] Extend `onFetchRequest` for `parentId == null` flat windows.
+- [x] Replace `runVirtualFetchAll` with `runVirtualFetchFirst` (page-1 only + totalRecords).
+- [x] `el.invalidateData()` on sort/settings change before refetch.
+- [x] Extend `onFetchRequest` for `parentId == null` flat windows (key the page cache on the requested `detail.page`, not `response.page`, so a server that normalises page numbers can't deadlock the window).
 
 ### Milestone 4: Tests + demo
 - [ ] WC unit tests (placeholder render, window-request dedup, cache populate, invalidation, spacer sizing).

--- a/docs/issue_385_plan.md
+++ b/docs/issue_385_plan.md
@@ -1,0 +1,154 @@
+# Development Plan: Issue #385
+
+**Issue**: #385
+**Title**: feat(datatable): lazy windowed fetch for `[fetch]` + `[virtualScroll]` (flat mode eager-loads all pages)
+**Type**: Feature / Enhancement
+**Priority**: High (blocks MintPlayer.Spark #178)
+
+## Executive Summary
+
+In ng-bootstrap 22 the flat (non-tree) datatable, when combined with server-side `[fetch]` and `[virtualScroll]`, eagerly drains the **entire** result set up front (`runVirtualFetchAll` loops every page in 200-row chunks into memory) and only then virtualizes the in-memory array. That defeats virtual scrolling and is a behavior regression versus the removed `virtual-datatable`'s true lazy `(skip,take)` windowing.
+
+This change makes flat virtual + `[fetch]` fetch **only the visible window (+ buffer) on demand**, rendering placeholder rows for not-yet-loaded ranges and sizing the scrollbar from `totalRecords`. It does so by reusing the existing tree lazy-fetch machinery (`mp-datatable-fetch-request` / `setFetchResponse` / placeholder rows), keyed by **page** instead of `parentId`. The public `[fetch]` contract (`(req: PaginationRequest) => Promise<PaginationResponse>`) is **unchanged** — consumers (ng-spark) need zero changes.
+
+---
+
+## Problem Statement
+
+### Current Behavior
+- Wrapper `datatable.component.ts` fetch effect (`:237-264`) routes flat + virtual to `runVirtualFetchAll` (`:411-431`), which fetches page 1, then loops pages `2..totalPages` (200-row `perPage`), accumulating all rows into `currentData` before the WC virtualizes.
+- WC `mp-datatable.ts` flat `getFlatList` branch (`:891-911`) produces a trivial mapping of `_data` with no placeholders. Lazy on-demand placeholder fetch (`maybeFetchPlaceholdersInViewport` `:586-599`, `requestChildrenFetch` `:1118-1132`, `setFetchResponse` `:1139-1145`) exists **only for tree children** (gated by `if (this._tree)` at `:579`).
+- Result: opening a virtual list of N rows triggers `⌈N/200⌉` sequential fetches and loads everything into memory before the first scroll.
+
+### Expected Behavior
+- Flat virtual + `[fetch]` fetches page 1 first (for `totalRecords` + initial rows), then fetches additional pages **only as their rows scroll into the viewport (+ buffer)**.
+- Unloaded ranges render placeholder rows; the virtual scroll region is sized from `totalRecords`, not `_data.length`.
+- Sort / settings changes invalidate the page cache and re-fetch the visible window.
+- Opening a virtual list of N rows issues `O(visible/perPage)` fetches, not `⌈N/perPage⌉`.
+
+### Impact
+- Unblocks **MintPlayer.Spark #178** (Angular 22 + ng-bootstrap 22 upgrade), which is held on this regression. ng-spark's `query-list` / `po-detail` `renderMode: 'VirtualScrolling'` queries become lazy again.
+- Benefits every ng-bootstrap consumer using flat virtual + server-side fetch.
+
+---
+
+## Technical Analysis
+
+### Files to Modify
+- `libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts` — flat-window placeholder/cache machinery (the bulk of the change).
+- `libs/mintplayer-web-components/datatable/src/types/tree.ts` — generalize the fetch-request/response docs (the `parentId: null` + `page` flat-window case); types are reused as-is, comments updated.
+- `libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts` — replace `runVirtualFetchAll` with `runVirtualFetchFirst`; extend `onFetchRequest` for `parentId == null` flat windows; call `el.invalidateData()` on sort/settings change.
+- Demo app (`apps/ng-bootstrap-demo/...` datatable demo page) — add a virtual + fetch example.
+- WC + wrapper unit test specs.
+- Version bump for `@mintplayer/ng-bootstrap` (+ `@mintplayer/web-components` if published independently).
+
+### Dependencies
+- None external. Reuses `@mintplayer/pagination` (`PaginationRequest`/`PaginationResponse`) and the existing tree fetch machinery.
+
+### Architecture Considerations
+- **Reuse over reinvention** (CLAUDE.md): the tree lazy-fetch path is the template. Flat windows are "roots without a tree" — keyed by `page` instead of `parentId`.
+- **`parentId: null` disambiguation** — the existing `setFetchResponse(null, …)` early-returns (tree-root semantics: "root-level fetches use the `data` setter directly"), and `requestChildrenFetch` skips `_pendingFetches` for null parents. Flat windows therefore use **separate page-keyed storage** (`_pageCache`, `_pendingPageFetches`) branched on `!this._tree`. Tree and flat are mutually exclusive, so branching on `_tree` is safe.
+- **Window size = `settings.perPage`** → the WC's `_perPage` drives both the fetch request and the index→page math (`page = ⌊i/perPage⌋+1`, `offset = i%perPage`), so the WC page index equals the fetch page identity. No second divisor, no cache-key divergence.
+- **Page-1 source mirrors tree mode**: wrapper sets `el.data = page-1 rows` + `el.totalRecords`; pages ≥2 flow through `setFetchResponse` into `_pageCache`. Analogous to tree (roots = `_data`, children = `_childCache`) — minimal new surface.
+- **`isExternallyPaged()`** (`_totalRecords > _data.length`) already gates external paging; the new flat-window sparse path keys off `_virtualScroll && isExternallyPaged() && !_tree`. When `totalRecords ≤ perPage` (single page) it falls back to the current trivial flat mapping.
+- See the PRD's **Chosen Design** for the settled interface + rejected alternatives.
+
+---
+
+## Implementation Plan
+
+### Phase 1: WC flat-window data model (`mp-datatable.ts`)
+1. Add fields: `private _pageCache: Map<number, unknown[]> = new Map();` and `private _pendingPageFetches: Set<number> = new Set();`.
+2. Add a `page?: number` field to the `FlatVisibleRow` placeholder shape (so the viewport scan reads the page directly).
+3. Add a helper `isFlatWindowed(): boolean` = `this._virtualScroll && !this._tree && this.isExternallyPaged()`.
+4. Rewrite the flat branch of `getFlatList()` (`:893-911`): when `isFlatWindowed()`, build a length-`_totalRecords` sparse list — for index `i`, `page = ⌊i/perPage⌋+1`, `pos = i%perPage`; real row from `_data[i]` when `page === 1`, else from `_pageCache.get(page)?.[pos]`; otherwise a placeholder `{ row: undefined, key: '__placeholder-flat-'+i, depth: 0, parentId: null, page, isExpanded: false, isPlaceholder: true }`. When not flat-windowed, keep the existing trivial mapping.
+5. Update `getEffectiveData()` so flat-windowed mode returns `getFlatList().map(r => r.row)` (length `_totalRecords`), mirroring the tree branch — this feeds `refreshVirtualRange` total + `getVirtualSpacerHeights`.
+6. Update `aria-rowcount` (`render()` `:613`) to use `getFlatList().length` in flat-windowed mode (currently `_data.length` for non-tree).
+
+### Phase 2: WC on-demand fetch + cache writes (`mp-datatable.ts`)
+1. In `refreshVirtualRange` (`:564-580`): call `maybeFetchPlaceholdersInViewport()` when `this._tree || this.isFlatWindowed()` (currently tree-only).
+2. Extend `maybeFetchPlaceholdersInViewport` (`:586-599`): for flat placeholders (`parentId == null`, has `page`), collect the page set in `[startIndex,endIndex)`, skip pages already in `_pageCache` or `_pendingPageFetches`, and emit one fetch-request per needed page. Keep the existing tree path for `parentId != null`.
+3. Add `requestPageFetch(page: number)`: add to `_pendingPageFetches`, dispatch `mp-datatable-fetch-request` with `{ parentId: null, page, perPage: this._perPage, sortColumns: [...this._sortColumns] }`.
+4. Extend `setFetchResponse(parentId, response)`: when `!this._tree` (flat-window), `_pendingPageFetches.delete(response.page)`, `_pageCache.set(response.page, [...response.data])`, set `_totalRecords` if changed, `requestUpdate()`. Keep the tree path (`parentId != null` → `_childCache`) and the existing null early-return only for the tree case.
+5. Add `public invalidateData(): void` — clears `_pageCache` + `_pendingPageFetches`, `requestUpdate()`.
+
+### Phase 3: Angular wrapper (`datatable.component.ts`)
+1. Replace `runVirtualFetchAll` (`:411-431`) with `runVirtualFetchFirst(fetcher, settings)`: fetch page 1 with `perPage = settings.perPage.selected`; set `currentData` = page-1 rows and `totalRecords` = response total; do **not** loop remaining pages. Keep the `virtualFetchToken` guard.
+2. Update the fetch effect (`:254`) to call `runVirtualFetchFirst` and, before it, call `el.invalidateData()` when the WC element exists (mirror tree `invalidateChildren()` at `:252`) so sort/settings changes drop the stale window.
+3. Extend `onFetchRequest` (`:536-562`): when `detail.parentId == null` (flat window), call `[fetch]({ page: detail.page, perPage: detail.perPage, sortColumns })` and `el.setFetchResponse(null, { data, totalRecords, page, perPage })`. Keep the existing tree-child path for `parentId != null`. Guard so this only runs in flat virtual mode (not classic tree-root, which the wrapper never emits as a `null`-parent request).
+
+### Phase 4: Tests
+1. WC unit tests (`vitest` + jsdom): placeholder render in flat virtual + external; window fetch-request emitted only for viewport pages; `_pendingPageFetches` dedup (no duplicate request for an in-flight page); `setFetchResponse(null, …)` populates `_pageCache` and clears placeholders; `invalidateData()` clears cache; scrollbar/spacer sized from `totalRecords`.
+2. Wrapper unit tests: page-1-first (only one fetch on open, not `⌈N/perPage⌉`); `parentId == null` bridge calls `[fetch]` with the requested page and forwards to `setFetchResponse`; sort change calls `invalidateData()` then refetches.
+
+### Phase 5: Demo + publish
+1. Add a "Virtual scroll + server-side fetch" example to the ng datatable demo page (demo before snippet — see CLAUDE.md/memory).
+2. `nx build mintplayer-web-components` + `nx build mintplayer-ng-bootstrap`; run WC + wrapper tests.
+3. Bump `@mintplayer/ng-bootstrap` version, publish, then notify so Spark #178 can bump and resume.
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Lazy window on open
+- **Given**: a flat `[fetch]` + `[virtualScroll]` datatable backed by 10,000 rows, `perPage = 50`, viewport showing ~20 rows.
+- **When**: the table first renders.
+- **Then**: exactly one fetch (page 1) fires on open; total `_data`/cache holds ≤ `perPage + buffer-pages` worth of rows, not 10,000; scrollbar is sized for 10,000 rows.
+
+### Scenario 2: Fetch-on-scroll
+- **Given**: the table from Scenario 1, page 1 loaded.
+- **When**: the user scrolls so rows 400–420 enter the viewport.
+- **Then**: a fetch-request for the page(s) covering indices 400–420 fires (once each), placeholders show until the response, then real rows replace them; pages not scrolled to are never fetched.
+
+### Scenario 3: Dedup in-flight page
+- **Given**: a page fetch for page 9 is in flight (`_pendingPageFetches` has 9).
+- **When**: `refreshVirtualRange` runs again (scroll jitter) with page 9 still in view.
+- **Then**: no second fetch-request for page 9 is emitted.
+
+### Scenario 4: Sort invalidates the window
+- **Given**: pages 1, 5, 9 loaded in `_pageCache`.
+- **When**: the user changes the sort column.
+- **Then**: `el.invalidateData()` clears `_pageCache` + `_pendingPageFetches`, the wrapper refetches page 1, and previously-loaded pages re-fetch lazily as they re-enter the viewport.
+
+### Scenario 5: Single-page list (no regression)
+- **Given**: a flat virtual `[fetch]` list where `totalRecords ≤ perPage`.
+- **When**: it renders.
+- **Then**: `isExternallyPaged()` is false → the trivial flat mapping path runs, no placeholders, behaves as today.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Opening a virtual list of N rows issues `O(visible/perPage)` fetches, not `⌈N/perPage⌉`.
+- [ ] Placeholders render for unloaded ranges; real rows replace them on response.
+- [ ] Virtual scroll region / scrollbar sized from `totalRecords`.
+- [ ] Sort / settings change invalidates the page cache and refetches the visible window.
+- [ ] Public `[fetch]` contract unchanged (existing consumers untouched).
+- [ ] Tree mode behavior unchanged (regression-guarded).
+- [ ] WC unit tests (placeholder render, window-request dedup, cache populate, invalidation, spacer sizing) green.
+- [ ] Wrapper unit tests (page-1-first, `parentId == null` bridge, invalidation) green.
+- [ ] Virtual + fetch demo example added.
+- [ ] New `@mintplayer/ng-bootstrap` version published.
+
+---
+
+## Build & Test Commands
+
+```bash
+npx nx run mintplayer-web-components:codegen-wc   # if any .styles.scss/.element.* changed
+npx nx build mintplayer-web-components
+npx nx build mintplayer-ng-bootstrap
+npx nx test mintplayer-web-components
+# wrapper tests:
+npx nx test mintplayer-ng-bootstrap
+```
+
+---
+
+## Related Files
+
+- `libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts`
+- `libs/mintplayer-web-components/datatable/src/types/tree.ts`
+- `libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts`
+- `libs/mintplayer-ng-bootstrap/datatable/src/datatable-fetch.ts`
+- ng datatable demo page (`apps/ng-bootstrap-demo/...`)

--- a/docs/issue_385_plan.md
+++ b/docs/issue_385_plan.md
@@ -66,8 +66,8 @@ This change makes flat virtual + `[fetch]` fetch **only the visible window (+ bu
 6. Update `aria-rowcount` (`render()` `:613`) to use `getFlatList().length` in flat-windowed mode (currently `_data.length` for non-tree).
 
 ### Phase 2: WC on-demand fetch + cache writes (`mp-datatable.ts`)
-1. In `refreshVirtualRange` (`:564-580`): call `maybeFetchPlaceholdersInViewport()` when `this._tree || this.isFlatWindowed()` (currently tree-only).
-2. Extend `maybeFetchPlaceholdersInViewport` (`:586-599`): for flat placeholders (`parentId == null`, has `page`), collect the page set in `[startIndex,endIndex)`, skip pages already in `_pageCache` or `_pendingPageFetches`, and emit one fetch-request per needed page. Keep the existing tree path for `parentId != null`.
+1. In `refreshVirtualRange` (`:564-580`): drive the viewport scan in flat-windowed mode too — `if (this._tree) maybeFetchPlaceholdersInViewport(); else if (this.isFlatWindowed()) maybeFetchPagesInViewport();` (the tree scan stays as-is).
+2. Add a sibling `maybeFetchPagesInViewport()` (rather than overloading the tree scan, which keys by `parentId`): for flat placeholders (`parentId == null`, has `page`), collect the page set in `[startIndex,endIndex)`, skip pages already in `_pageCache` or `_pendingPageFetches`, and emit one fetch-request per needed page. `maybeFetchPlaceholdersInViewport` stays tree-only.
 3. Add `requestPageFetch(page: number)`: add to `_pendingPageFetches`, dispatch `mp-datatable-fetch-request` with `{ parentId: null, page, perPage: this._perPage, sortColumns: [...this._sortColumns] }`.
 4. Extend `setFetchResponse(parentId, response)`: when `!this._tree` (flat-window), `_pendingPageFetches.delete(response.page)`, `_pageCache.set(response.page, [...response.data])`, set `_totalRecords` if changed, `requestUpdate()`. Keep the tree path (`parentId != null` → `_childCache`) and the existing null early-return only for the tree case.
 5. Add `public invalidateData(): void` — clears `_pageCache` + `_pendingPageFetches`, `requestUpdate()`.

--- a/docs/issue_385_plan.md
+++ b/docs/issue_385_plan.md
@@ -5,6 +5,13 @@
 **Type**: Feature / Enhancement
 **Priority**: High (blocks MintPlayer.Spark #178)
 
+> ⚠️ **Superseded by #386 (same branch).** The fetch *driving* mechanism in this
+> plan (`mp-datatable-fetch-request` event, `setFetchResponse`, `invalidateData`,
+> `runVirtualFetchFirst`, consumer-set `totalRecords`) was replaced by a WC-owned
+> `fetch` callback in #386. The windowing internals (placeholders, `_pageCache`,
+> sparse `getFlatList`, tree-root windowing) remain. Current contract:
+> **`docs/issue_386_PRD.md`**. Kept as the #385 implementation record.
+
 ## Executive Summary
 
 In ng-bootstrap 22 the flat (non-tree) datatable, when combined with server-side `[fetch]` and `[virtualScroll]`, eagerly drains the **entire** result set up front (`runVirtualFetchAll` loops every page in 200-row chunks into memory) and only then virtualizes the in-memory array. That defeats virtual scrolling and is a behavior regression versus the removed `virtual-datatable`'s true lazy `(skip,take)` windowing.

--- a/docs/issue_386_PRD.md
+++ b/docs/issue_386_PRD.md
@@ -1,0 +1,81 @@
+# Product Requirements Document: WC-owned `fetch` callback for `<mp-datatable>`
+
+**Issue**: #386
+**Title**: WC owns the server-fetch loop via a `fetch` callback (drop consumer phantom wiring + the `totalRecords` prop; work standalone)
+**Status**: Complete
+**Created**: 2026-06-07
+**Last Updated**: 2026-06-07
+
+---
+
+## Summary
+
+`<mp-datatable>` now owns the entire server-paged loop behind a single `fetch` callback. A consumer sets `el.fetch = (req) => Promise<{ data, totalRecords }>` and nothing else — the web component loads page 1, derives the grand total from the response, fetches each window/child on demand as rows scroll into view, paginates, and reloads on sort/perPage. This replaces the previous design where the consumer (or each framework wrapper) had to seed page 1 via `data`, set a separate `totalRecords` property, bridge the `mp-datatable-fetch-request` event to `setFetchResponse()`, and call `invalidateData()`/`invalidateChildren()` on sort. All of that "phantom wiring" is gone. The component is brand new, so **no backward-compatibility layer was kept** — there is exactly one server-paging contract.
+
+---
+
+## Decisions and the "why"
+
+### 1. The WC owns the fetch loop via a `fetch` callback (not an event + `setFetchResponse`)
+**Why:** the previous event-bridge made *every* consumer re-implement the same orchestration — and a framework-less / Rollup consumer had to write all of it by hand. Moving the loop into the WC means the orchestration exists once, in the one place that already knows the viewport, the caches, and the page math. The wrappers collapse to forwarders (`el.fetch = fn`); a vanilla consumer writes one line. The callback is a property (like `rowKey`/`columns`), so `@lit/react` forwards it for free and Vue assigns it in `syncProps` — no per-framework event plumbing.
+**Rejected:** keeping the event + `setFetchResponse` as the primary API (forces the bridge on everyone); keeping it as a *secondary* fallback (dual code paths to maintain on a brand-new component with no consumers to protect).
+
+### 2. `totalRecords` is derived from the response, never set by the consumer
+**Why:** every paginated API already returns the total alongside the rows. Requiring the consumer to *also* hand it to the component as a separate property was redundant — "bogus," in the reviewer's words. The only reason it used to be separate is that page 1 entered through the `data` setter, which carries rows but no total. Now that the WC makes the page-1 call itself, it reads `totalRecords` straight off the response. The public `totalRecords` **setter was removed**; a read-only getter remains so a consumer can display "row X of N".
+**Rejected:** a consumer-set `totalRecords` input (redundant with the response); inferring the total by scrolling to the end (infinite-scroll — loses random access and an accurate scrollbar, the very things #385 windowing provides).
+
+### 3. The web component must work standalone (vanilla + Rollup)
+**Why:** `<mp-datatable>` is a framework-agnostic Lit element; not every consumer uses Angular/React/Vue. The server-paged experience has to be first-class with no framework: `el.fetch = fn` is the whole API. The WC unit tests exercise exactly this path (`document.createElement('mp-datatable')` + `el.fetch`), so "works standalone" is a tested guarantee, not an aspiration.
+
+### 4. Selection-change emits the selected **row objects**, not just ids
+**Why:** once the WC owns the data, the consumer no longer holds the rows to resolve `selectedIds → row objects` itself (the old Angular wrapper did this from its private `currentData` copy, which would now always be empty). The WC has every loaded row (page 1 + windows + children), so it resolves ids → rows in one pass and emits `selectedRows` on `mp-datatable-selection-change`. This is the one deliberate **public event-contract change**; it's additive (`selectedIds` stays).
+**Rejected:** leaving selection id-only and making each wrapper keep a shadow copy of the data (defeats the point of WC ownership; breaks cross-window selection).
+
+### 5. Direct callback calls, no internal event round-trip
+**Why:** the windowing/child machinery used to *dispatch* `mp-datatable-fetch-request` so an external bridge could answer it. With the WC owning `fetch`, it just calls the callback directly where it used to dispatch — fewer moving parts, no event/`setFetchResponse` ceremony, and the requested-page key (the #385 deadlock guard) lives inside the WC instead of relying on the wrapper to echo it.
+
+### 6. Reloads are coalesced (microtask + change-key) and stale responses are dropped (generation token)
+**Why:** sort/perPage/page changes arrive *both* as user actions (header click, footer) *and* as echoed property pushes from a framework's two-way binding. Without coalescing, one logical change triggers several fetches. A microtask debounce plus a `{sort, perPage, page}` change-key collapses the burst into one reload and makes echoes no-ops. A generation token, bumped on every invalidation, drops in-flight responses that resolve after a newer sort — so a slow page-1 from the old sort can't clobber the new window.
+
+### 7. `fetch` implies server-side sort (`autoSort = false`); static `data` still supported
+**Why:** when a server is paging, it also sorts — the WC must not re-sort the one page it holds. Setting `fetch` flips `autoSort` off automatically. Static in-memory tables (`el.data = [...]`, no `fetch`) are unchanged: client sort + client pagination, `totalRecords` defaults to `data.length`.
+
+---
+
+## Public API (after)
+
+```ts
+type DatatableFetchRequest  = { parentId: unknown | null; page: number; perPage: number; sortColumns: SortColumn[] };
+type DatatableFetchResponse<T> = { data: T[]; totalRecords: number };
+type DatatableFetch<T> = (req: DatatableFetchRequest) => Promise<DatatableFetchResponse<T>>;
+
+// vanilla:
+const el = document.querySelector('mp-datatable');
+el.columns = [...];
+el.fetch = async ({ parentId, page, perPage, sortColumns }) => {
+  const r = await api.list({ parentId, page, perPage, sortColumns });
+  return { data: r.items, totalRecords: r.totalCount };
+};
+// nothing else.
+```
+
+**Removed** (no backward compat): `mp-datatable-fetch-request` event, `setFetchResponse()`, `invalidateData()`, `invalidateChildren()`, the `totalRecords` **setter**, and the `TreeFetchRequestDetail` / `TreeFetchResponse` types. `parentId === null` = a root window (flat rows or the tree's top level, pages ≥ 2 windowed); non-null = a node's children — branched on inside the WC.
+
+## Wrappers (now forwarders)
+
+- **Angular** (`bs-datatable`): `[fetch]` → `el.fetch`. Removed `runVirtualFetchFirst`/`runFetch`/the `onFetchRequest` bridge/the `totalRecords` signal/invalidate-on-sort. Kept `[(settings)]` two-way binding + static `[data]`; `[(selection)]` now reads `detail.selectedRows`.
+- **React**: pure `@lit/react` passthrough; `fetch` forwards as a property. Removed the dead `onFetchRequest` event.
+- **Vue**: forwards one `fetch` prop in `syncProps`; removed the `fetchRequest` emit and the `setFetchResponse`/`invalidate*` exposes.
+
+## Out of Scope
+
+- Re-introducing an event-based fetch path (explicitly removed; one contract only).
+- The Spark-blocking #385 windowing machinery itself — this PRD is the ownership/ergonomics layer on top of it.
+
+## Versions
+
+`@mintplayer/web-components` → **2.0.0** (breaking public-API redesign). Wrappers track their framework major and bump minor with a `^2.0.0` peer floor: `@mintplayer/ng-bootstrap` 22.4.0, `@mintplayer/react-bootstrap` 19.6.0, `@mintplayer/vue-bootstrap` 3.7.0.
+
+## Related
+- Issue #386 (this), built on #385 (lazy windowed fetch machinery)
+- Unblocks the ergonomics for MintPlayer.Spark query-pages (the real consumer of windowed server paging)

--- a/docs/prd/datatable.md
+++ b/docs/prd/datatable.md
@@ -167,17 +167,25 @@ keep working — function parameter contravariance accepts the wider input.
 
 ### Mode dispatch
 
+The web component **owns the entire server-fetch loop** behind a single
+`fetch` callback (`el.fetch = (req) => Promise<{ data, totalRecords }>`). It
+calls the callback itself — for page 1, each window, and each tree child —
+derives `totalRecords` from the response, and re-renders. There is no event /
+`setFetchResponse` bridge and no consumer-set `totalRecords`. Framework wrappers
+just forward `el.fetch`; a vanilla/Rollup consumer sets it directly.
+
 | Mode | Trigger | Behaviour |
 |---|---|---|
-| **Paginated** | default | One `fetch({ page, perPage, sortColumns })` per settings change. `parentId` undefined. |
-| **Virtual flat** | `[virtualScroll]="true"` | Wrapper drains every page from the fetcher sequentially up front into `currentData`; WC slices the in-memory array via virtualized `_virtualRange`. |
-| **Paginated tree** | `[tree]="true"` | One root fetch on settings change; one child fetch per parent on expand. |
-| **Virtual tree + lazy** | `[tree]` + `[virtualScroll]` | Root fetch; child fetch on expand; child fetch when a placeholder enters the viewport. |
+| **Paginated** | default | WC calls `fetch({ parentId: null, page, perPage, sortColumns })` per page; the footer drives page changes. |
+| **Virtual flat** | `[virtualScroll]="true"` | WC fetches page 1, then each root page on demand as its placeholder rows enter the viewport (`_pageCache`); scroll region sized from `totalRecords`. |
+| **Paginated tree** | `[tree]="true"` | Root page fetch; one child fetch per parent on expand. |
+| **Virtual tree + lazy** | `[tree]` + `[virtualScroll]` | Root windowing (as flat) **and** child fetch on expand / when a child placeholder enters the viewport. |
 
-The WC stays framework-agnostic: in tree mode it dispatches
-`mp-datatable-fetch-request`; the wrapper resolves the consumer's
-`fetch` callback and hands the response back via
-`setFetchResponse(parentId, response)` on the element ref.
+`parentId === null` is a root window (flat rows or the tree top level); a
+non-null `parentId` is a node's children — the WC branches on it internally.
+A generation token drops responses that resolve after an invalidation, and
+sort/perPage/page changes are coalesced so two-way-binding echoes don't
+double-fetch.
 
 ## Virtual scroll — weighted-rows model
 
@@ -238,18 +246,16 @@ the post-render call can't loop.
 
 ### Lazy children — wire protocol
 
-1. User clicks a chevron OR a placeholder enters the viewport.
-2. WC dispatches `mp-datatable-fetch-request` with `{ parentId, page: 1,
-   perPage, sortColumns }`.
-3. Wrapper resolves the consumer's `[fetch]` callback with the request
-   (now carrying `parentId`).
-4. Wrapper calls `setFetchResponse(parentId, response)` on the WC.
-5. WC populates `_childCache[parentId]` + `_childTotals[parentId]` and
+1. User clicks a chevron OR a child placeholder enters the viewport.
+2. WC calls its `fetch` callback directly with `{ parentId, page: 1,
+   perPage, sortColumns }` (a non-null `parentId`).
+3. WC populates `_childCache[parentId]` + `_childTotals[parentId]` and
    re-renders. Placeholders replaced with real rows.
 
-Cache invalidation: sort change triggers `invalidateChildren()` (drops
-the per-parent cache) before the next root fetch. Server-side sort
-applies within siblings only.
+Cache invalidation: a sort/perPage change bumps the WC's fetch-generation
+token and clears the caches (roots + children), then reloads page 1.
+Server-side sort applies within siblings only. (There is no consumer-side
+bridge: the WC owns the call and the cache.)
 
 ### Demo backend
 
@@ -414,23 +420,25 @@ Tree-mode-specific:
 `createComponent` property-forwarding path — no explicit
 declarations needed.
 
-Consumer pattern for lazy children:
+Consumer pattern — one `fetch` callback drives everything (roots, windows,
+children); branch on `req.parentId`:
 
 ```tsx
-const ref = useRef<MpDatatable | null>(null);
-const onFetchRequest = useCallback(async (e: CustomEvent<TreeFetchRequestDetail>) => {
-  const result = await fetchTreeItems(e.detail.parentId as number);
-  ref.current?.setFetchResponse(e.detail.parentId, { ... });
-}, []);
+const fetchData = useCallback(
+  async (req: DatatableFetchRequest): Promise<DatatableFetchResponse<Row>> => {
+    const r = await api.list(req.parentId, req.page, req.perPage, req.sortColumns);
+    return { data: r.items, totalRecords: r.totalCount };
+  }, []);
+// <BsDatatable fetch={fetchData} ... />  — selected rows arrive on onSelectionChange's detail.selectedRows
 ```
 
 ### Vue (`BsDatatable.vue`)
 
-`<script setup>` syncing JS-property props (arrays, Sets, functions
-can't ride attributes). Adds `addEventListener` per CustomEvent →
-`emit('camelCase', detail)`. Exposes `setFetchResponse` +
-`invalidateChildren` via `defineExpose` so consumers can drive the
-WC imperatively from a template ref.
+`<script setup>` syncing JS-property props (arrays, Sets, functions —
+including `fetch` — can't ride attributes). Adds `addEventListener` per
+CustomEvent → `emit('camelCase', detail)`. Exposes only `el` via
+`defineExpose` (the WC owns the fetch loop, so there are no imperative
+fetch methods to expose).
 
 `v-model:expandedIds` and `v-model:selectedIds` are supported via the
 matching `update:` emits.

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.html
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.html
@@ -8,7 +8,6 @@
   (mp-datatable-row-click)="onRowClick($event)"
   (mp-datatable-row-dblclick)="onRowDblClick($event)"
   (mp-datatable-row-contextmenu)="onRowContextMenu($event)"
-  (mp-datatable-fetch-request)="onFetchRequest($event)"
   (mp-datatable-row-expand)="onRowExpand($event)"
   (mp-datatable-row-collapse)="onRowCollapse($event)"
   (mp-datatable-expanded-ids-change)="onExpandedIdsChange($event)"

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts
@@ -228,12 +228,12 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
       }
     });
 
-    // Async fetch: re-run on fetch / settings changes. In virtual flat mode
-    // the WC's virtualizer slices the in-memory `currentData` array, so the
-    // wrapper drains every page from the fetcher up front. In tree mode the
-    // wrapper does one root-page fetch; the WC pulls children on demand via
-    // `mp-datatable-fetch-request` (bridged by `onFetchRequest` below), so
-    // virtual + tree composes without front-loading.
+    // Async fetch: re-run on fetch / settings changes. In flat virtual mode the
+    // wrapper fetches only page 1 (for the total + initial rows); the WC pulls
+    // the remaining pages on demand as they scroll into view via
+    // `mp-datatable-fetch-request` (bridged by `onFetchRequest` below). In tree
+    // mode the wrapper does one root-page fetch and the WC pulls children the
+    // same way. Neither front-loads the whole result set.
     effect(() => {
       if (isPlatformServer(this.platformId)) return;
       const fetcher = this.fetch();
@@ -252,7 +252,12 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
         if (el && typeof el.invalidateChildren === 'function') el.invalidateChildren();
         void this.runFetch(fetcher, req, settings);
       } else if (this.virtualScroll()) {
-        void this.runVirtualFetchAll(fetcher, settings.sortColumns);
+        // Sort/settings changes invalidate the windowed page cache (the page
+        // boundaries + ordering are stale) before the page-1 refetch — mirrors
+        // the tree `invalidateChildren()` above.
+        const el = this.datatableRef()?.nativeElement;
+        if (el && typeof el.invalidateData === 'function') el.invalidateData();
+        void this.runVirtualFetchFirst(fetcher, settings);
       } else {
         const req: PaginationRequest = {
           page: settings.page.selected,
@@ -405,29 +410,32 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
     };
   }
 
-  /** Generation token: invalidates an in-flight virtual-mode preload when sort/fetcher changes. */
+  /** Generation token: invalidates an in-flight virtual-mode fetch when sort/fetcher changes. */
   private virtualFetchToken = 0;
 
-  private async runVirtualFetchAll(
+  /**
+   * Flat virtual mode: fetch only page 1 and report the total. The WC seeds
+   * page 1 from `currentData` (via the `el.data` effect), sizes the scroll
+   * region from `totalRecords`, and pulls pages ≥ 2 lazily as they scroll into
+   * view — bridged back through `onFetchRequest`. The window size is
+   * `settings.perPage`, so the WC's page index matches the fetch page.
+   *
+   * The `virtualFetchToken` guard drops a stale page-1 response from a previous
+   * sort/fetcher generation so it can't clobber the current window.
+   */
+  private async runVirtualFetchFirst(
     fetcher: BsDatatableFetch<TData>,
-    sortColumns: SortColumn[],
+    settings: DatatableSettings,
   ): Promise<void> {
     const token = ++this.virtualFetchToken;
-    const perPage = 200;
-    const first = await fetcher({ page: 1, perPage, sortColumns });
+    const first = await fetcher({
+      page: 1,
+      perPage: settings.perPage.selected,
+      sortColumns: settings.sortColumns,
+    });
     if (!first || token !== this.virtualFetchToken) return;
-    const accumulator: TData[] = [...(first.data ?? [])];
-    const totalRecords = first.totalRecords ?? accumulator.length;
-    const totalPages = Math.max(1, first.totalPages ?? Math.ceil(totalRecords / perPage));
-    this.currentData.set(accumulator);
-    this.totalRecords.set(totalRecords);
-    const remaining = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
-    for (const page of remaining) {
-      const response = await fetcher({ page, perPage, sortColumns });
-      if (!response || token !== this.virtualFetchToken) return;
-      accumulator.push(...(response.data ?? []));
-      this.currentData.set([...accumulator]);
-    }
+    this.currentData.set(first.data ?? []);
+    this.totalRecords.set(first.totalRecords ?? first.data?.length ?? 0);
   }
 
   private async runFetch(
@@ -528,10 +536,17 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
   // ─── Tree-mode event handlers ────────────────────────────────────────────
 
   /**
-   * Bridge the WC's fetch-request to the consumer's `[fetch]` callback. The
-   * WC fires this when a row is expanded (or scrolled into view as a
-   * placeholder) without cached children. We resolve the consumer's promise
-   * and hand the response back to the WC via `setFetchResponse`.
+   * Bridge the WC's fetch-request to the consumer's `[fetch]` callback. Fires
+   * for tree-mode children (a non-null `parentId` is scrolled/expanded into
+   * view without cached children) AND for flat virtual windows (`parentId`
+   * null, `page` ≥ 2 scrolled into view). We resolve the consumer's promise and
+   * hand the response back via `setFetchResponse`.
+   *
+   * The page handed to `setFetchResponse` is the *requested* `detail.page`, not
+   * `response.page`: in flat-window mode the WC keys both its page cache and
+   * its in-flight set on the requested page, so a server that normalises/echoes
+   * a different page number would otherwise leave the placeholder unresolved
+   * and the page stuck pending.
    */
   onFetchRequest(event: Event): void {
     const detail = (event as CustomEvent<TreeFetchRequestDetail>).detail;
@@ -550,7 +565,7 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
         el.setFetchResponse(detail.parentId, {
           data: response.data ?? [],
           totalRecords: response.totalRecords ?? response.data?.length ?? 0,
-          page: response.page ?? detail.page,
+          page: detail.page,
           perPage: response.perPage ?? detail.perPage,
         });
       } catch (err) {

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts
@@ -20,7 +20,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { isPlatformServer } from '@angular/common';
-import { PaginationRequest, PaginationResponse, SortColumn } from '@mintplayer/pagination';
+import { SortColumn } from '@mintplayer/pagination';
 import {
   computeNextSort,
   type DatatableColumnDef,
@@ -30,7 +30,6 @@ import {
   type RowRenderer,
   type SortChangeEventDetail,
   type SelectionChangeEventDetail,
-  type TreeFetchRequestDetail,
   type TreeRowExpandDetail,
   type TreeExpandedIdsChangeDetail,
   type TreeIdKey,
@@ -41,7 +40,7 @@ import {
 import '@mintplayer/web-components/datatable';
 
 import { DatatableSettings } from '../datatable-settings';
-import { BsDatatableFetch, BsDatatableFetchRequest } from '../datatable-fetch';
+import { BsDatatableFetch } from '../datatable-fetch';
 import { BsDatatableColumnDirective } from '../datatable-column/datatable-column.directive';
 import { BsRowTemplateDirective, BsRowTemplateContext } from '../row-template/row-template.directive';
 
@@ -171,10 +170,6 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
   /** Optional row template. When present, drives a per-row EmbeddedView render path. */
   readonly rowTemplate = contentChild(BsRowTemplateDirective<TData>);
 
-  /** Internal data source — populated either from `data()` or from `fetch()` responses. */
-  protected readonly currentData = signal<TData[]>([]);
-  protected readonly totalRecords = signal<number>(0);
-
   /**
    * Merged column defs:
    *  - `[columns]` if provided
@@ -219,69 +214,33 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
       this.rowViews.clear();
     });
 
-    // Sync data input → internal source.
+    // Forward the `[fetch]` callback to the WC, which owns the entire
+    // server-paged loop (initial page, on-demand windows, tree children,
+    // pagination, sort/perPage reloads) and derives `totalRecords` from the
+    // response. The wrapper no longer runs any fetch loop. Skipped on the
+    // server so SSR doesn't kick off a client fetch.
     effect(() => {
-      const d = this.data();
-      if (d !== null) {
-        this.currentData.set(d);
-        this.totalRecords.set(d.length);
-      }
-    });
-
-    // Async fetch: re-run on fetch / settings changes. In flat virtual mode the
-    // wrapper fetches only page 1 (for the total + initial rows); the WC pulls
-    // the remaining pages on demand as they scroll into view via
-    // `mp-datatable-fetch-request` (bridged by `onFetchRequest` below). In tree
-    // mode the wrapper does one root-page fetch and the WC pulls children the
-    // same way. Neither front-loads the whole result set.
-    effect(() => {
+      const el = this.datatableRef()?.nativeElement;
+      if (!el) return;
       if (isPlatformServer(this.platformId)) return;
-      const fetcher = this.fetch();
-      if (!fetcher) return;
-      const settings = this.settings();
-      if (this.tree()) {
-        const req: BsDatatableFetchRequest = {
-          page: settings.page.selected,
-          perPage: settings.perPage.selected,
-          sortColumns: settings.sortColumns,
-          parentId: undefined,
-        };
-        // Sort changes invalidate the per-parent child cache (server-side sort
-        // applies within siblings, so cached children are stale) AND the lazy
-        // root-page window cache (root ordering across pages changes too).
-        const el = this.datatableRef()?.nativeElement;
-        if (el && typeof el.invalidateChildren === 'function') el.invalidateChildren();
-        if (el && typeof el.invalidateData === 'function') el.invalidateData();
-        void this.runFetch(fetcher, req, settings);
-      } else if (this.virtualScroll()) {
-        // Sort/settings changes invalidate the windowed page cache (the page
-        // boundaries + ordering are stale) before the page-1 refetch — mirrors
-        // the tree `invalidateChildren()` above.
-        const el = this.datatableRef()?.nativeElement;
-        if (el && typeof el.invalidateData === 'function') el.invalidateData();
-        void this.runVirtualFetchFirst(fetcher, settings);
-      } else {
-        const req: PaginationRequest = {
-          page: settings.page.selected,
-          perPage: settings.perPage.selected,
-          sortColumns: settings.sortColumns,
-        };
-        void this.runFetch(fetcher, req, settings);
-      }
+      el.fetch = (this.fetch() as unknown as MpDatatable['fetch']) ?? null;
     });
 
-    // Forward columns + data to the WC.
+    // Forward columns to the WC.
     effect(() => {
       const el = this.datatableRef()?.nativeElement;
       if (!el) return;
       el.columns = this.effectiveColumns() as DatatableColumnDef[];
     });
 
+    // Static `[data]` only. When `[fetch]` is set the WC owns the rows, so the
+    // wrapper must not also push `el.data` (it would clobber fetched pages).
     effect(() => {
       const el = this.datatableRef()?.nativeElement;
       if (!el) return;
-      el.data = this.currentData() as unknown[];
-      // Stale row views for rows no longer present are pruned lazily on next render.
+      if (this.fetch()) return;
+      const d = this.data();
+      el.data = (d ?? []) as unknown[];
     });
 
     effect(() => {
@@ -298,7 +257,6 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
       el.page = settings.page.selected;
       el.perPage = settings.perPage.selected;
       el.perPageOptions = settings.perPage.values;
-      el.totalRecords = fetching ? this.totalRecords() : null;
     });
 
     effect(() => {
@@ -412,58 +370,6 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
     };
   }
 
-  /** Generation token: invalidates an in-flight virtual-mode fetch when sort/fetcher changes. */
-  private virtualFetchToken = 0;
-
-  /**
-   * Flat virtual mode: fetch only page 1 and report the total. The WC seeds
-   * page 1 from `currentData` (via the `el.data` effect), sizes the scroll
-   * region from `totalRecords`, and pulls pages ≥ 2 lazily as they scroll into
-   * view — bridged back through `onFetchRequest`. The window size is
-   * `settings.perPage`, so the WC's page index matches the fetch page.
-   *
-   * The `virtualFetchToken` guard drops a stale page-1 response from a previous
-   * sort/fetcher generation so it can't clobber the current window.
-   */
-  private async runVirtualFetchFirst(
-    fetcher: BsDatatableFetch<TData>,
-    settings: DatatableSettings,
-  ): Promise<void> {
-    const token = ++this.virtualFetchToken;
-    const first = await fetcher({
-      page: 1,
-      perPage: settings.perPage.selected,
-      sortColumns: settings.sortColumns,
-    });
-    if (!first || token !== this.virtualFetchToken) return;
-    this.currentData.set(first.data ?? []);
-    this.totalRecords.set(first.totalRecords ?? first.data?.length ?? 0);
-  }
-
-  private async runFetch(
-    fetcher: BsDatatableFetch<TData>,
-    req: PaginationRequest,
-    settings: DatatableSettings,
-  ): Promise<void> {
-    const response = await fetcher(req);
-    if (!response) return;
-    this.currentData.set(response.data ?? []);
-    this.totalRecords.set(response.totalRecords ?? response.data?.length ?? 0);
-
-    const desiredPageCount = Math.max(1, response.totalPages ?? 1);
-    if (settings.page.values.length !== desiredPageCount) {
-      this.settings.set(
-        new DatatableSettings({
-          ...settings,
-          page: {
-            values: Array.from({ length: desiredPageCount }, (_, i) => i + 1),
-            selected: Math.min(settings.page.selected, desiredPageCount),
-          },
-        }),
-      );
-    }
-  }
-
   // ─── WC event handlers ───────────────────────────────────────────────────
 
   onSortChange(event: Event): void {
@@ -479,27 +385,11 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
   }
 
   onSelectionChange(event: Event): void {
-    const detail = (event as CustomEvent<SelectionChangeEventDetail>).detail;
-    const keyFn = this.rowKey();
-
-    // The naïve `currentData().filter(id ∈ idSet)` drops cross-page
-    // selections in pagination mode — `currentData` only holds the
-    // currently-visible page, so any id selected on a page the user has
-    // since navigated away from disappears. Look up known IDs in
-    // `selection()` first (rows from earlier pages we still remember),
-    // then fall back to `currentData()` for IDs the WC just acknowledged
-    // from the current page.
-    const existingById = new Map<string, TData>();
-    this.selection().forEach((row, i) => existingById.set(keyFn(row, i), row));
-    const currentById = new Map<string, TData>();
-    this.currentData().forEach((row, i) => currentById.set(keyFn(row, i), row));
-
-    const next: TData[] = [];
-    for (const id of detail.selectedIds) {
-      const row = existingById.get(id) ?? currentById.get(id);
-      if (row !== undefined) next.push(row);
-    }
-    this.selection.set(next);
+    const detail = (event as CustomEvent<SelectionChangeEventDetail<TData>>).detail;
+    // The WC owns the data and resolves ids → row objects itself (across page 1,
+    // fetched windows, and tree children), so we take the rows straight from the
+    // event — no wrapper-side row bookkeeping.
+    this.selection.set([...detail.selectedRows]);
   }
 
   onPageChange(event: Event): void {
@@ -536,47 +426,6 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
   }
 
   // ─── Tree-mode event handlers ────────────────────────────────────────────
-
-  /**
-   * Bridge the WC's fetch-request to the consumer's `[fetch]` callback. Fires
-   * for tree-mode children (a non-null `parentId` is scrolled/expanded into
-   * view without cached children) AND for flat virtual windows (`parentId`
-   * null, `page` ≥ 2 scrolled into view). We resolve the consumer's promise and
-   * hand the response back via `setFetchResponse`.
-   *
-   * The page handed to `setFetchResponse` is the *requested* `detail.page`, not
-   * `response.page`: in flat-window mode the WC keys both its page cache and
-   * its in-flight set on the requested page, so a server that normalises/echoes
-   * a different page number would otherwise leave the placeholder unresolved
-   * and the page stuck pending.
-   */
-  onFetchRequest(event: Event): void {
-    const detail = (event as CustomEvent<TreeFetchRequestDetail>).detail;
-    const fetcher = this.fetch();
-    if (!fetcher) return;
-    void (async () => {
-      try {
-        const response = await fetcher({
-          page: detail.page,
-          perPage: detail.perPage,
-          sortColumns: detail.sortColumns as SortColumn[],
-          parentId: detail.parentId ?? undefined,
-        });
-        const el = this.datatableRef()?.nativeElement;
-        if (!el) return;
-        el.setFetchResponse(detail.parentId, {
-          data: response.data ?? [],
-          totalRecords: response.totalRecords ?? response.data?.length ?? 0,
-          page: detail.page,
-          perPage: response.perPage ?? detail.perPage,
-        });
-      } catch (err) {
-        // Surface failures to the consumer via the rowExpand event chain in a
-        // future iteration. For v1 logging is sufficient to debug bad fetches.
-        console.error('[bs-datatable] tree fetch failed', err);
-      }
-    })();
-  }
 
   onRowExpand(event: Event): void {
     const detail = (event as CustomEvent<TreeRowExpandDetail<TData>>).detail;

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.component.ts
@@ -247,9 +247,11 @@ export class BsDatatableComponent<TData> implements AfterViewInit {
           parentId: undefined,
         };
         // Sort changes invalidate the per-parent child cache (server-side sort
-        // applies within siblings, so cached children are stale).
+        // applies within siblings, so cached children are stale) AND the lazy
+        // root-page window cache (root ordering across pages changes too).
         const el = this.datatableRef()?.nativeElement;
         if (el && typeof el.invalidateChildren === 'function') el.invalidateChildren();
+        if (el && typeof el.invalidateData === 'function') el.invalidateData();
         void this.runFetch(fetcher, req, settings);
       } else if (this.virtualScroll()) {
         // Sort/settings changes invalidate the windowed page cache (the page

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.windowed-fetch.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.windowed-fetch.spec.ts
@@ -4,27 +4,13 @@ import type { DatatableColumnDef, MpDatatable } from '@mintplayer/web-components
 import type { PaginationResponse } from '@mintplayer/pagination';
 
 import { BsDatatableComponent } from './datatable.component';
-import { BsDatatableFetchRequest } from '../datatable-fetch';
-import { DatatableSettings } from '../datatable-settings';
+import { BsDatatableFetch, BsDatatableFetchRequest } from '../datatable-fetch';
 
 interface Row {
   id: number;
   name: string;
 }
 
-function makePage(page: number, perPage: number): Row[] {
-  return Array.from({ length: perPage }, (_, i) => {
-    const id = (page - 1) * perPage + i + 1;
-    return { id, name: `p${page}-${i}` };
-  });
-}
-
-/**
- * `[virtualBuffer]="0"` collapses the WC's virtual viewport to an empty range in
- * jsdom (no layout → clientHeight 0), so the WC emits no spontaneous
- * viewport-driven fetch-requests. That isolates the WRAPPER's behaviour: page-1
- * fetch on init, and the explicit fetch-request bridge we dispatch by hand.
- */
 @Component({
   selector: 'dt-fetch-harness',
   imports: [BsDatatableComponent],
@@ -32,31 +18,21 @@ function makePage(page: number, perPage: number): Row[] {
     [columns]="columns()"
     [fetch]="fetch"
     [virtualScroll]="true"
-    [virtualBuffer]="0"
-    [settings]="settings()"
+    [(selection)]="selection"
   ></bs-datatable>`,
 })
 class FetchHarness {
   readonly columns = signal<DatatableColumnDef<Row>[]>([
     { name: 'name', label: 'Name', cellRenderer: (r) => r.name },
   ]);
-  readonly settings = signal<DatatableSettings>(
-    new DatatableSettings({ perPage: { values: [10, 20, 50], selected: 10 } }),
-  );
-
+  readonly selection = signal<Row[]>([]);
   readonly fetchCalls: BsDatatableFetchRequest[] = [];
-  /** Overridable per-test; defaults to a faithful 1000-row server over 100 pages of 10. */
-  responder: (req: BsDatatableFetchRequest) => PaginationResponse<Row> = (req) => ({
-    data: makePage(req.page, 10),
-    totalRecords: 1000,
-    page: req.page,
-    perPage: 10,
-    totalPages: 100,
-  });
 
-  readonly fetch = (req: BsDatatableFetchRequest): Promise<PaginationResponse<Row>> => {
+  readonly fetch: BsDatatableFetch<Row> = (req: BsDatatableFetchRequest) => {
     this.fetchCalls.push(req);
-    return Promise.resolve(this.responder(req));
+    const perPage = req.perPage || 10;
+    const data = Array.from({ length: perPage }, (_, i) => ({ id: (req.page - 1) * perPage + i + 1, name: `r${i}` }));
+    return Promise.resolve(<PaginationResponse<Row>>{ data, totalRecords: 1000, page: req.page, perPage });
   };
 }
 
@@ -66,12 +42,10 @@ const flush = async (fixture: ComponentFixture<unknown>): Promise<void> => {
   await fixture.whenStable();
 };
 
-describe('BsDatatableComponent — flat virtual windowed fetch (wrapper)', () => {
+describe('BsDatatableComponent — fetch forwarder (wrapper)', () => {
   let fixture: ComponentFixture<FetchHarness>;
   let harness: FetchHarness;
-
-  const mpEl = (): MpDatatable =>
-    fixture.nativeElement.querySelector('mp-datatable') as MpDatatable;
+  const mpEl = (): MpDatatable => fixture.nativeElement.querySelector('mp-datatable') as MpDatatable;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({ imports: [FetchHarness] }).compileComponents();
@@ -81,82 +55,23 @@ describe('BsDatatableComponent — flat virtual windowed fetch (wrapper)', () =>
     await flush(fixture);
   });
 
-  it('fetches only page 1 on init — no eager full drain', () => {
-    // The old runVirtualFetchAll would loop every page up front; the windowed
-    // path fetches just page 1 and lets the WC pull the rest on scroll.
-    expect(harness.fetchCalls.length).toBe(1);
-    expect(harness.fetchCalls[0].page).toBe(1);
-    expect(harness.fetchCalls[0].perPage).toBe(10);
+  it('forwards [fetch] to the WC, which drives the initial page-1 load itself', () => {
+    // The wrapper no longer runs a fetch loop — it just assigns el.fetch and the
+    // WC calls it. Page 1 with parentId null proves the forward + WC ownership.
+    expect(typeof mpEl().fetch).toBe('function');
+    expect(harness.fetchCalls.some((c) => c.parentId == null && c.page === 1)).toBe(true);
   });
 
-  it('bridges a flat-window fetch-request (parentId:null) to [fetch] and back to setFetchResponse', async () => {
-    const el = mpEl();
-    const setSpy = vi.spyOn(el, 'setFetchResponse');
-    harness.fetchCalls.length = 0;
-
-    el.dispatchEvent(
-      new CustomEvent('mp-datatable-fetch-request', {
-        detail: { parentId: null, page: 3, perPage: 10, sortColumns: [] },
+  it('maps the WC selection-change event onto the [(selection)] model via selectedRows', async () => {
+    const rows: Row[] = [{ id: 7, name: 'seven' }];
+    mpEl().dispatchEvent(
+      new CustomEvent('mp-datatable-selection-change', {
+        detail: { selectedIds: ['7'], selectedRows: rows },
         bubbles: true,
         composed: true,
       }),
     );
     await flush(fixture);
-
-    // Wrapper resolved the consumer's [fetch] for the requested page…
-    expect(harness.fetchCalls.map((r) => r.page)).toEqual([3]);
-    // …and handed the result back to the WC, keyed by parentId null.
-    expect(setSpy).toHaveBeenCalledTimes(1);
-    expect(setSpy.mock.calls[0][0]).toBeNull();
-  });
-
-  it('keys setFetchResponse on the REQUESTED page, not the server-echoed page', async () => {
-    const el = mpEl();
-    const setSpy = vi.spyOn(el, 'setFetchResponse');
-    harness.fetchCalls.length = 0;
-    // Simulate a server that normalises/echoes a different page number.
-    harness.responder = (req) => ({
-      data: makePage(req.page, 10),
-      totalRecords: 1000,
-      page: 99, // ← deliberately wrong
-      perPage: 10,
-      totalPages: 100,
-    });
-
-    el.dispatchEvent(
-      new CustomEvent('mp-datatable-fetch-request', {
-        detail: { parentId: null, page: 4, perPage: 10, sortColumns: [] },
-        bubbles: true,
-        composed: true,
-      }),
-    );
-    await flush(fixture);
-
-    // The page handed to the WC must be the requested 4 — otherwise the
-    // placeholder for page 4 never clears and the page stays pending forever.
-    const response = setSpy.mock.calls[0][1] as { page: number };
-    expect(response.page).toBe(4);
-  });
-
-  it('invalidates the windowed cache on sort change before refetching page 1', async () => {
-    const el = mpEl();
-    const invSpy = vi.spyOn(el, 'invalidateData');
-    harness.fetchCalls.length = 0;
-
-    // New sort → wrapper drops the stale window and refetches page 1.
-    harness.settings.set(
-      new DatatableSettings({
-        perPage: { values: [10, 20, 50], selected: 10 },
-        sortColumns: [{ property: 'name', direction: 'ascending' }],
-      }),
-    );
-    fixture.detectChanges();
-    await flush(fixture);
-
-    expect(invSpy).toHaveBeenCalled();
-    expect(harness.fetchCalls.map((r) => r.page)).toContain(1);
-    expect(harness.fetchCalls[harness.fetchCalls.length - 1].sortColumns).toEqual([
-      { property: 'name', direction: 'ascending' },
-    ]);
+    expect(harness.selection()).toEqual(rows);
   });
 });

--- a/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.windowed-fetch.spec.ts
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/datatable/datatable.windowed-fetch.spec.ts
@@ -1,0 +1,162 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { DatatableColumnDef, MpDatatable } from '@mintplayer/web-components/datatable';
+import type { PaginationResponse } from '@mintplayer/pagination';
+
+import { BsDatatableComponent } from './datatable.component';
+import { BsDatatableFetchRequest } from '../datatable-fetch';
+import { DatatableSettings } from '../datatable-settings';
+
+interface Row {
+  id: number;
+  name: string;
+}
+
+function makePage(page: number, perPage: number): Row[] {
+  return Array.from({ length: perPage }, (_, i) => {
+    const id = (page - 1) * perPage + i + 1;
+    return { id, name: `p${page}-${i}` };
+  });
+}
+
+/**
+ * `[virtualBuffer]="0"` collapses the WC's virtual viewport to an empty range in
+ * jsdom (no layout → clientHeight 0), so the WC emits no spontaneous
+ * viewport-driven fetch-requests. That isolates the WRAPPER's behaviour: page-1
+ * fetch on init, and the explicit fetch-request bridge we dispatch by hand.
+ */
+@Component({
+  selector: 'dt-fetch-harness',
+  imports: [BsDatatableComponent],
+  template: `<bs-datatable
+    [columns]="columns()"
+    [fetch]="fetch"
+    [virtualScroll]="true"
+    [virtualBuffer]="0"
+    [settings]="settings()"
+  ></bs-datatable>`,
+})
+class FetchHarness {
+  readonly columns = signal<DatatableColumnDef<Row>[]>([
+    { name: 'name', label: 'Name', cellRenderer: (r) => r.name },
+  ]);
+  readonly settings = signal<DatatableSettings>(
+    new DatatableSettings({ perPage: { values: [10, 20, 50], selected: 10 } }),
+  );
+
+  readonly fetchCalls: BsDatatableFetchRequest[] = [];
+  /** Overridable per-test; defaults to a faithful 1000-row server over 100 pages of 10. */
+  responder: (req: BsDatatableFetchRequest) => PaginationResponse<Row> = (req) => ({
+    data: makePage(req.page, 10),
+    totalRecords: 1000,
+    page: req.page,
+    perPage: 10,
+    totalPages: 100,
+  });
+
+  readonly fetch = (req: BsDatatableFetchRequest): Promise<PaginationResponse<Row>> => {
+    this.fetchCalls.push(req);
+    return Promise.resolve(this.responder(req));
+  };
+}
+
+const flush = async (fixture: ComponentFixture<unknown>): Promise<void> => {
+  await new Promise((r) => setTimeout(r));
+  fixture.detectChanges();
+  await fixture.whenStable();
+};
+
+describe('BsDatatableComponent — flat virtual windowed fetch (wrapper)', () => {
+  let fixture: ComponentFixture<FetchHarness>;
+  let harness: FetchHarness;
+
+  const mpEl = (): MpDatatable =>
+    fixture.nativeElement.querySelector('mp-datatable') as MpDatatable;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [FetchHarness] }).compileComponents();
+    fixture = TestBed.createComponent(FetchHarness);
+    harness = fixture.componentInstance;
+    fixture.detectChanges();
+    await flush(fixture);
+  });
+
+  it('fetches only page 1 on init — no eager full drain', () => {
+    // The old runVirtualFetchAll would loop every page up front; the windowed
+    // path fetches just page 1 and lets the WC pull the rest on scroll.
+    expect(harness.fetchCalls.length).toBe(1);
+    expect(harness.fetchCalls[0].page).toBe(1);
+    expect(harness.fetchCalls[0].perPage).toBe(10);
+  });
+
+  it('bridges a flat-window fetch-request (parentId:null) to [fetch] and back to setFetchResponse', async () => {
+    const el = mpEl();
+    const setSpy = vi.spyOn(el, 'setFetchResponse');
+    harness.fetchCalls.length = 0;
+
+    el.dispatchEvent(
+      new CustomEvent('mp-datatable-fetch-request', {
+        detail: { parentId: null, page: 3, perPage: 10, sortColumns: [] },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await flush(fixture);
+
+    // Wrapper resolved the consumer's [fetch] for the requested page…
+    expect(harness.fetchCalls.map((r) => r.page)).toEqual([3]);
+    // …and handed the result back to the WC, keyed by parentId null.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy.mock.calls[0][0]).toBeNull();
+  });
+
+  it('keys setFetchResponse on the REQUESTED page, not the server-echoed page', async () => {
+    const el = mpEl();
+    const setSpy = vi.spyOn(el, 'setFetchResponse');
+    harness.fetchCalls.length = 0;
+    // Simulate a server that normalises/echoes a different page number.
+    harness.responder = (req) => ({
+      data: makePage(req.page, 10),
+      totalRecords: 1000,
+      page: 99, // ← deliberately wrong
+      perPage: 10,
+      totalPages: 100,
+    });
+
+    el.dispatchEvent(
+      new CustomEvent('mp-datatable-fetch-request', {
+        detail: { parentId: null, page: 4, perPage: 10, sortColumns: [] },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    await flush(fixture);
+
+    // The page handed to the WC must be the requested 4 — otherwise the
+    // placeholder for page 4 never clears and the page stays pending forever.
+    const response = setSpy.mock.calls[0][1] as { page: number };
+    expect(response.page).toBe(4);
+  });
+
+  it('invalidates the windowed cache on sort change before refetching page 1', async () => {
+    const el = mpEl();
+    const invSpy = vi.spyOn(el, 'invalidateData');
+    harness.fetchCalls.length = 0;
+
+    // New sort → wrapper drops the stale window and refetches page 1.
+    harness.settings.set(
+      new DatatableSettings({
+        perPage: { values: [10, 20, 50], selected: 10 },
+        sortColumns: [{ property: 'name', direction: 'ascending' }],
+      }),
+    );
+    fixture.detectChanges();
+    await flush(fixture);
+
+    expect(invSpy).toHaveBeenCalled();
+    expect(harness.fetchCalls.map((r) => r.page)).toContain(1);
+    expect(harness.fetchCalls[harness.fetchCalls.length - 1].sortColumns).toEqual([
+      { property: 'name', direction: 'ascending' },
+    ]);
+  });
+});

--- a/libs/mintplayer-ng-bootstrap/datatable/src/index.ts
+++ b/libs/mintplayer-ng-bootstrap/datatable/src/index.ts
@@ -17,8 +17,9 @@ export type {
   SelectionChangeEventDetail,
   TreeIdKey,
   TreeSelectionStrategy,
-  TreeFetchRequestDetail,
-  TreeFetchResponse,
+  DatatableFetchRequest,
+  DatatableFetchResponse,
+  DatatableFetch,
   TreeRowExpandDetail,
   TreeExpandedIdsChangeDetail,
 } from '@mintplayer/web-components/datatable';

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "22.2.0",
+  "version": "22.3.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "@mintplayer/pagination": "^2.3.0",
     "@mintplayer/ng-focus-on-load": "^22.0.0",
     "@mintplayer/ng-swiper": "^22.0.0",
-    "@mintplayer/web-components": "^1.6.0",
+    "@mintplayer/web-components": "^1.7.0",
     "lit": "^3.3.0"
   },
   "dependencies": {

--- a/libs/mintplayer-ng-bootstrap/package.json
+++ b/libs/mintplayer-ng-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mintplayer/ng-bootstrap",
   "private": false,
-  "version": "22.3.0",
+  "version": "22.4.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "@mintplayer/pagination": "^2.3.0",
     "@mintplayer/ng-focus-on-load": "^22.0.0",
     "@mintplayer/ng-swiper": "^22.0.0",
-    "@mintplayer/web-components": "^1.7.0",
+    "@mintplayer/web-components": "^2.0.0",
     "lit": "^3.3.0"
   },
   "dependencies": {

--- a/libs/mintplayer-react-bootstrap/datatable/src/BsDatatable.tsx
+++ b/libs/mintplayer-react-bootstrap/datatable/src/BsDatatable.tsx
@@ -5,7 +5,6 @@ import {
   type RowEventDetail,
   type SortChangeEventDetail,
   type SelectionChangeEventDetail,
-  type TreeFetchRequestDetail,
   type TreeRowExpandDetail,
   type TreeExpandedIdsChangeDetail,
 } from '@mintplayer/web-components/datatable';
@@ -21,11 +20,12 @@ import {
  * properties (not attributes) so Sets/arrays/functions round-trip
  * correctly.
  *
- * Tree-mode lazy fetch: the WC emits `mp-datatable-fetch-request` when
- * it needs children for an expanded row (surfaced here as
- * `onFetchRequest`). The consumer resolves the request and calls
- * `setFetchResponse(parentId, response)` on the element ref to feed
- * the children back into the WC's cache.
+ * Server paging: set the `fetch` prop to a callback returning
+ * `{ data, totalRecords }`. `createComponent` forwards it to the element's
+ * `fetch` property, and the web component owns the whole loop — initial page,
+ * on-demand windows, tree children, pagination, sort/perPage reloads. The
+ * consumer wires nothing else (no `totalRecords`, no event bridge). Selected
+ * row objects arrive on `onSelectionChange`'s `detail.selectedRows`.
  */
 export const BsDatatable = createComponent({
   react: React,
@@ -39,7 +39,6 @@ export const BsDatatable = createComponent({
     onRowDblClick: 'mp-datatable-row-dblclick' as EventName<CustomEvent<RowEventDetail>>,
     onRowContextMenu: 'mp-datatable-row-contextmenu' as EventName<CustomEvent<RowEventDetail>>,
     onSelectionChange: 'mp-datatable-selection-change' as EventName<CustomEvent<SelectionChangeEventDetail>>,
-    onFetchRequest: 'mp-datatable-fetch-request' as EventName<CustomEvent<TreeFetchRequestDetail>>,
     onRowExpand: 'mp-datatable-row-expand' as EventName<CustomEvent<TreeRowExpandDetail>>,
     onRowCollapse: 'mp-datatable-row-collapse' as EventName<CustomEvent<TreeRowExpandDetail>>,
     onExpandedIdsChange: 'mp-datatable-expanded-ids-change' as EventName<CustomEvent<TreeExpandedIdsChangeDetail>>,

--- a/libs/mintplayer-react-bootstrap/package.json
+++ b/libs/mintplayer-react-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintplayer/react-bootstrap",
-  "version": "19.5.0",
+  "version": "19.6.0",
   "description": "React 19 wrappers around @mintplayer/web-components. Each sub-entry maps one-to-one with a WC sub-entry and exposes typed React components via @lit/react's createComponent.",
   "license": "MIT",
   "repository": {
@@ -28,7 +28,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@lit/react": "^1.0.0",
-    "@mintplayer/web-components": "^1.0.0"
+    "@mintplayer/web-components": "^2.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/mintplayer-vue-bootstrap/datatable/src/BsDatatable.vue
+++ b/libs/mintplayer-vue-bootstrap/datatable/src/BsDatatable.vue
@@ -61,8 +61,14 @@ const syncProps = () => {
   el.value.columns = (props.columns ?? []) as DatatableColumnDef[];
   // `fetch` and static `data` are mutually exclusive — when fetching, the WC
   // owns the rows, so don't also push `data` (it would clobber fetched pages).
-  if (props.fetch != null) el.value.fetch = props.fetch;
-  else el.value.data = props.data ?? [];
+  // When `fetch` is cleared at runtime, drop the stale callback off the WC and
+  // fall back to static `data` (otherwise the WC keeps server-paging forever).
+  if (props.fetch != null) {
+    el.value.fetch = props.fetch;
+  } else {
+    el.value.fetch = null;
+    el.value.data = props.data ?? [];
+  }
   if (props.rowKey !== undefined) el.value.rowKey = props.rowKey;
   if (props.tree !== undefined) el.value.tree = props.tree;
   if (props.idKey !== undefined) el.value.idKey = props.idKey as TreeIdKey | null;

--- a/libs/mintplayer-vue-bootstrap/datatable/src/BsDatatable.vue
+++ b/libs/mintplayer-vue-bootstrap/datatable/src/BsDatatable.vue
@@ -132,16 +132,23 @@ watch(() => props.selectionMode, syncProps);
 watch(() => props.selectionStrategy, syncProps);
 watch(() => props.selectedIds, syncProps, { deep: false });
 
-// Expose the underlying element + the two tree-mode imperative methods
-// so consumers can feed lazy-fetched children back into the WC.
+// Expose the underlying element + the imperative fetch methods so consumers
+// can feed lazy-fetched data back into the WC. `setFetchResponse` serves both
+// tree children (non-null parentId) and flat virtual windows (parentId null,
+// keyed by `response.page`). `invalidateChildren` drops the tree child cache;
+// `invalidateData` drops the flat virtual-window page cache (call it on
+// sort/settings change before refetching page 1).
 const setFetchResponse = (parentId: unknown, response: TreeFetchResponse) => {
   el.value?.setFetchResponse(parentId, response);
 };
 const invalidateChildren = (parentId?: unknown) => {
   el.value?.invalidateChildren(parentId);
 };
+const invalidateData = () => {
+  el.value?.invalidateData();
+};
 
-defineExpose({ el, setFetchResponse, invalidateChildren });
+defineExpose({ el, setFetchResponse, invalidateChildren, invalidateData });
 </script>
 
 <template>

--- a/libs/mintplayer-vue-bootstrap/datatable/src/BsDatatable.vue
+++ b/libs/mintplayer-vue-bootstrap/datatable/src/BsDatatable.vue
@@ -4,12 +4,11 @@ import '@mintplayer/web-components/datatable';
 import {
   MpDatatable,
   type DatatableColumnDef,
+  type DatatableFetch,
   type RowKey,
   type DatatableSelectionMode,
   type TreeIdKey,
   type TreeSelectionStrategy,
-  type TreeFetchRequestDetail,
-  type TreeFetchResponse,
   type TreeRowExpandDetail,
   type TreeExpandedIdsChangeDetail,
   type RowEventDetail,
@@ -27,6 +26,8 @@ defineOptions({ inheritAttrs: false });
 const props = defineProps<{
   columns?: DatatableColumnDef[];
   data?: unknown[];
+  /** Server-paged source. The WC owns the whole fetch loop; nothing else to wire. */
+  fetch?: DatatableFetch | null;
   rowKey?: RowKey;
   // Tree-mode JS-property props
   tree?: boolean;
@@ -42,7 +43,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'update:expandedIds', value: Set<unknown>): void;
   (e: 'update:selectedIds', value: string[]): void;
-  (e: 'fetchRequest', detail: TreeFetchRequestDetail): void;
   (e: 'rowExpand', detail: TreeRowExpandDetail): void;
   (e: 'rowCollapse', detail: TreeRowExpandDetail): void;
   (e: 'sortChange', detail: SortChangeEventDetail): void;
@@ -59,7 +59,10 @@ const el = ref<MpDatatable | null>(null);
 const syncProps = () => {
   if (!el.value) return;
   el.value.columns = (props.columns ?? []) as DatatableColumnDef[];
-  el.value.data = props.data ?? [];
+  // `fetch` and static `data` are mutually exclusive — when fetching, the WC
+  // owns the rows, so don't also push `data` (it would clobber fetched pages).
+  if (props.fetch != null) el.value.fetch = props.fetch;
+  else el.value.data = props.data ?? [];
   if (props.rowKey !== undefined) el.value.rowKey = props.rowKey;
   if (props.tree !== undefined) el.value.tree = props.tree;
   if (props.idKey !== undefined) el.value.idKey = props.idKey as TreeIdKey | null;
@@ -79,7 +82,6 @@ const syncProps = () => {
 // flatten to camelCase Vue events. `update:expandedIds` is the v-model
 // channel so `v-model:expandedIds` works on consumers.
 const handlers: Record<string, (e: Event) => void> = {
-  'mp-datatable-fetch-request': (e) => emit('fetchRequest', (e as CustomEvent<TreeFetchRequestDetail>).detail),
   'mp-datatable-row-expand': (e) => emit('rowExpand', (e as CustomEvent<TreeRowExpandDetail>).detail),
   'mp-datatable-row-collapse': (e) => emit('rowCollapse', (e as CustomEvent<TreeRowExpandDetail>).detail),
   'mp-datatable-expanded-ids-change': (e) => {
@@ -122,6 +124,7 @@ onBeforeUnmount(detachEvents);
 
 watch(() => props.columns, syncProps, { deep: false });
 watch(() => props.data, syncProps, { deep: false });
+watch(() => props.fetch, syncProps);
 watch(() => props.rowKey, syncProps);
 watch(() => props.tree, syncProps);
 watch(() => props.idKey, syncProps);
@@ -132,23 +135,9 @@ watch(() => props.selectionMode, syncProps);
 watch(() => props.selectionStrategy, syncProps);
 watch(() => props.selectedIds, syncProps, { deep: false });
 
-// Expose the underlying element + the imperative fetch methods so consumers
-// can feed lazy-fetched data back into the WC. `setFetchResponse` serves both
-// tree children (non-null parentId) and flat virtual windows (parentId null,
-// keyed by `response.page`). `invalidateChildren` drops the tree child cache;
-// `invalidateData` drops the flat virtual-window page cache (call it on
-// sort/settings change before refetching page 1).
-const setFetchResponse = (parentId: unknown, response: TreeFetchResponse) => {
-  el.value?.setFetchResponse(parentId, response);
-};
-const invalidateChildren = (parentId?: unknown) => {
-  el.value?.invalidateChildren(parentId);
-};
-const invalidateData = () => {
-  el.value?.invalidateData();
-};
-
-defineExpose({ el, setFetchResponse, invalidateChildren, invalidateData });
+// The WC owns the fetch loop, so there are no imperative fetch methods to
+// expose any more — just the underlying element for advanced access.
+defineExpose({ el });
 </script>
 
 <template>

--- a/libs/mintplayer-vue-bootstrap/package.json
+++ b/libs/mintplayer-vue-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintplayer/vue-bootstrap",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Vue 3.5 SFC adapters around @mintplayer/web-components. Each sub-entry maps one-to-one with a WC sub-entry and exposes typed Vue components with v-model support for input WCs.",
   "license": "MIT",
   "repository": {
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "vue": "^3.5.0",
-    "@mintplayer/web-components": "^1.7.0"
+    "@mintplayer/web-components": "^2.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/mintplayer-vue-bootstrap/package.json
+++ b/libs/mintplayer-vue-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintplayer/vue-bootstrap",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Vue 3.5 SFC adapters around @mintplayer/web-components. Each sub-entry maps one-to-one with a WC sub-entry and exposes typed Vue components with v-model support for input WCs.",
   "license": "MIT",
   "repository": {
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "vue": "^3.5.0",
-    "@mintplayer/web-components": "^1.0.0"
+    "@mintplayer/web-components": "^1.7.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
@@ -49,6 +49,10 @@ export interface SelectionChangeEventDetail {
  * In tree mode children of expanded rows are inlined as siblings with
  * `depth > 0`; not-yet-loaded children appear as placeholder entries with
  * `row: undefined` so the viewport can reserve vertical space for them.
+ *
+ * In flat virtual + external-paging mode (`isFlatWindowed()`) placeholder
+ * entries additionally carry `page` — the 1-based page the missing row belongs
+ * to — so the viewport scan can request that page without re-deriving it.
  */
 interface FlatVisibleRow {
   row: unknown | undefined;
@@ -57,6 +61,8 @@ interface FlatVisibleRow {
   parentId: unknown | null;
   isExpanded: boolean;
   isPlaceholder: boolean;
+  /** Flat-window placeholders only: the 1-based page this slot belongs to. */
+  page?: number;
 }
 
 let instanceCounter = 0;
@@ -141,6 +147,18 @@ export class MpDatatable extends LitElement {
   private _childTotals: Map<unknown, number> = new Map();
   /** Parents with an in-flight fetch; suppresses re-requests. */
   private _pendingFetches: Set<unknown> = new Set();
+
+  // ─── Flat virtual windowed-fetch state ──────────────────────────────────
+  // Flat (non-tree) virtual + external `[fetch]` is lazy and page-keyed: page 1
+  // lives in `_data` (mirroring tree roots), pages ≥ 2 are fetched on demand as
+  // their rows scroll into view and stored here. Kept separate from the tree
+  // caches because `parentId: null` already means "tree root" — the WC
+  // disambiguates by `this._tree` being false. Cleared by `invalidateData()`.
+  /** Loaded rows per 1-based page (pages ≥ 2; page 1 is `_data`). */
+  private _pageCache: Map<number, unknown[]> = new Map();
+  /** Pages with an in-flight fetch; suppresses re-requests. */
+  private _pendingPageFetches: Set<number> = new Set();
+
   /** Per-render memo of `getFlatList()`. Invalidated in `willUpdate`. */
   private _cachedFlatList: FlatVisibleRow[] | null = null;
   /** Per-render memo of the set of row keys whose loaded subtree is partially selected. */
@@ -414,6 +432,16 @@ export class MpDatatable extends LitElement {
     return this._totalRecords != null && this._totalRecords > this._data.length;
   }
 
+  /**
+   * True when flat (non-tree) virtual scrolling is driving lazy windowed
+   * fetches: the consumer pages externally and the WC pulls pages ≥ 2 on
+   * demand. When false (single page, no virtual scroll, or tree mode) the WC
+   * falls back to the trivial flat mapping of `_data`.
+   */
+  private isFlatWindowed(): boolean {
+    return this._virtualScroll && !this._tree && this.isExternallyPaged();
+  }
+
   override attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
     super.attributeChangedCallback(name, oldValue, newValue);
 
@@ -610,7 +638,7 @@ export class MpDatatable extends LitElement {
 
     // Virtual scroll: spacer rows at top and bottom.
     const virtualMeta = this.getVirtualSpacerHeights();
-    const ariaRowcount = (this._tree ? this.getFlatList().length : this._data.length) + 1;
+    const ariaRowcount = (this._tree || this.isFlatWindowed() ? this.getFlatList().length : this._data.length) + 1;
 
     return html`
       <div class="datatable-shell">
@@ -862,7 +890,9 @@ export class MpDatatable extends LitElement {
     // (real rows + placeholders); callers that need row metadata use
     // `getFlatList()` instead. We keep this method returning a `unknown[]`
     // so `_data.length`-style code paths stay valid.
-    if (this._tree) {
+    if (this._tree || this.isFlatWindowed()) {
+      // Tree: flattened forest (rows + placeholders). Flat-window: the sparse
+      // length-`totalRecords` list. Both drive the virtual-scroll row count.
       return this.getFlatList().map((r) => r.row);
     }
     let rows: unknown[] = this._data;
@@ -891,6 +921,33 @@ export class MpDatatable extends LitElement {
   private getFlatList(): FlatVisibleRow[] {
     if (this._cachedFlatList !== null) return this._cachedFlatList;
     if (!this._tree) {
+      // Flat virtual + external paging: build a sparse list of length
+      // `_totalRecords`. Loaded rows come from `_data` (page 1) and
+      // `_pageCache` (pages ≥ 2); every not-yet-loaded slot is a placeholder so
+      // the virtualizer sizes the scroll region from the true total and
+      // `maybeFetchPlaceholdersInViewport` can pull the missing pages on demand.
+      // No client sort here: `_autoSort` is false in fetch mode (the server
+      // owns ordering), so page ordering is authoritative.
+      //
+      // NOTE: this materialises one entry per total row. It is memoised per
+      // render (cleared in `willUpdate`) and the realistic totals for
+      // server-paged lists are bounded; revisit with slice-only
+      // materialisation if very large totals ever jank.
+      if (this.isFlatWindowed()) {
+        const total = this._totalRecords ?? this._data.length;
+        const perPage = Math.max(1, this._perPage);
+        const out: FlatVisibleRow[] = new Array(total);
+        for (let i = 0; i < total; i++) {
+          const page = Math.floor(i / perPage) + 1;
+          const pos = i % perPage;
+          const row = page === 1 ? this._data[pos] : this._pageCache.get(page)?.[pos];
+          out[i] = row !== undefined
+            ? { row, key: this._rowKey(row, i), depth: 0, parentId: null, isExpanded: false, isPlaceholder: false }
+            : { row: undefined, key: `__placeholder-flat-${i}`, depth: 0, parentId: null, page, isExpanded: false, isPlaceholder: true };
+        }
+        return this._cachedFlatList = out;
+      }
+
       const rows = (() => {
         let r: unknown[] = this._data;
         if (this._autoSort && this._sortColumns.length > 0) r = sortRows(r, this._sortColumns);

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
@@ -50,9 +50,11 @@ export interface SelectionChangeEventDetail {
  * `depth > 0`; not-yet-loaded children appear as placeholder entries with
  * `row: undefined` so the viewport can reserve vertical space for them.
  *
- * In flat virtual + external-paging mode (`isFlatWindowed()`) placeholder
- * entries additionally carry `page` — the 1-based page the missing row belongs
- * to — so the viewport scan can request that page without re-deriving it.
+ * In root-windowed mode (`isRootWindowed()`) unloaded **root** slots are
+ * placeholders (`parentId: null`) that additionally carry `page` — the 1-based
+ * root page the missing row belongs to — so the viewport scan can request that
+ * page without re-deriving it. (Child placeholders carry `parentId` and no
+ * `page`.)
  */
 interface FlatVisibleRow {
   row: unknown | undefined;
@@ -61,7 +63,7 @@ interface FlatVisibleRow {
   parentId: unknown | null;
   isExpanded: boolean;
   isPlaceholder: boolean;
-  /** Flat-window placeholders only: the 1-based page this slot belongs to. */
+  /** Root-window placeholders only: the 1-based root page this slot belongs to. */
   page?: number;
 }
 
@@ -433,13 +435,15 @@ export class MpDatatable extends LitElement {
   }
 
   /**
-   * True when flat (non-tree) virtual scrolling is driving lazy windowed
-   * fetches: the consumer pages externally and the WC pulls pages ≥ 2 on
-   * demand. When false (single page, no virtual scroll, or tree mode) the WC
-   * falls back to the trivial flat mapping of `_data`.
+   * True when virtual scrolling is driving lazy windowed fetches at the **root**
+   * level: the consumer pages externally and the WC pulls root pages ≥ 2 on
+   * demand. Applies to BOTH flat mode (the rows are the roots) and tree mode
+   * (the top-level rows; their children are windowed separately, keyed by
+   * parentId). When false (single page or no virtual scroll) the WC falls back
+   * to the trivial mapping of `_data`.
    */
-  private isFlatWindowed(): boolean {
-    return this._virtualScroll && !this._tree && this.isExternallyPaged();
+  private isRootWindowed(): boolean {
+    return this._virtualScroll && this.isExternallyPaged();
   }
 
   override attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
@@ -603,10 +607,12 @@ export class MpDatatable extends LitElement {
       this._virtualRange = { startIndex: start, endIndex: end };
       this.requestUpdate();
     }
-    // Lazily fetch data whose placeholder rows enter the viewport:
-    // tree-mode children (keyed by parentId) or flat-window pages (keyed by page).
+    // Lazily fetch data whose placeholder rows enter the viewport. Tree-mode
+    // children are keyed by parentId; root-window pages (flat rows, or the
+    // top level of a tree) are keyed by page. A virtual tree needs both: its
+    // roots paginate AND its expanded children load on demand.
     if (this._tree) this.maybeFetchPlaceholdersInViewport();
-    else if (this.isFlatWindowed()) this.maybeFetchPagesInViewport();
+    if (this.isRootWindowed()) this.maybeFetchPagesInViewport();
   }
 
   /**
@@ -662,7 +668,7 @@ export class MpDatatable extends LitElement {
 
     // Virtual scroll: spacer rows at top and bottom.
     const virtualMeta = this.getVirtualSpacerHeights();
-    const ariaRowcount = (this._tree || this.isFlatWindowed() ? this.getFlatList().length : this._data.length) + 1;
+    const ariaRowcount = (this._tree || this.isRootWindowed() ? this.getFlatList().length : this._data.length) + 1;
 
     return html`
       <div class="datatable-shell">
@@ -914,9 +920,9 @@ export class MpDatatable extends LitElement {
     // (real rows + placeholders); callers that need row metadata use
     // `getFlatList()` instead. We keep this method returning a `unknown[]`
     // so `_data.length`-style code paths stay valid.
-    if (this._tree || this.isFlatWindowed()) {
-      // Tree: flattened forest (rows + placeholders). Flat-window: the sparse
-      // length-`totalRecords` list. Both drive the virtual-scroll row count.
+    if (this._tree || this.isRootWindowed()) {
+      // Tree: flattened forest (rows + placeholders). Root-windowed flat: the
+      // sparse length-`totalRecords` list. Both drive the virtual-scroll count.
       return this.getFlatList().map((r) => r.row);
     }
     let rows: unknown[] = this._data;
@@ -963,7 +969,7 @@ export class MpDatatable extends LitElement {
       // perPage while the total spans multiple pages, indices past `_data`
       // would map to page 1 and never resolve (`maybeFetchPagesInViewport`
       // skips page ≤ 1) — out of contract, not handled here.
-      if (this.isFlatWindowed()) {
+      if (this.isRootWindowed()) {
         const total = this._totalRecords ?? this._data.length;
         const perPage = Math.max(1, this._perPage);
         const out: FlatVisibleRow[] = new Array(total);
@@ -997,57 +1003,62 @@ export class MpDatatable extends LitElement {
       }));
     }
 
+    // ── Tree mode ──
     const out: FlatVisibleRow[] = [];
-    const rootRows = this._autoSort && this._sortColumns.length > 0
-      ? sortRows(this._data, this._sortColumns)
-      : this._data;
+    const perPage = Math.max(1, this._perPage);
+    const sortChildren = (rows: unknown[]): unknown[] =>
+      this._autoSort && this._sortColumns.length > 0 ? sortRows(rows, this._sortColumns) : rows;
 
-    const walk = (rows: unknown[], depth: number, parentId: unknown | null): void => {
-      for (const row of rows) {
-        const id = this.extractId(row);
-        const isExpanded = id != null && this._expandedIds.has(id);
-        const childCount = this.extractChildCount(row);
-        const key = this._rowKey(row, out.length);
-        out.push({ row, key, depth, parentId, isExpanded, isPlaceholder: false });
+    // Push a real node and, when it's expanded, its loaded children followed by
+    // placeholders for any not-yet-loaded children of that parent.
+    const pushNode = (row: unknown, depth: number, parentId: unknown | null): void => {
+      const id = this.extractId(row);
+      const isExpanded = id != null && this._expandedIds.has(id);
+      const childCount = this.extractChildCount(row);
+      out.push({ row, key: this._rowKey(row, out.length), depth, parentId, isExpanded, isPlaceholder: false });
 
-        if (!isExpanded || childCount === 0 || id == null) continue;
+      if (!isExpanded || childCount === 0 || id == null) return;
 
-        const cached = this._childCache.get(id);
-        if (cached && cached.length > 0) {
-          const sortedChildren = this._autoSort && this._sortColumns.length > 0
-            ? sortRows(cached, this._sortColumns)
-            : cached;
-          walk(sortedChildren, depth + 1, id);
-          // Reserve placeholders for any not-yet-loaded children of this parent.
-          const total = this._childTotals.get(id) ?? cached.length;
-          const remaining = Math.max(0, total - cached.length);
-          for (let j = 0; j < remaining; j++) {
-            out.push({
-              row: undefined,
-              key: `__placeholder-${String(id)}-${cached.length + j}`,
-              depth: depth + 1,
-              parentId: id,
-              isExpanded: false,
-              isPlaceholder: true,
-            });
-          }
-        } else {
-          // Expanded but children not loaded yet — reserve childCount placeholders.
-          for (let j = 0; j < childCount; j++) {
-            out.push({
-              row: undefined,
-              key: `__placeholder-${String(id)}-${j}`,
-              depth: depth + 1,
-              parentId: id,
-              isExpanded: false,
-              isPlaceholder: true,
-            });
-          }
+      const cached = this._childCache.get(id);
+      if (cached && cached.length > 0) {
+        for (const child of sortChildren(cached)) pushNode(child, depth + 1, id);
+        const total = this._childTotals.get(id) ?? cached.length;
+        for (let j = 0; j < Math.max(0, total - cached.length); j++) {
+          out.push({ row: undefined, key: `__placeholder-${String(id)}-${cached.length + j}`, depth: depth + 1, parentId: id, isExpanded: false, isPlaceholder: true });
+        }
+      } else {
+        // Expanded but children not loaded yet — reserve childCount placeholders.
+        for (let j = 0; j < childCount; j++) {
+          out.push({ row: undefined, key: `__placeholder-${String(id)}-${j}`, depth: depth + 1, parentId: id, isExpanded: false, isPlaceholder: true });
         }
       }
     };
 
-    walk(rootRows, 0, null);
+    if (this.isRootWindowed()) {
+      // Roots paginate lazily, exactly like flat mode: root page 1 is `_data`,
+      // pages ≥ 2 come from `_pageCache`, and unloaded root slots are
+      // placeholders (keyed by page, parentId null) so the scroll region spans
+      // every root and scrolling pulls the missing root pages via
+      // `maybeFetchPagesInViewport`. Loaded + expanded roots still inline their
+      // children. No client sort — the server owns root ordering in fetch mode.
+      const rootTotal = this._totalRecords ?? this._data.length;
+      for (let r = 0; r < rootTotal; r++) {
+        const page = Math.floor(r / perPage) + 1;
+        const pos = r % perPage;
+        const root = page === 1 ? this._data[pos] : this._pageCache.get(page)?.[pos];
+        if (root === undefined) {
+          out.push({ row: undefined, key: `__placeholder-root-${r}`, depth: 0, parentId: null, page, isExpanded: false, isPlaceholder: true });
+        } else {
+          pushNode(root, 0, null);
+        }
+      }
+    } else {
+      const rootRows = this._autoSort && this._sortColumns.length > 0
+        ? sortRows(this._data, this._sortColumns)
+        : this._data;
+      for (const row of rootRows) pushNode(row, 0, null);
+    }
+
     return this._cachedFlatList = out;
   }
 
@@ -1241,18 +1252,19 @@ export class MpDatatable extends LitElement {
 
   /**
    * Public method called by the framework wrapper after the consumer's
-   * `[fetch]` callback resolves. Populates the cache + total for the parent,
-   * clears the pending flag, and rerenders so placeholders disappear.
+   * `[fetch]` callback resolves. Populates the cache + total, clears the
+   * pending flag, and rerenders so placeholders disappear.
    *
-   * In flat (non-tree) mode this is the flat-window page sink: `parentId` is
-   * ignored and `response.page` keys the page cache. `parentId == null` here
-   * is a flat window, NOT a tree root — the two are mutually exclusive, so the
-   * WC disambiguates by `this._tree`.
+   * `parentId == null` is a **root window** (flat rows, or the top level of a
+   * tree): `response.page` keys the page cache. Page 1 is owned by the `data`
+   * setter, so a page-1 response here is a no-op. `parentId != null` is a tree
+   * child set, keyed by parentId. Root-window vs child is decided by parentId,
+   * not by `this._tree`, so a virtual tree windows BOTH its roots and children.
    */
   public setFetchResponse(parentId: unknown | null, response: TreeFetchResponse): void {
-    if (!this._tree) {
-      // Flat virtual-window: store by page. Page 1 lives in `_data` (seeded by
-      // the wrapper's first-page fetch), so ignore it here.
+    if (parentId == null) {
+      // Root window: store by page. Page 1 lives in `_data` (seeded by the
+      // wrapper's first-page fetch), so ignore it here.
       const page = response.page;
       if (page == null || page <= 1) return;
       this._pendingPageFetches.delete(page);
@@ -1262,7 +1274,6 @@ export class MpDatatable extends LitElement {
       this.requestUpdate();
       return;
     }
-    if (parentId == null) return; // tree root-level fetches use the `data` setter directly
     this._pendingFetches.delete(parentId);
     this._childCache.set(parentId, [...response.data]);
     this._childTotals.set(parentId, response.totalRecords);

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
@@ -1274,8 +1274,9 @@ export class MpDatatable extends LitElement {
       const total = resp?.totalRecords == null ? null : Math.max(0, Math.floor(resp.totalRecords));
       if (total != null) this._totalRecords = total;
       this.requestUpdate();
-    } catch {
+    } catch (err) {
       this._pendingPageFetches.delete(page);
+      console.error('[mp-datatable] fetch failed for root page', page, err);
     }
   }
 
@@ -1294,8 +1295,9 @@ export class MpDatatable extends LitElement {
       this._childCache.set(parentId, [...(resp?.data ?? [])]);
       this._childTotals.set(parentId, resp?.totalRecords ?? (resp?.data?.length ?? 0));
       this.requestUpdate();
-    } catch {
+    } catch (err) {
       this._pendingFetches.delete(parentId);
+      console.error('[mp-datatable] fetch failed for children of', parentId, err);
     }
   }
 
@@ -1310,7 +1312,8 @@ export class MpDatatable extends LitElement {
     let resp: { data?: unknown[]; totalRecords?: number } | undefined;
     try {
       resp = await this._fetch({ parentId: null, page, perPage: this._perPage, sortColumns: [...this._sortColumns] });
-    } catch {
+    } catch (err) {
+      console.error('[mp-datatable] fetch failed for page', page, err);
       return;
     }
     if (generation !== this._fetchGeneration || !this._fetch) return;

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
@@ -949,7 +949,7 @@ export class MpDatatable extends LitElement {
       // `_totalRecords`. Loaded rows come from `_data` (page 1) and
       // `_pageCache` (pages ≥ 2); every not-yet-loaded slot is a placeholder so
       // the virtualizer sizes the scroll region from the true total and
-      // `maybeFetchPlaceholdersInViewport` can pull the missing pages on demand.
+      // `maybeFetchPagesInViewport` can pull the missing pages on demand.
       // No client sort here: `_autoSort` is false in fetch mode (the server
       // owns ordering), so page ordering is authoritative.
       //
@@ -957,6 +957,12 @@ export class MpDatatable extends LitElement {
       // render (cleared in `willUpdate`) and the realistic totals for
       // server-paged lists are bounded; revisit with slice-only
       // materialisation if very large totals ever jank.
+      //
+      // Page 1 is assumed to fill `_data` to `perPage` rows (the `[fetch]`
+      // contract honours the requested perPage). If a server caps page 1 below
+      // perPage while the total spans multiple pages, indices past `_data`
+      // would map to page 1 and never resolve (`maybeFetchPagesInViewport`
+      // skips page ≤ 1) — out of contract, not handled here.
       if (this.isFlatWindowed()) {
         const total = this._totalRecords ?? this._data.length;
         const perPage = Math.max(1, this._perPage);

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
@@ -11,8 +11,7 @@ import type {
   RowKey,
   RowRenderer,
   RowRenderContext,
-  TreeFetchRequestDetail,
-  TreeFetchResponse,
+  DatatableFetch,
   TreeRowExpandDetail,
   TreeExpandedIdsChangeDetail,
   TreeIdKey,
@@ -39,8 +38,16 @@ export interface SortChangeEventDetail {
   sortColumns: SortColumn[];
 }
 
-export interface SelectionChangeEventDetail {
+export interface SelectionChangeEventDetail<T = unknown> {
   selectedIds: string[];
+  /**
+   * The selected row objects, resolved from the WC's loaded data (page 1 +
+   * fetched windows + tree children). Since the WC owns the data when fetching,
+   * consumers can't resolve ids → rows themselves — this is how a consumer gets
+   * the actual selected records. An id whose row isn't currently loaded is
+   * omitted (shouldn't happen: you can only select a row you can see).
+   */
+  selectedRows: T[];
 }
 
 /**
@@ -161,6 +168,23 @@ export class MpDatatable extends LitElement {
   /** Pages with an in-flight fetch; suppresses re-requests. */
   private _pendingPageFetches: Set<number> = new Set();
 
+  // ─── High-level fetch-callback ownership ────────────────────────────────
+  // When `_fetch` is set, the WC owns the whole server-paged loop: it calls the
+  // callback for page 1, every window, every tree child, every page change, and
+  // reloads on sort/perPage — deriving totalRecords from the response. The
+  // existing `mp-datatable-fetch-request` event + `setFetchResponse` remain the
+  // lower-level path used when no callback is provided; when one is, the WC
+  // self-handles its own event so the same cache code is reused, not duplicated.
+  private _fetch: DatatableFetch | null = null;
+  /** Bumped on invalidation; in-flight responses from an older generation are dropped. */
+  private _fetchGeneration = 0;
+  /** Guards the one-time initial page-1 load. Reset by `invalidateData`. */
+  private _initialFetchDone = false;
+  /** Coalesces multiple setter calls in one flush into a single reload. */
+  private _reloadScheduled = false;
+  /** Last loaded {sort,perPage,page} signature — echoes with the same key skip. */
+  private _lastReloadKey: string | null = null;
+
   /** Per-render memo of `getFlatList()`. Invalidated in `willUpdate`. */
   private _cachedFlatList: FlatVisibleRow[] | null = null;
   /** Per-render memo of the set of row keys whose loaded subtree is partially selected. */
@@ -240,12 +264,34 @@ export class MpDatatable extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * High-level fetch callback. When set, the WC owns the entire server-paged
+   * loop and the consumer provides nothing else — no page-1 seeding via `data`,
+   * no separate `totalRecords`, no event bridge. Works with any framework or
+   * none (`el.fetch = fn`). Setting it kicks off the initial page-1 load.
+   */
+  get fetch(): DatatableFetch | null {
+    return this._fetch;
+  }
+  set fetch(value: DatatableFetch | null) {
+    this._fetch = typeof value === 'function' ? value : null;
+    if (this._fetch) {
+      // The server owns sorting/paging when fetching; never client-sort.
+      this._autoSort = false;
+      // (Re)seed from the callback. New callback ⇒ fresh data.
+      this._initialFetchDone = false;
+      this._lastReloadKey = null;
+      this.scheduleFetchReload();
+    }
+  }
+
   get sortColumns(): SortColumn[] {
     return [...this._sortColumns];
   }
   set sortColumns(value: SortColumn[]) {
     this._sortColumns = Array.isArray(value) ? [...value] : [];
     this.requestUpdate();
+    this.scheduleFetchReload(); // no-op unless `fetch` is set; coalesced + echo-deduped
   }
 
   get selectionMode(): DatatableSelectionMode {
@@ -390,6 +436,7 @@ export class MpDatatable extends LitElement {
     if (this._page !== next) {
       this._page = next;
       this.requestUpdate();
+      this.scheduleFetchReload(); // non-virtual page change → fetch that page (coalesced)
     }
   }
 
@@ -402,6 +449,7 @@ export class MpDatatable extends LitElement {
       this._perPage = next;
       this._page = 1;
       this.requestUpdate();
+      this.scheduleFetchReload();
     }
   }
 
@@ -414,19 +462,12 @@ export class MpDatatable extends LitElement {
   }
 
   /**
-   * Caller-supplied total record count for external paging. Set this when
-   * `[fetch]` returns one page at a time so the pagination footer can show
-   * the correct total. Leave as `null` (default) to use `_data.length`.
+   * Read-only grand total. Derived by the WC from the `fetch` response (server
+   * paging) or `_data.length` (static data) — consumers never set it. Exposed
+   * so a consumer can render "row X of N" if it wants.
    */
   get totalRecords(): number | null {
     return this._totalRecords;
-  }
-  set totalRecords(value: number | null) {
-    const next = value == null ? null : Math.max(0, Math.floor(value));
-    if (this._totalRecords !== next) {
-      this._totalRecords = next;
-      this.requestUpdate();
-    }
   }
 
   /** True when the consumer is paging externally (totalRecords exceeds the in-memory rows). */
@@ -631,7 +672,7 @@ export class MpDatatable extends LitElement {
       if (this._childCache.has(r.parentId) || this._pendingFetches.has(r.parentId)) continue;
       toFetch.add(r.parentId);
     }
-    for (const parentId of toFetch) this.requestChildrenFetch(parentId);
+    for (const parentId of toFetch) void this.fetchChildren(parentId);
   }
 
   /**
@@ -653,7 +694,7 @@ export class MpDatatable extends LitElement {
       if (this._pageCache.has(r.page) || this._pendingPageFetches.has(r.page)) continue;
       toFetch.add(r.page);
     }
-    for (const page of toFetch) this.requestPageFetch(page);
+    for (const page of toFetch) void this.fetchWindowPage(page);
   }
 
   override render(): TemplateResult {
@@ -898,6 +939,7 @@ export class MpDatatable extends LitElement {
     this._perPage = next;
     this._page = 1;
     this.requestUpdate();
+    this.scheduleFetchReload();
     this.dispatchEvent(
       new CustomEvent<{ perPage: number }>('mp-datatable-per-page-change', {
         detail: { perPage: next },
@@ -1183,10 +1225,10 @@ export class MpDatatable extends LitElement {
           composed: true,
         }),
       );
-      // Fire a fetch request if the consumer hasn't already populated the cache.
+      // Lazily load this node's children if not already cached / in-flight.
       const cc = this.extractChildCount(row);
       if (cc > 0 && !this._childCache.has(id) && !this._pendingFetches.has(id)) {
-        this.requestChildrenFetch(id);
+        void this.fetchChildren(id);
       }
     } else {
       this.dispatchEvent(
@@ -1212,97 +1254,101 @@ export class MpDatatable extends LitElement {
     );
   }
 
-  /** Emit a fetch-request event the wrapper will bridge to the consumer's `[fetch]`. */
-  private requestChildrenFetch(parentId: unknown | null): void {
-    if (parentId != null) this._pendingFetches.add(parentId);
-    this.dispatchEvent(
-      new CustomEvent<TreeFetchRequestDetail>('mp-datatable-fetch-request', {
-        detail: {
-          parentId,
-          page: 1,
-          perPage: this._perPage,
-          sortColumns: [...this._sortColumns],
-        },
-        bubbles: true,
-        composed: true,
-      }),
-    );
-  }
+  // ─── Fetch-callback driver (the WC owns the whole server-paged loop) ─────
 
   /**
-   * Flat-window counterpart of `requestChildrenFetch`: emit a fetch-request for
-   * a specific page (≥ 2). `parentId: null` + a real `page` is the wire shape
-   * the wrapper bridges to `[fetch]({ page, perPage, sortColumns })`.
+   * Fetch a windowed root page (≥ 2) into the page cache. Called when a root
+   * placeholder scrolls into view. Keyed on the requested page, so a server
+   * that echoes a different page number can't deadlock the window.
+   * Generation-guarded against responses that land after an invalidation.
    */
-  private requestPageFetch(page: number): void {
+  private async fetchWindowPage(page: number): Promise<void> {
+    if (!this._fetch || page <= 1) return;
     this._pendingPageFetches.add(page);
-    this.dispatchEvent(
-      new CustomEvent<TreeFetchRequestDetail>('mp-datatable-fetch-request', {
-        detail: {
-          parentId: null,
-          page,
-          perPage: this._perPage,
-          sortColumns: [...this._sortColumns],
-        },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    const generation = this._fetchGeneration;
+    try {
+      const resp = await this._fetch({ parentId: null, page, perPage: this._perPage, sortColumns: [...this._sortColumns] });
+      if (generation !== this._fetchGeneration || !this._fetch) return;
+      this._pendingPageFetches.delete(page);
+      this._pageCache.set(page, [...(resp?.data ?? [])]);
+      const total = resp?.totalRecords == null ? null : Math.max(0, Math.floor(resp.totalRecords));
+      if (total != null) this._totalRecords = total;
+      this.requestUpdate();
+    } catch {
+      this._pendingPageFetches.delete(page);
+    }
   }
 
   /**
-   * Public method called by the framework wrapper after the consumer's
-   * `[fetch]` callback resolves. Populates the cache + total, clears the
-   * pending flag, and rerenders so placeholders disappear.
-   *
-   * `parentId == null` is a **root window** (flat rows, or the top level of a
-   * tree): `response.page` keys the page cache. Page 1 is owned by the `data`
-   * setter, so a page-1 response here is a no-op. `parentId != null` is a tree
-   * child set, keyed by parentId. Root-window vs child is decided by parentId,
-   * not by `this._tree`, so a virtual tree windows BOTH its roots and children.
+   * Fetch a node's children into the child cache. Called on expand or when a
+   * child placeholder scrolls into view. Generation-guarded.
    */
-  public setFetchResponse(parentId: unknown | null, response: TreeFetchResponse): void {
-    if (parentId == null) {
-      // Root window: store by page. Page 1 lives in `_data` (seeded by the
-      // wrapper's first-page fetch), so ignore it here.
-      const page = response.page;
-      if (page == null || page <= 1) return;
-      this._pendingPageFetches.delete(page);
-      this._pageCache.set(page, [...response.data]);
-      const total = response.totalRecords == null ? null : Math.max(0, Math.floor(response.totalRecords));
-      if (total != null && total !== this._totalRecords) this._totalRecords = total;
+  private async fetchChildren(parentId: unknown): Promise<void> {
+    if (!this._fetch || parentId == null) return;
+    this._pendingFetches.add(parentId);
+    const generation = this._fetchGeneration;
+    try {
+      const resp = await this._fetch({ parentId, page: 1, perPage: this._perPage, sortColumns: [...this._sortColumns] });
+      if (generation !== this._fetchGeneration || !this._fetch) return;
+      this._pendingFetches.delete(parentId);
+      this._childCache.set(parentId, [...(resp?.data ?? [])]);
+      this._childTotals.set(parentId, resp?.totalRecords ?? (resp?.data?.length ?? 0));
       this.requestUpdate();
+    } catch {
+      this._pendingFetches.delete(parentId);
+    }
+  }
+
+  /**
+   * Fetch a single page of roots and make it the page-1 data (initial load and
+   * non-virtual pagination). The grand total is read from the response —
+   * consumers never set `totalRecords`. Generation-guarded against stale loads.
+   */
+  private async loadPage(page: number): Promise<void> {
+    if (!this._fetch) return;
+    const generation = this._fetchGeneration;
+    let resp: { data?: unknown[]; totalRecords?: number } | undefined;
+    try {
+      resp = await this._fetch({ parentId: null, page, perPage: this._perPage, sortColumns: [...this._sortColumns] });
+    } catch {
       return;
     }
-    this._pendingFetches.delete(parentId);
-    this._childCache.set(parentId, [...response.data]);
-    this._childTotals.set(parentId, response.totalRecords);
+    if (generation !== this._fetchGeneration || !this._fetch) return;
+    this._data = [...(resp?.data ?? [])];
+    const total = resp?.totalRecords == null ? null : Math.max(0, Math.floor(resp.totalRecords));
+    this._totalRecords = total;
+    this._initialFetchDone = true;
     this.requestUpdate();
   }
 
-  /** Drop cached children for one parent (or all). Used on sort change / refresh. */
-  public invalidateChildren(parentId?: unknown): void {
-    if (parentId === undefined) {
+  /**
+   * Coalesce sort/perPage/page changes (which arrive both as user actions and
+   * as echoed property pushes) into a single reload. A microtask debounces the
+   * burst; a `{sort,perPage,page}` change-key skips echoes that didn't actually
+   * change anything.
+   */
+  private scheduleFetchReload(): void {
+    if (!this._fetch || this._reloadScheduled) return;
+    this._reloadScheduled = true;
+    queueMicrotask(() => {
+      this._reloadScheduled = false;
+      if (!this._fetch) return;
+      const key = JSON.stringify({
+        s: this._sortColumns,
+        pp: this._perPage,
+        p: this._virtualScroll ? 1 : this._page,
+      });
+      if (this._initialFetchDone && key === this._lastReloadKey) return; // echo, no real change
+      this._lastReloadKey = key;
+      // New sort/perPage/page ⇒ the cached windows + children are stale.
+      this._fetchGeneration++;
+      this._pageCache.clear();
+      this._pendingPageFetches.clear();
       this._childCache.clear();
       this._childTotals.clear();
       this._pendingFetches.clear();
-    } else {
-      this._childCache.delete(parentId);
-      this._childTotals.delete(parentId);
-      this._pendingFetches.delete(parentId);
-    }
-    this.requestUpdate();
-  }
-
-  /**
-   * Drop the flat virtual-window page cache + in-flight set. Called by the
-   * wrapper on sort/settings change before refetching page 1, so stale pages
-   * don't survive a re-sort (mirrors `invalidateChildren` for tree mode).
-   */
-  public invalidateData(): void {
-    this._pageCache.clear();
-    this._pendingPageFetches.clear();
-    this.requestUpdate();
+      void this.loadPage(this._virtualScroll ? 1 : this._page);
+    });
   }
 
   /** Keyboard handling on a tree-mode row. Arrow keys + Enter/Space toggle expansion. */
@@ -1335,7 +1381,9 @@ export class MpDatatable extends LitElement {
     if (target.closest('.resize-handle')) return;
     const next = computeNextSort(this._sortColumns, col.name, ev.shiftKey);
     this._sortColumns = next;
+    this._page = 1; // a new sort returns to the first page
     this.requestUpdate();
+    this.scheduleFetchReload(); // re-fetch from page 1 under the new sort (if fetching)
     this.dispatchEvent(
       new CustomEvent<SortChangeEventDetail>('mp-datatable-sort-change', {
         detail: { sortColumns: next },
@@ -1460,13 +1508,31 @@ export class MpDatatable extends LitElement {
   }
 
   private emitSelectionChange(): void {
+    const ids = [...this._selectedIds];
     this.dispatchEvent(
       new CustomEvent<SelectionChangeEventDetail>('mp-datatable-selection-change', {
-        detail: { selectedIds: [...this._selectedIds] },
+        detail: { selectedIds: ids, selectedRows: this.resolveRows(ids) },
         bubbles: true,
         composed: true,
       }),
     );
+  }
+
+  /**
+   * Resolve row keys → row objects across every loaded source (page-1 `_data`,
+   * fetched windows in `_pageCache`, tree children in `_childCache`). One pass
+   * builds a key→row index; unresolvable ids are skipped.
+   */
+  private resolveRows(ids: string[]): unknown[] {
+    if (ids.length === 0) return [];
+    const byKey = new Map<string, unknown>();
+    const index = (rows: unknown[]): void => {
+      for (const row of rows) byKey.set(this._rowKey(row, -1), row);
+    };
+    index(this._data);
+    for (const rows of this._pageCache.values()) index(rows);
+    for (const rows of this._childCache.values()) index(rows);
+    return ids.map((id) => byKey.get(id)).filter((row): row is unknown => row !== undefined);
   }
 
   private gotoPage(page: number): void {
@@ -1474,6 +1540,7 @@ export class MpDatatable extends LitElement {
     const totalPages = Math.max(1, Math.ceil(denominator / this._perPage));
     this._page = Math.max(1, Math.min(totalPages, page));
     this.requestUpdate();
+    this.scheduleFetchReload(); // non-virtual page change → fetch that page (if fetching)
     this.dispatchEvent(
       new CustomEvent<{ page: number }>('mp-datatable-page-change', {
         detail: { page: this._page },

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.ts
@@ -603,8 +603,10 @@ export class MpDatatable extends LitElement {
       this._virtualRange = { startIndex: start, endIndex: end };
       this.requestUpdate();
     }
-    // Tree-mode: lazily fetch children whose placeholder rows enter the viewport.
+    // Lazily fetch data whose placeholder rows enter the viewport:
+    // tree-mode children (keyed by parentId) or flat-window pages (keyed by page).
     if (this._tree) this.maybeFetchPlaceholdersInViewport();
+    else if (this.isFlatWindowed()) this.maybeFetchPagesInViewport();
   }
 
   /**
@@ -624,6 +626,28 @@ export class MpDatatable extends LitElement {
       toFetch.add(r.parentId);
     }
     for (const parentId of toFetch) this.requestChildrenFetch(parentId);
+  }
+
+  /**
+   * Flat-window counterpart of `maybeFetchPlaceholdersInViewport`: scan the
+   * visible range for flat placeholder rows, collect the distinct pages they
+   * belong to that aren't cached or already in-flight, and request each once.
+   * Page 1 is never requested here — it lives in `_data` (seeded by the
+   * wrapper's first-page fetch).
+   */
+  private maybeFetchPagesInViewport(): void {
+    const list = this.getFlatList();
+    const { startIndex, endIndex } = this._virtualRange;
+    const lo = this._virtualScroll ? startIndex : 0;
+    const hi = this._virtualScroll ? endIndex : list.length;
+    const toFetch = new Set<number>();
+    for (let i = lo; i < hi; i++) {
+      const r = list[i];
+      if (!r.isPlaceholder || r.page == null || r.page <= 1) continue;
+      if (this._pageCache.has(r.page) || this._pendingPageFetches.has(r.page)) continue;
+      toFetch.add(r.page);
+    }
+    for (const page of toFetch) this.requestPageFetch(page);
   }
 
   override render(): TemplateResult {
@@ -1189,12 +1213,50 @@ export class MpDatatable extends LitElement {
   }
 
   /**
+   * Flat-window counterpart of `requestChildrenFetch`: emit a fetch-request for
+   * a specific page (≥ 2). `parentId: null` + a real `page` is the wire shape
+   * the wrapper bridges to `[fetch]({ page, perPage, sortColumns })`.
+   */
+  private requestPageFetch(page: number): void {
+    this._pendingPageFetches.add(page);
+    this.dispatchEvent(
+      new CustomEvent<TreeFetchRequestDetail>('mp-datatable-fetch-request', {
+        detail: {
+          parentId: null,
+          page,
+          perPage: this._perPage,
+          sortColumns: [...this._sortColumns],
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
    * Public method called by the framework wrapper after the consumer's
    * `[fetch]` callback resolves. Populates the cache + total for the parent,
    * clears the pending flag, and rerenders so placeholders disappear.
+   *
+   * In flat (non-tree) mode this is the flat-window page sink: `parentId` is
+   * ignored and `response.page` keys the page cache. `parentId == null` here
+   * is a flat window, NOT a tree root — the two are mutually exclusive, so the
+   * WC disambiguates by `this._tree`.
    */
   public setFetchResponse(parentId: unknown | null, response: TreeFetchResponse): void {
-    if (parentId == null) return; // root-level fetches use the `data` setter directly
+    if (!this._tree) {
+      // Flat virtual-window: store by page. Page 1 lives in `_data` (seeded by
+      // the wrapper's first-page fetch), so ignore it here.
+      const page = response.page;
+      if (page == null || page <= 1) return;
+      this._pendingPageFetches.delete(page);
+      this._pageCache.set(page, [...response.data]);
+      const total = response.totalRecords == null ? null : Math.max(0, Math.floor(response.totalRecords));
+      if (total != null && total !== this._totalRecords) this._totalRecords = total;
+      this.requestUpdate();
+      return;
+    }
+    if (parentId == null) return; // tree root-level fetches use the `data` setter directly
     this._pendingFetches.delete(parentId);
     this._childCache.set(parentId, [...response.data]);
     this._childTotals.set(parentId, response.totalRecords);
@@ -1212,6 +1274,17 @@ export class MpDatatable extends LitElement {
       this._childTotals.delete(parentId);
       this._pendingFetches.delete(parentId);
     }
+    this.requestUpdate();
+  }
+
+  /**
+   * Drop the flat virtual-window page cache + in-flight set. Called by the
+   * wrapper on sort/settings change before refetching page 1, so stale pages
+   * don't survive a re-sort (mirrors `invalidateChildren` for tree mode).
+   */
+  public invalidateData(): void {
+    this._pageCache.clear();
+    this._pendingPageFetches.clear();
     this.requestUpdate();
   }
 

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
@@ -1,291 +1,221 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import './mp-datatable';
 import { MpDatatable } from './mp-datatable';
-import type { DatatableColumnDef } from '../types';
+import type {
+  DatatableColumnDef,
+  DatatableFetch,
+  DatatableFetchRequest,
+  SelectionChangeEventDetail,
+} from '../types';
+
+// These tests use the web component with NO framework — just
+// `document.createElement('mp-datatable')` + `el.fetch = fn`. That is exactly
+// the vanilla / Rollup usage contract: one callback, nothing else.
 
 interface Row {
   id: number;
   name: string;
+  childCount?: number;
 }
 
 const columns: DatatableColumnDef<Row>[] = [
   { name: 'name', label: 'Name', cellRenderer: (r) => r.name },
 ];
 
-function makePage(page: number, perPage: number): Row[] {
-  // 1-based page; ids are globally unique so rowKey (default `id`) is stable.
-  return Array.from({ length: perPage }, (_, i) => {
-    const id = (page - 1) * perPage + i + 1;
-    return { id, name: `p${page}-${i}` };
-  });
-}
+const makeRows = (page: number, perPage: number, total: number): Row[] => {
+  const start = (page - 1) * perPage;
+  return Array.from({ length: Math.max(0, Math.min(perPage, total - start)) }, (_, i) => ({
+    id: start + i + 1,
+    name: `r${start + i + 1}`,
+  }));
+};
 
-/**
- * Build a flat virtual + external-paging datatable: page 1 seeded into `data`,
- * `totalRecords` larger than one page so `isFlatWindowed()` is true. jsdom does
- * no layout (`clientHeight === 0`), so `refreshVirtualRange` lands a viewport of
- * `[0, virtualBuffer * 2)` on first render — with `perPage` of 10 and a buffer
- * of 10 that covers pages 1 and 2, which is exactly what these tests exercise.
- */
-async function makeWindowed(opts: {
-  totalRecords: number;
-  perPage: number;
-  page1?: Row[];
-  onRequest?: (detail: { parentId: unknown; page: number; perPage: number }) => void;
-}): Promise<MpDatatable> {
-  const el = document.createElement('mp-datatable') as MpDatatable;
-  el.columns = columns as DatatableColumnDef[];
-  el.virtualScroll = true;
-  el.perPage = opts.perPage;
-  el.autoSort = false; // fetch mode: server owns ordering
-  el.data = (opts.page1 ?? makePage(1, opts.perPage)) as unknown[];
-  el.totalRecords = opts.totalRecords;
-  if (opts.onRequest) {
-    el.addEventListener('mp-datatable-fetch-request', (ev) => {
-      opts.onRequest!((ev as CustomEvent).detail);
-    });
-  }
-  document.body.appendChild(el);
+/** Flush the WC's reload microtask + async fetch, then settle the render. */
+const flush = async (el: MpDatatable): Promise<void> => {
   await el.updateComplete;
-  return el;
-}
+  await new Promise((r) => setTimeout(r));
+  await el.updateComplete;
+};
 
 function placeholderCount(el: MpDatatable): number {
   return el.shadowRoot!.querySelectorAll('tbody tr[data-placeholder="true"]').length;
 }
-
 function realRowCount(el: MpDatatable): number {
   return el.shadowRoot!.querySelectorAll('tbody tr[data-placeholder="false"]').length;
 }
 
-describe('mp-datatable — flat virtual windowed fetch', () => {
+/**
+ * Create a fetch-driven table. `latch:false` makes the fetch resolve
+ * immediately; `latch:true` returns promises you resolve manually via
+ * `release()` (so placeholders can be observed before data arrives).
+ */
+function setup(opts: {
+  total: number;
+  perPage: number;
+  tree?: boolean;
+  latch?: boolean;
+}): {
+  el: MpDatatable;
+  calls: DatatableFetchRequest[];
+  release: () => Promise<void>;
+} {
+  const calls: DatatableFetchRequest[] = [];
+  const pending: Array<() => void> = [];
+  const fetchFn: DatatableFetch<Row> = (req) => {
+    calls.push({ ...req });
+    const make = () => {
+      if (req.parentId == null) {
+        // Roots / flat windows. In tree mode give roots a child count so
+        // expansion reserves child placeholders (which triggers a child fetch).
+        const rows = makeRows(req.page, req.perPage, opts.total);
+        const data = opts.tree ? rows.map((r) => ({ ...r, childCount: 2 })) : rows;
+        return { data, totalRecords: opts.total };
+      }
+      return { data: [{ id: 10000 + Number(req.parentId), name: `child-of-${String(req.parentId)}` }], totalRecords: 2 };
+    };
+    // Page 1 always resolves immediately (the total must be known before any
+    // windowing/placeholders exist); only pages ≥ 2 latch when requested.
+    return opts.latch && req.parentId == null && req.page > 1
+      ? new Promise<{ data: Row[]; totalRecords: number }>((res) => pending.push(() => res(make())))
+      : Promise.resolve(make());
+  };
+
+  const el = document.createElement('mp-datatable') as MpDatatable;
+  el.columns = columns as DatatableColumnDef[];
+  el.virtualScroll = true;
+  el.perPage = opts.perPage;
+  if (opts.tree) {
+    el.tree = true;
+    el.idKey = 'id';
+    el.childCountKey = 'childCount';
+  }
+  el.fetch = fetchFn as DatatableFetch;
+  document.body.appendChild(el);
+
+  return {
+    el,
+    calls,
+    release: async () => {
+      pending.splice(0).forEach((r) => r());
+      await flush(el);
+    },
+  };
+}
+
+describe('mp-datatable — fetch-callback (vanilla, no framework)', () => {
   let el: MpDatatable | undefined;
   afterEach(() => {
     el?.remove();
     el = undefined;
   });
 
-  it('renders placeholders for unloaded pages and sizes aria-rowcount from totalRecords', async () => {
-    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
+  it('loads page 1 from `fetch` alone — no data/totalRecords wiring', async () => {
+    const h = setup({ total: 50, perPage: 10 });
+    el = h.el;
+    await flush(el);
 
-    // Viewport is [0, 20): page 1 (indices 0-9, in `data`) is real, page 2
-    // (indices 10-19, not yet fetched) is placeholders.
-    expect(realRowCount(el)).toBe(10);
-    expect(placeholderCount(el)).toBe(10);
+    // Page 1 fetched with parentId null; rows rendered.
+    expect(h.calls[0]).toMatchObject({ parentId: null, page: 1, perPage: 10 });
+    expect(realRowCount(el)).toBeGreaterThanOrEqual(10);
+  });
 
-    // Scrollbar/structure sized from the full total, not the 10 loaded rows.
+  it('derives totalRecords from the response (consumer never sets it)', async () => {
+    const h = setup({ total: 50, perPage: 10 });
+    el = h.el;
+    await flush(el);
+    expect(el.totalRecords).toBe(50);
     const table = el.shadowRoot!.querySelector('table')!;
     expect(table.getAttribute('aria-rowcount')).toBe('51'); // 50 + header
   });
 
-  it('requests exactly the viewport pages on demand and dedups in-flight pages', async () => {
-    const requested: number[] = [];
-    el = await makeWindowed({
-      totalRecords: 50,
-      perPage: 10,
-      onRequest: (d) => requested.push(d.page),
-    });
+  it('fetches only the viewport pages on demand, and dedups them', async () => {
+    const h = setup({ total: 50, perPage: 10 });
+    el = h.el;
+    await flush(el);
 
-    // Page 2 is the only unloaded page in the viewport — page 1 is in `data`,
-    // pages 3-5 are below the fold and must NOT be fetched.
-    expect(requested).toEqual([2]);
+    const pages = h.calls.filter((c) => c.parentId == null).map((c) => c.page).sort((a, b) => a - b);
+    // Page 1 (initial) + page 2 (in the jsdom viewport [0,20)); pages 3-5 below the fold.
+    expect(pages).toEqual([1, 2]);
 
-    // A second scan (scroll jitter; scrollTop stays 0 in jsdom) must not
-    // re-request page 2 — it's already in `_pendingPageFetches`.
+    // A second scan (scroll jitter) must not re-request page 2.
     const scroll = el.shadowRoot!.querySelector('.datatable-scroll')!;
     scroll.dispatchEvent(new Event('scroll'));
-    await el.updateComplete;
-    expect(requested).toEqual([2]);
+    await flush(el);
+    expect(h.calls.filter((c) => c.parentId == null && c.page === 2)).toHaveLength(1);
   });
 
-  it('carries parentId:null + the requested page/perPage on the fetch-request', async () => {
-    let detail: { parentId: unknown; page: number; perPage: number } | undefined;
-    el = await makeWindowed({ totalRecords: 50, perPage: 10, onRequest: (d) => (detail = d) });
-    expect(detail).toBeDefined();
-    expect(detail!.parentId).toBeNull();
-    expect(detail!.page).toBe(2);
-    expect(detail!.perPage).toBe(10);
-  });
-
-  it('setFetchResponse(null, …) fills a page and clears its placeholders', async () => {
-    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
+  it('renders placeholders for not-yet-resolved windows, then real rows', async () => {
+    const h = setup({ total: 50, perPage: 10, latch: true });
+    el = h.el;
+    await flush(el);
+    // Page 1 resolved (10 real rows); page 2 is in flight → its slots are
+    // placeholders in the viewport [0,20).
+    expect(realRowCount(el)).toBe(10);
     expect(placeholderCount(el)).toBe(10);
 
-    el.setFetchResponse(null, {
-      data: makePage(2, 10) as unknown[],
-      totalRecords: 50,
-      page: 2,
-      perPage: 10,
-    });
-    await el.updateComplete;
-
-    // Page 2 is now loaded — the whole visible window [0,20) is real rows.
-    expect(placeholderCount(el)).toBe(0);
+    await h.release();
+    // Page 2 resolved → the whole visible window is real rows.
     expect(realRowCount(el)).toBe(20);
-  });
-
-  it('keys the page cache on response.page, ignoring page 1 (page 1 lives in data)', async () => {
-    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
-
-    // A stray page-1 response is a no-op: page 1 is owned by the `data` setter.
-    el.setFetchResponse(null, {
-      data: [{ id: 999, name: 'bogus' }] as unknown[],
-      totalRecords: 50,
-      page: 1,
-      perPage: 10,
-    });
-    await el.updateComplete;
-    expect(el.shadowRoot!.textContent).not.toContain('bogus');
-  });
-
-  it('invalidateData() clears the page cache so placeholders reappear', async () => {
-    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
-    el.setFetchResponse(null, {
-      data: makePage(2, 10) as unknown[],
-      totalRecords: 50,
-      page: 2,
-      perPage: 10,
-    });
-    await el.updateComplete;
     expect(placeholderCount(el)).toBe(0);
-
-    el.invalidateData();
-    await el.updateComplete;
-    expect(placeholderCount(el)).toBe(10); // page 2 reverted to placeholders
   });
 
-  it('re-fetches the visible window after invalidateData without needing a scroll', async () => {
-    // Parity with the old VirtualDatatableDataSource.reset(): invalidation must
-    // re-request the currently-visible pages on the next render (driven by
-    // updated() → refreshVirtualRange), not wait for the next scroll event.
-    const requested: number[] = [];
-    el = await makeWindowed({
-      totalRecords: 50,
-      perPage: 10,
-      onRequest: (d) => requested.push(d.page),
-    });
-    el.setFetchResponse(null, {
-      data: makePage(2, 10) as unknown[],
-      totalRecords: 50,
-      page: 2,
-      perPage: 10,
-    });
-    await el.updateComplete;
-    expect(requested).toEqual([2]); // initial request only
+  it('reloads from page 1 under the new sort when a sort header is clicked', async () => {
+    const h = setup({ total: 50, perPage: 10 });
+    el = h.el;
+    await flush(el);
+    const before = h.calls.length;
 
-    el.invalidateData();
-    await el.updateComplete;
-    // Page 2 is visible and no longer cached/pending → requested again.
-    expect(requested).toEqual([2, 2]);
+    const th = el.shadowRoot!.querySelector('th[data-column="name"]') as HTMLElement;
+    th.click();
+    await flush(el);
+
+    const after = h.calls.slice(before).filter((c) => c.parentId == null);
+    expect(after.some((c) => c.page === 1 && c.sortColumns.length > 0)).toBe(true);
   });
 
-  it('does not window a single-page list (totalRecords ≤ data.length)', async () => {
-    const onlyPage = makePage(1, 5);
-    const requested: number[] = [];
-    el = await makeWindowed({
-      totalRecords: 5,
-      perPage: 10,
-      page1: onlyPage,
-      onRequest: (d) => requested.push(d.page),
+  it('emits selected ROW objects, not just ids', async () => {
+    const h = setup({ total: 50, perPage: 10 });
+    el = h.el;
+    el.selectionMode = 'multiple';
+    await flush(el);
+
+    let detail: SelectionChangeEventDetail<Row> | undefined;
+    el.addEventListener('mp-datatable-selection-change', (e) => {
+      detail = (e as CustomEvent<SelectionChangeEventDetail<Row>>).detail;
     });
 
-    // Not externally paged → trivial flat mapping, no placeholders, no fetches.
-    expect(placeholderCount(el)).toBe(0);
-    expect(realRowCount(el)).toBe(5);
-    expect(requested).toEqual([]);
+    const firstCheckbox = el.shadowRoot!.querySelector('tbody tr[data-placeholder="false"] mp-checkbox') as HTMLElement;
+    firstCheckbox?.dispatchEvent(new CustomEvent('change', { detail: { checked: true }, bubbles: true, composed: true }));
+    await flush(el);
+
+    expect(detail).toBeDefined();
+    expect(detail!.selectedRows.length).toBe(detail!.selectedIds.length);
+    expect(detail!.selectedRows[0]).toMatchObject({ id: expect.any(Number), name: expect.any(String) });
   });
 });
 
-interface RootRow {
-  id: number;
-  name: string;
-  childCount: number;
-}
-
-function makeRoots(startId: number, count: number, childCount = 0): RootRow[] {
-  return Array.from({ length: count }, (_, i) => ({
-    id: startId + i,
-    name: `root-${startId + i}`,
-    childCount,
-  }));
-}
-
-async function makeTreeWindowed(opts: {
-  totalRecords: number;
-  perPage: number;
-  page1Roots: RootRow[];
-  onRequest?: (detail: { parentId: unknown; page: number }) => void;
-}): Promise<MpDatatable> {
-  const el = document.createElement('mp-datatable') as MpDatatable;
-  el.columns = columns as DatatableColumnDef[];
-  el.tree = true;
-  el.idKey = 'id';
-  el.childCountKey = 'childCount';
-  el.virtualScroll = true;
-  el.perPage = opts.perPage;
-  el.autoSort = false;
-  el.data = opts.page1Roots as unknown[];
-  el.totalRecords = opts.totalRecords;
-  if (opts.onRequest) {
-    el.addEventListener('mp-datatable-fetch-request', (ev) => {
-      opts.onRequest!((ev as CustomEvent).detail);
-    });
-  }
-  document.body.appendChild(el);
-  await el.updateComplete;
-  return el;
-}
-
-describe('mp-datatable — tree-mode lazy root windowing', () => {
+describe('mp-datatable — fetch-callback tree mode', () => {
   let el: MpDatatable | undefined;
   afterEach(() => {
     el?.remove();
     el = undefined;
   });
 
-  it('reserves root placeholders and requests unloaded root pages (parentId null)', async () => {
-    const requested: { parentId: unknown; page: number }[] = [];
-    el = await makeTreeWindowed({
-      totalRecords: 50,
-      perPage: 10,
-      page1Roots: makeRoots(1, 10),
-      onRequest: (d) => requested.push(d),
-    });
+  it('fetches roots (parentId null) and children (parentId set) through one callback', async () => {
+    const h = setup({ total: 50, perPage: 10, tree: true });
+    el = h.el;
+    // Give roots a child count so expansion triggers a child fetch.
+    await flush(el);
+    el.data; // (roots are owned by the WC; nothing to assert directly here)
 
-    // Viewport [0,20): root page 1 (0-9) is real, root page 2 (10-19) is
-    // placeholders — the regression was that these never existed in tree mode.
-    expect(realRowCount(el)).toBe(10);
-    expect(placeholderCount(el)).toBe(10);
-    // The root page is fetched with parentId null (a root window), not a child id.
-    expect(requested.some((r) => r.parentId === null && r.page === 2)).toBe(true);
-  });
+    // Roots were fetched with parentId null.
+    expect(h.calls.some((c) => c.parentId === null && c.page === 1)).toBe(true);
 
-  it('fills a root page via setFetchResponse(null, …) and clears its placeholders', async () => {
-    el = await makeTreeWindowed({ totalRecords: 50, perPage: 10, page1Roots: makeRoots(1, 10) });
-    expect(placeholderCount(el)).toBe(10);
-
-    el.setFetchResponse(null, {
-      data: makeRoots(11, 10) as unknown[],
-      totalRecords: 50,
-      page: 2,
-      perPage: 10,
-    });
-    await el.updateComplete;
-    expect(placeholderCount(el)).toBe(0);
-    expect(realRowCount(el)).toBe(20);
-  });
-
-  it('windows roots AND still reserves child placeholders under an expanded root', async () => {
-    // Root id 1 has 2 children (not yet loaded); the rest are leaves.
-    const roots = makeRoots(1, 10).map((r, i) => (i === 0 ? { ...r, childCount: 2 } : r));
-    el = await makeTreeWindowed({ totalRecords: 50, perPage: 10, page1Roots: roots });
+    // Expand the first root → its child placeholders enter the viewport → a
+    // child fetch with that parentId.
     el.expandedIds = new Set([1]);
-    await el.updateComplete;
-
-    // 50 root slots (10 real + 40 placeholders) + 2 child placeholders under
-    // root 1 + 1 header row → aria-rowcount 53. Proves root windowing and child
-    // reservation compose (the interleaving the flat case never exercises).
-    const table = el.shadowRoot!.querySelector('table')!;
-    expect(table.getAttribute('aria-rowcount')).toBe('53');
+    await flush(el);
+    await flush(el);
+    expect(h.calls.some((c) => c.parentId === 1)).toBe(true);
   });
 });

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
@@ -154,6 +154,31 @@ describe('mp-datatable — flat virtual windowed fetch', () => {
     expect(placeholderCount(el)).toBe(10); // page 2 reverted to placeholders
   });
 
+  it('re-fetches the visible window after invalidateData without needing a scroll', async () => {
+    // Parity with the old VirtualDatatableDataSource.reset(): invalidation must
+    // re-request the currently-visible pages on the next render (driven by
+    // updated() → refreshVirtualRange), not wait for the next scroll event.
+    const requested: number[] = [];
+    el = await makeWindowed({
+      totalRecords: 50,
+      perPage: 10,
+      onRequest: (d) => requested.push(d.page),
+    });
+    el.setFetchResponse(null, {
+      data: makePage(2, 10) as unknown[],
+      totalRecords: 50,
+      page: 2,
+      perPage: 10,
+    });
+    await el.updateComplete;
+    expect(requested).toEqual([2]); // initial request only
+
+    el.invalidateData();
+    await el.updateComplete;
+    // Page 2 is visible and no longer cached/pending → requested again.
+    expect(requested).toEqual([2, 2]);
+  });
+
   it('does not window a single-page list (totalRecords ≤ data.length)', async () => {
     const onlyPage = makePage(1, 5);
     const requested: number[] = [];

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
@@ -195,3 +195,97 @@ describe('mp-datatable — flat virtual windowed fetch', () => {
     expect(requested).toEqual([]);
   });
 });
+
+interface RootRow {
+  id: number;
+  name: string;
+  childCount: number;
+}
+
+function makeRoots(startId: number, count: number, childCount = 0): RootRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: startId + i,
+    name: `root-${startId + i}`,
+    childCount,
+  }));
+}
+
+async function makeTreeWindowed(opts: {
+  totalRecords: number;
+  perPage: number;
+  page1Roots: RootRow[];
+  onRequest?: (detail: { parentId: unknown; page: number }) => void;
+}): Promise<MpDatatable> {
+  const el = document.createElement('mp-datatable') as MpDatatable;
+  el.columns = columns as DatatableColumnDef[];
+  el.tree = true;
+  el.idKey = 'id';
+  el.childCountKey = 'childCount';
+  el.virtualScroll = true;
+  el.perPage = opts.perPage;
+  el.autoSort = false;
+  el.data = opts.page1Roots as unknown[];
+  el.totalRecords = opts.totalRecords;
+  if (opts.onRequest) {
+    el.addEventListener('mp-datatable-fetch-request', (ev) => {
+      opts.onRequest!((ev as CustomEvent).detail);
+    });
+  }
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe('mp-datatable — tree-mode lazy root windowing', () => {
+  let el: MpDatatable | undefined;
+  afterEach(() => {
+    el?.remove();
+    el = undefined;
+  });
+
+  it('reserves root placeholders and requests unloaded root pages (parentId null)', async () => {
+    const requested: { parentId: unknown; page: number }[] = [];
+    el = await makeTreeWindowed({
+      totalRecords: 50,
+      perPage: 10,
+      page1Roots: makeRoots(1, 10),
+      onRequest: (d) => requested.push(d),
+    });
+
+    // Viewport [0,20): root page 1 (0-9) is real, root page 2 (10-19) is
+    // placeholders — the regression was that these never existed in tree mode.
+    expect(realRowCount(el)).toBe(10);
+    expect(placeholderCount(el)).toBe(10);
+    // The root page is fetched with parentId null (a root window), not a child id.
+    expect(requested.some((r) => r.parentId === null && r.page === 2)).toBe(true);
+  });
+
+  it('fills a root page via setFetchResponse(null, …) and clears its placeholders', async () => {
+    el = await makeTreeWindowed({ totalRecords: 50, perPage: 10, page1Roots: makeRoots(1, 10) });
+    expect(placeholderCount(el)).toBe(10);
+
+    el.setFetchResponse(null, {
+      data: makeRoots(11, 10) as unknown[],
+      totalRecords: 50,
+      page: 2,
+      perPage: 10,
+    });
+    await el.updateComplete;
+    expect(placeholderCount(el)).toBe(0);
+    expect(realRowCount(el)).toBe(20);
+  });
+
+  it('windows roots AND still reserves child placeholders under an expanded root', async () => {
+    // Root id 1 has 2 children (not yet loaded); the rest are leaves.
+    const roots = makeRoots(1, 10).map((r, i) => (i === 0 ? { ...r, childCount: 2 } : r));
+    el = await makeTreeWindowed({ totalRecords: 50, perPage: 10, page1Roots: roots });
+    el.expandedIds = new Set([1]);
+    await el.updateComplete;
+
+    // 50 root slots (10 real + 40 placeholders) + 2 child placeholders under
+    // root 1 + 1 header row → aria-rowcount 53. Proves root windowing and child
+    // reservation compose (the interleaving the flat case never exercises).
+    const table = el.shadowRoot!.querySelector('table')!;
+    expect(table.getAttribute('aria-rowcount')).toBe('53');
+  });
+});

--- a/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
+++ b/libs/mintplayer-web-components/datatable/src/components/mp-datatable.windowed-fetch.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import './mp-datatable';
+import { MpDatatable } from './mp-datatable';
+import type { DatatableColumnDef } from '../types';
+
+interface Row {
+  id: number;
+  name: string;
+}
+
+const columns: DatatableColumnDef<Row>[] = [
+  { name: 'name', label: 'Name', cellRenderer: (r) => r.name },
+];
+
+function makePage(page: number, perPage: number): Row[] {
+  // 1-based page; ids are globally unique so rowKey (default `id`) is stable.
+  return Array.from({ length: perPage }, (_, i) => {
+    const id = (page - 1) * perPage + i + 1;
+    return { id, name: `p${page}-${i}` };
+  });
+}
+
+/**
+ * Build a flat virtual + external-paging datatable: page 1 seeded into `data`,
+ * `totalRecords` larger than one page so `isFlatWindowed()` is true. jsdom does
+ * no layout (`clientHeight === 0`), so `refreshVirtualRange` lands a viewport of
+ * `[0, virtualBuffer * 2)` on first render — with `perPage` of 10 and a buffer
+ * of 10 that covers pages 1 and 2, which is exactly what these tests exercise.
+ */
+async function makeWindowed(opts: {
+  totalRecords: number;
+  perPage: number;
+  page1?: Row[];
+  onRequest?: (detail: { parentId: unknown; page: number; perPage: number }) => void;
+}): Promise<MpDatatable> {
+  const el = document.createElement('mp-datatable') as MpDatatable;
+  el.columns = columns as DatatableColumnDef[];
+  el.virtualScroll = true;
+  el.perPage = opts.perPage;
+  el.autoSort = false; // fetch mode: server owns ordering
+  el.data = (opts.page1 ?? makePage(1, opts.perPage)) as unknown[];
+  el.totalRecords = opts.totalRecords;
+  if (opts.onRequest) {
+    el.addEventListener('mp-datatable-fetch-request', (ev) => {
+      opts.onRequest!((ev as CustomEvent).detail);
+    });
+  }
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function placeholderCount(el: MpDatatable): number {
+  return el.shadowRoot!.querySelectorAll('tbody tr[data-placeholder="true"]').length;
+}
+
+function realRowCount(el: MpDatatable): number {
+  return el.shadowRoot!.querySelectorAll('tbody tr[data-placeholder="false"]').length;
+}
+
+describe('mp-datatable — flat virtual windowed fetch', () => {
+  let el: MpDatatable | undefined;
+  afterEach(() => {
+    el?.remove();
+    el = undefined;
+  });
+
+  it('renders placeholders for unloaded pages and sizes aria-rowcount from totalRecords', async () => {
+    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
+
+    // Viewport is [0, 20): page 1 (indices 0-9, in `data`) is real, page 2
+    // (indices 10-19, not yet fetched) is placeholders.
+    expect(realRowCount(el)).toBe(10);
+    expect(placeholderCount(el)).toBe(10);
+
+    // Scrollbar/structure sized from the full total, not the 10 loaded rows.
+    const table = el.shadowRoot!.querySelector('table')!;
+    expect(table.getAttribute('aria-rowcount')).toBe('51'); // 50 + header
+  });
+
+  it('requests exactly the viewport pages on demand and dedups in-flight pages', async () => {
+    const requested: number[] = [];
+    el = await makeWindowed({
+      totalRecords: 50,
+      perPage: 10,
+      onRequest: (d) => requested.push(d.page),
+    });
+
+    // Page 2 is the only unloaded page in the viewport — page 1 is in `data`,
+    // pages 3-5 are below the fold and must NOT be fetched.
+    expect(requested).toEqual([2]);
+
+    // A second scan (scroll jitter; scrollTop stays 0 in jsdom) must not
+    // re-request page 2 — it's already in `_pendingPageFetches`.
+    const scroll = el.shadowRoot!.querySelector('.datatable-scroll')!;
+    scroll.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+    expect(requested).toEqual([2]);
+  });
+
+  it('carries parentId:null + the requested page/perPage on the fetch-request', async () => {
+    let detail: { parentId: unknown; page: number; perPage: number } | undefined;
+    el = await makeWindowed({ totalRecords: 50, perPage: 10, onRequest: (d) => (detail = d) });
+    expect(detail).toBeDefined();
+    expect(detail!.parentId).toBeNull();
+    expect(detail!.page).toBe(2);
+    expect(detail!.perPage).toBe(10);
+  });
+
+  it('setFetchResponse(null, …) fills a page and clears its placeholders', async () => {
+    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
+    expect(placeholderCount(el)).toBe(10);
+
+    el.setFetchResponse(null, {
+      data: makePage(2, 10) as unknown[],
+      totalRecords: 50,
+      page: 2,
+      perPage: 10,
+    });
+    await el.updateComplete;
+
+    // Page 2 is now loaded — the whole visible window [0,20) is real rows.
+    expect(placeholderCount(el)).toBe(0);
+    expect(realRowCount(el)).toBe(20);
+  });
+
+  it('keys the page cache on response.page, ignoring page 1 (page 1 lives in data)', async () => {
+    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
+
+    // A stray page-1 response is a no-op: page 1 is owned by the `data` setter.
+    el.setFetchResponse(null, {
+      data: [{ id: 999, name: 'bogus' }] as unknown[],
+      totalRecords: 50,
+      page: 1,
+      perPage: 10,
+    });
+    await el.updateComplete;
+    expect(el.shadowRoot!.textContent).not.toContain('bogus');
+  });
+
+  it('invalidateData() clears the page cache so placeholders reappear', async () => {
+    el = await makeWindowed({ totalRecords: 50, perPage: 10 });
+    el.setFetchResponse(null, {
+      data: makePage(2, 10) as unknown[],
+      totalRecords: 50,
+      page: 2,
+      perPage: 10,
+    });
+    await el.updateComplete;
+    expect(placeholderCount(el)).toBe(0);
+
+    el.invalidateData();
+    await el.updateComplete;
+    expect(placeholderCount(el)).toBe(10); // page 2 reverted to placeholders
+  });
+
+  it('does not window a single-page list (totalRecords ≤ data.length)', async () => {
+    const onlyPage = makePage(1, 5);
+    const requested: number[] = [];
+    el = await makeWindowed({
+      totalRecords: 5,
+      perPage: 10,
+      page1: onlyPage,
+      onRequest: (d) => requested.push(d.page),
+    });
+
+    // Not externally paged → trivial flat mapping, no placeholders, no fetches.
+    expect(placeholderCount(el)).toBe(0);
+    expect(realRowCount(el)).toBe(5);
+    expect(requested).toEqual([]);
+  });
+});

--- a/libs/mintplayer-web-components/datatable/src/index.ts
+++ b/libs/mintplayer-web-components/datatable/src/index.ts
@@ -15,8 +15,9 @@ export type {
   RowRenderContext,
   TreeIdKey,
   TreeSelectionStrategy,
-  TreeFetchRequestDetail,
-  TreeFetchResponse,
+  DatatableFetchRequest,
+  DatatableFetchResponse,
+  DatatableFetch,
   TreeRowExpandDetail,
   TreeExpandedIdsChangeDetail,
 } from './types';

--- a/libs/mintplayer-web-components/datatable/src/types/index.ts
+++ b/libs/mintplayer-web-components/datatable/src/types/index.ts
@@ -8,8 +8,9 @@ export type {
   RowRenderContext,
 } from './column-def';
 export type {
-  TreeFetchRequestDetail,
-  TreeFetchResponse,
+  DatatableFetchRequest,
+  DatatableFetchResponse,
+  DatatableFetch,
   TreeRowExpandDetail,
   TreeExpandedIdsChangeDetail,
   TreeIdKey,

--- a/libs/mintplayer-web-components/datatable/src/types/tree.ts
+++ b/libs/mintplayer-web-components/datatable/src/types/tree.ts
@@ -17,25 +17,36 @@ export type TreeIdKey<T = unknown> = keyof T | string | ((row: T) => unknown);
 export type TreeSelectionStrategy = 'flat' | 'cascading';
 
 /**
- * Detail of `mp-datatable-fetch-request` — emitted by the WC when it needs
- * data for a parent (tree mode, lazy children). The wrapper bridges this to
- * the consumer's `[fetch]` callback and calls `setFetchResponse()` with the
- * result. `parentId === null` means roots.
+ * Request passed to the `fetch` callback. `parentId === null` is a root window
+ * (flat rows, or the tree's top level — pages ≥ 2 are windowed lazily); a
+ * non-null `parentId` is a tree node's children.
  */
-export interface TreeFetchRequestDetail {
+export interface DatatableFetchRequest {
   parentId: unknown | null;
   page: number;
   perPage: number;
   sortColumns: SortColumn[];
 }
 
-/** Response shape consumed by `setFetchResponse()`. */
-export interface TreeFetchResponse<T = unknown> {
+/**
+ * Response returned from the `fetch` callback. Only `data` + `totalRecords` are
+ * required — the WC already knows the page/perPage it asked for, and derives
+ * the grand total from `totalRecords`, so consumers never set a separate
+ * `totalRecords` property.
+ */
+export interface DatatableFetchResponse<T = unknown> {
   data: T[];
   totalRecords: number;
-  page: number;
-  perPage: number;
 }
+
+/**
+ * High-level fetch callback — the ONLY server-paging API. Set `el.fetch` and
+ * the web component owns the whole loop: initial page, on-demand windows, tree
+ * children, pagination, and sort/perPage reloads, deriving `totalRecords` from
+ * the response. Works standalone (no framework) — `el.fetch = fn` is all a
+ * plain web-components consumer needs.
+ */
+export type DatatableFetch<T = unknown> = (req: DatatableFetchRequest) => Promise<DatatableFetchResponse<T>>;
 
 export interface TreeRowExpandDetail<T = unknown> {
   row: T;

--- a/libs/mintplayer-web-components/package.json
+++ b/libs/mintplayer-web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintplayer/web-components",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Framework-agnostic Lit web components for the @mintplayer/bootstrap design system. Consumed by @mintplayer/ng-bootstrap, @mintplayer/react-bootstrap, and @mintplayer/vue-bootstrap.",
   "license": "MIT",
   "repository": {

--- a/libs/mintplayer-web-components/package.json
+++ b/libs/mintplayer-web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintplayer/web-components",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Framework-agnostic Lit web components for the @mintplayer/bootstrap design system. Consumed by @mintplayer/ng-bootstrap, @mintplayer/react-bootstrap, and @mintplayer/vue-bootstrap.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What & why

Restores **lazy windowed fetch** for the datatable and then makes the web component **own the entire server-fetch loop** behind a single `fetch` callback. Closes #385 and #386 (the latter was folded into this branch).

### #385 — lazy windowed fetch (the regression fix)
Flat `[fetch]` + `[virtualScroll]` used to eager-load the whole result set (`runVirtualFetchAll` drained every page) — a regression vs. the removed `virtual-datatable`. The WC now windows: placeholders for unloaded ranges, a `_pageCache`, a sparse `getFlatList`, and the scroll region sized from the total. Tree **roots** paginate lazily too (not just children). This unblocks **MintPlayer.Spark #178**.

### #386 — WC owns the fetch loop (the ergonomics + correctness layer)
Set `el.fetch = (req) => Promise<{ data, totalRecords }>` and **nothing else** — the WC loads page 1, derives the grand total from the response, fetches each window/child on demand, paginates, and reloads on sort/perPage. Works standalone (vanilla/Rollup), no framework required. The framework wrappers collapse to thin forwarders.

## ⚠️ Breaking (web-components 2.0.0)

The datatable is a brand-new component, so no back-compat layer was kept:

- **Removed:** the `mp-datatable-fetch-request` event, `setFetchResponse()`, `invalidateData()`, `invalidateChildren()`, the `totalRecords` **setter** (now derived from the response; read-only getter remains), and the `TreeFetchRequestDetail` / `TreeFetchResponse` types.
- **Added:** `DatatableFetch` / `DatatableFetchRequest` / `DatatableFetchResponse`.
- **Changed:** `mp-datatable-selection-change` now also carries `selectedRows` (the WC owns the data, so it resolves ids → row objects).

Internals: direct callback calls (no event round-trip); a generation token drops stale responses on invalidation; sort/perPage/page reloads are coalesced (microtask + `{sort,perPage,page}` change-key) so two-way-binding echoes don't double-fetch; setting `fetch` implies server-side sort (`autoSort = false`). Static `[data]` tables are unchanged.

## Wrappers (now forwarders)

- **Angular** `[fetch]` → `el.fetch`; `[(selection)]` reads `detail.selectedRows`. Dropped `runVirtualFetchFirst`/`runFetch`/the `onFetchRequest` bridge/`totalRecords` signal.
- **React** passes `fetch` through `createComponent`; removed the dead `onFetchRequest` event.
- **Vue** forwards one `fetch` prop; removed the `fetchRequest` emit + `setFetchResponse`/`invalidate*` exposes.

## Demos

All three datatable demos now hit **real `apps/api` data** (orders `/search` for the windowed list, artist paging for Angular, `treeItems` for tree) — no synthetic generators.

## Versions

| Package | from | to |
|---|---|---|
| `@mintplayer/web-components` | 1.6.0 | **2.0.0** (breaking) |
| `@mintplayer/ng-bootstrap` | 22.2.0 | **22.4.0** |
| `@mintplayer/react-bootstrap` | 19.5.0 | **19.6.0** |
| `@mintplayer/vue-bootstrap` | 3.5.0 | **3.7.0** |

Wrapper peer floors raised to `@mintplayer/web-components ^2.0.0`.

## Testing

- **757** web-components tests + **517** wrapper tests green.
- All 4 libs + all 3 demo apps build.
- WC tests exercise the vanilla `createElement` + `el.fetch` path (the no-framework contract).

## Docs

- `docs/issue_386_PRD.md` — as-built design + the rationale for each decision.
- `docs/prd/datatable.md` (living spec) — fetch model rewritten to the callback.
- `docs/issue_385_{PRD,plan}.md` — banner-marked as superseded by #386 (windowing internals stand; the event-bridge driving was replaced).

Closes #385
Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
